### PR TITLE
Implement BN_clear_free and EC_POINT_clear_free. Awaiting upstream release for cryptography.io

### DIFF
--- a/umbral/bignum.py
+++ b/umbral/bignum.py
@@ -26,7 +26,7 @@ class BigNum(object):
 
         order = backend._lib.BN_new()
         backend.openssl_assert(order != backend._ffi.NULL)
-        order = backend._ffi.gc(order, backend._lib.BN_free)
+        order = backend._ffi.gc(order, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_GROUP_get_order(group, order, bn_ctx)
@@ -40,7 +40,7 @@ class BigNum(object):
             rand_num = int.from_bytes(os.urandom(curve.key_size // 8), 'big')
 
         new_rand_bn = backend._int_to_bn(rand_num)
-        new_rand_bn = backend._ffi.gc(new_rand_bn, backend._lib.BN_free)
+        new_rand_bn = backend._ffi.gc(new_rand_bn, backend._lib.BN_clear_free)
 
         return BigNum(new_rand_bn, curve_nid, group, order)
 
@@ -60,7 +60,7 @@ class BigNum(object):
 
         order = backend._lib.BN_new()
         backend.openssl_assert(order != backend._ffi.NULL)
-        order = backend._ffi.gc(order, backend._lib.BN_free)
+        order = backend._ffi.gc(order, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_GROUP_get_order(group, order, bn_ctx)
@@ -72,7 +72,7 @@ class BigNum(object):
             raise ValueError("Integer provided is not on the given curve.")
 
         bignum = backend._int_to_bn(num)
-        bignum = backend._ffi.gc(bignum, backend._lib.BN_free)
+        bignum = backend._ffi.gc(bignum, backend._lib.BN_clear_free)
 
         return BigNum(bignum, curve_nid, group, order)
 
@@ -106,7 +106,7 @@ class BigNum(object):
         """
         if type(other) == int:
             other = backend._int_to_bn(other)
-            other = backend._ffi.gc(other, backend._lib.BN_free)
+            other = backend._ffi.gc(other, backend._lib.BN_clear_free)
 
             other = BigNum(other, None, None, None)
 
@@ -119,13 +119,13 @@ class BigNum(object):
         """
         if type(other) == int:
             other = backend._int_to_bn(other)
-            other = backend._ffi.gc(other, backend._lib.BN_free)
+            other = backend._ffi.gc(other, backend._lib.BN_clear_free)
 
             other = BigNum(other, None, None, None)
 
         power = backend._lib.BN_new()
         backend.openssl_assert(power != backend._ffi.NULL)
-        power = backend._ffi.gc(power, backend._lib.BN_free)
+        power = backend._ffi.gc(power, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.BN_mod_exp(
@@ -141,7 +141,7 @@ class BigNum(object):
         """
         product = backend._lib.BN_new()
         backend.openssl_assert(product != backend._ffi.NULL)
-        product = backend._ffi.gc(product, backend._lib.BN_free)
+        product = backend._ffi.gc(product, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.BN_mod_mul(
@@ -157,7 +157,7 @@ class BigNum(object):
         """
         product = backend._lib.BN_new()
         backend.openssl_assert(product != backend._ffi.NULL)
-        product = backend._ffi.gc(product, backend._lib.BN_free)
+        product = backend._ffi.gc(product, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             inv_other = backend._lib.BN_mod_inverse(
@@ -178,7 +178,7 @@ class BigNum(object):
         """
         sum = backend._lib.BN_new()
         backend.openssl_assert(sum != backend._ffi.NULL)
-        sum = backend._ffi.gc(sum, backend._lib.BN_free)
+        sum = backend._ffi.gc(sum, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.BN_mod_add(
@@ -194,7 +194,7 @@ class BigNum(object):
         """
         diff = backend._lib.BN_new()
         backend.openssl_assert(diff != backend._ffi.NULL)
-        diff = backend._ffi.gc(diff, backend._lib.BN_free)
+        diff = backend._ffi.gc(diff, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.BN_mod_sub(
@@ -213,7 +213,7 @@ class BigNum(object):
                 backend._ffi.NULL, self.bignum, self.order, bn_ctx
             )
             backend.openssl_assert(inv != backend._ffi.NULL)
-            inv = backend._ffi.gc(inv, backend._lib.BN_free)
+            inv = backend._ffi.gc(inv, backend._lib.BN_clear_free)
 
         return BigNum(inv, self.curve_nid, self.group, self.order)
 
@@ -223,13 +223,13 @@ class BigNum(object):
         """
         if type(other) == int:
             other = backend._int_to_bn(other)
-            other = backend._ffi.gc(other, backend._lib.BN_free)
+            other = backend._ffi.gc(other, backend._lib.BN_clear_free)
 
             other = BigNum(other, None, None, None)
 
         rem = backend._lib.BN_new()
         backend.openssl_assert(rem != backend._ffi.NULL)
-        rem = backend._ffi.gc(rem, backend._lib.BN_free)
+        rem = backend._ffi.gc(rem, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.BN_nnmod(

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -55,11 +55,11 @@ class Point(object):
         affine_x, affine_y = coords
         if type(affine_x) == int:
             affine_x = backend._int_to_bn(affine_x)
-            affine_x = backend._ffi.gc(affine_x, backend._lib.BN_free)
+            affine_x = backend._ffi.gc(affine_x, backend._lib.BN_clear_free)
 
         if type(affine_y) == int:
             affine_y = backend._int_to_bn(affine_y)
-            affine_y = backend._ffi.gc(affine_y, backend._lib.BN_free)
+            affine_y = backend._ffi.gc(affine_y, backend._lib.BN_clear_free)
 
         group = backend._lib.EC_GROUP_new_by_curve_name(curve_nid)
         backend.openssl_assert(group != backend._ffi.NULL)
@@ -82,11 +82,11 @@ class Point(object):
         """
         affine_x = backend._lib.BN_new()
         backend.openssl_assert(affine_x != backend._ffi.NULL)
-        affine_x = backend._ffi.gc(affine_x, backend._lib.BN_free)
+        affine_x = backend._ffi.gc(affine_x, backend._lib.BN_clear_free)
 
         affine_y = backend._lib.BN_new()
         backend.openssl_assert(affine_y != backend._ffi.NULL)
-        affine_y = backend._ffi.gc(affine_y, backend._lib.BN_free)
+        affine_y = backend._ffi.gc(affine_y, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_POINT_get_affine_coordinates_GFp(
@@ -194,7 +194,7 @@ class Point(object):
 
         order = backend._lib.BN_new()
         backend.openssl_assert(order != backend._ffi.NULL)
-        order = backend._ffi.gc(order, backend._lib.BN_free)
+        order = backend._ffi.gc(order, backend._lib.BN_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_GROUP_get_order(group, order, bn_ctx)

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -28,7 +28,8 @@ class Point(object):
 
         rand_point = backend._lib.EC_POINT_new(group)
         backend.openssl_assert(rand_point != backend._ffi.NULL)
-        rand_point = backend._ffi.gc(rand_point, backend._lib.EC_POINT_free)
+        rand_point = backend._ffi.gc(rand_point,
+                                     backend._lib.EC_POINT_clear_free)
 
         rand_bn = BigNum.gen_rand(curve).bignum
 
@@ -117,7 +118,8 @@ class Point(object):
 
             ec_point = backend._lib.EC_POINT_new(affine_x.group)
             backend.openssl_assert(ec_point != backend._ffi.NULL)
-            ec_point = backend._ffi.gc(ec_point, backend._lib.EC_POINT_free)
+            ec_point = backend._ffi.gc(ec_point,
+                                       backend._lib.EC_POINT_clear_free)
 
             with backend._tmp_bn_ctx() as bn_ctx:
                 res = backend._lib.EC_POINT_set_compressed_coordinates_GFp(
@@ -221,7 +223,7 @@ class Point(object):
         """
         prod = backend._lib.EC_POINT_new(self.group)
         backend.openssl_assert(prod != backend._ffi.NULL)
-        prod = backend._ffi.gc(prod, backend._lib.EC_POINT_free)
+        prod = backend._ffi.gc(prod, backend._lib.EC_POINT_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_POINT_mul(
@@ -238,7 +240,7 @@ class Point(object):
         """
         sum = backend._lib.EC_POINT_new(self.group)
         backend.openssl_assert(sum != backend._ffi.NULL)
-        sum = backend._ffi.gc(sum, backend._lib.EC_POINT_free)
+        sum = backend._ffi.gc(sum, backend._lib.EC_POINT_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_POINT_add(
@@ -260,7 +262,7 @@ class Point(object):
         """
         inv = backend._lib.EC_POINT_dup(self.ec_point, self.group)
         backend.openssl_assert(inv != backend._ffi.NULL)
-        inv = backend._ffi.gc(inv, backend._lib.EC_POINT_free)
+        inv = backend._ffi.gc(inv, backend._lib.EC_POINT_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_POINT_invert(


### PR DESCRIPTION
### What this does:
1. Implements OpenSSL's `BN_clear_free` and `EC_POINT_clear_free`.
2. Zeros memory before freeing it for OpenSSL BIGNUMs and EC_POINTs.
3. This is indiscriminate. It always zeros the memory irrespective of the secrecy of the material.

See #13 