### PR TITLE
Add Key classes and add some fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup, Extension
 
-INSTALL_REQUIRES = ['msgpack-python', 'cryptography'] #'pysha3', 
+INSTALL_REQUIRES = ['msgpack-python', 'cryptography', 'pynacl'] #'pysha3', 
 
 TESTS_REQUIRE = [
     'pytest',

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,0 +1,48 @@
+import pytest
+
+from umbral import umbral, keys
+
+
+def test_private_key_serialization():
+    pre = umbral.PRE(umbral.UmbralParameters())
+
+    priv_key = pre.gen_priv()
+    umbral_key = keys.UmbralPrivateKey(priv_key)
+
+    encoded_key = umbral_key.save_key()
+
+    decoded_key = keys.UmbralPrivateKey.load_key(encoded_key,
+                                                 umbral.UmbralParameters())
+
+    assert priv_key == decoded_key.bn_key
+
+
+def test_private_key_serialization_with_encryption():
+    pre = umbral.PRE(umbral.UmbralParameters())
+
+    priv_key = pre.gen_priv()
+    umbral_key = keys.UmbralPrivateKey(priv_key)
+
+    encoded_key = umbral_key.save_key(password=b'test')
+
+    decoded_key = keys.UmbralPrivateKey.load_key(encoded_key,
+                                                 umbral.UmbralParameters(),
+                                                 password=b'test')
+
+    assert priv_key == decoded_key.bn_key
+
+
+def test_public_key_serialization():
+    pre = umbral.PRE(umbral.UmbralParameters())
+
+    priv_key = pre.gen_priv()
+    pub_key = pre.priv2pub(priv_key)
+
+    umbral_key = keys.UmbralPublicKey(pub_key)
+
+    encoded_key = umbral_key.save_key()
+
+    decoded_key = keys.UmbralPublicKey.load_key(encoded_key,
+                                                umbral.UmbralParameters())
+
+    assert pub_key == decoded_key.point_key

--- a/umbral/bignum.py
+++ b/umbral/bignum.py
@@ -139,6 +139,9 @@ class BigNum(object):
         """
         Performs a BN_mod_mul between two BIGNUMS.
         """
+        if type(other) != BigNum:
+            return NotImplemented
+
         product = backend._lib.BN_new()
         backend.openssl_assert(product != backend._ffi.NULL)
         product = backend._ffi.gc(product, backend._lib.BN_free)

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -1,0 +1,6 @@
+class UmbralPrivateKey(object):
+    pass
+
+
+class UmbralPublicKey(object):
+    pass

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -1,6 +1,10 @@
+import os
 import base64
 
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+from cryptography.hazmat.backends import default_backend
+from nacl.secret import SecretBox
 from umbral.umbral import UmbralParameters
 from umbral.point import Point, BigNum
 
@@ -13,14 +17,68 @@ class UmbralPrivateKey(object):
         self.bn_key = bn_key
 
     @classmethod
-    def load_key(cls, key_data: str, params: UmbralParameters):
+    def load_key(cls, key_data: str, params: UmbralParameters,
+                 password: bytes=None, _scrypt_cost: int=20):
         """
         Loads an Umbral private key from a urlsafe base64 encoded string.
+        Optionally, if a password is provided it will decrypt the key using
+        nacl's Salsa20-Poly1305 and Scrypt key derivation.
+
+        WARNING: RFC7914 recommends that you use a 2^20 cost value for sensitive
+        files. Unless you changed this when you called `save_key`, you should
+        not change it here. It is NOT recommended to change the `_scrypt_cost`
+        value unless you know what you're doing.
         """
         key_bytes = base64.urlsafe_b64decode(key_data)
 
+        if password:
+            salt = key_bytes[-16:]
+            key_bytes = key_bytes[:-16]
+
+            key = Scrypt(
+                salt=salt,
+                length=SecretBox.KEY_SIZE,
+                n=2**_scrypt_cost,
+                r=8,
+                p=1,
+                backend=default_backend()
+            ).derive(password)
+
+            key_bytes = SecretBox(key).decrypt(key_bytes)
+
         bn_key = BigNum.from_bytes(key_bytes, params.curve)
         return cls(bn_key)
+
+    def save_key(self, password: bytes=None, _scrypt_cost: int=20):
+        """
+        Returns an Umbral private key as a urlsafe base64 encoded string with
+        optional symmetric encryption via nacl's Salsa20-Poly1305 and Scrypt
+        key derivation. If a password is provided, the user must encode it to
+        bytes.
+
+        WARNING: RFC7914 recommends that you use a 2^20 cost value for sensitive
+        files. It is NOT recommended to change the `_scrypt_cost` value unless
+        you know what you are doing.
+        """
+        umbral_priv_key = self.bn_key.to_bytes()
+
+        if password:
+            salt = os.urandom(16)
+
+            key = Scrypt(
+                salt=salt,
+                length=SecretBox.KEY_SIZE,
+                n=2**_scrypt_cost,
+                r=8,
+                p=1,
+                backend=default_backend()
+            ).derive(password)
+
+            umbral_priv_key = SecretBox(key).encrypt(umbral_priv_key)
+            umbral_priv_key += salt
+
+        encoded_key = base64.urlsafe_b64encode(umbral_priv_key)
+        return encoded_key
 
 
 class UmbralPublicKey(object):

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -1,6 +1,41 @@
+import base64
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from umbral.umbral import UmbralParameters
+from umbral.point import Point, BigNum
+
+
 class UmbralPrivateKey(object):
-    pass
+    def __init__(self, bn_key: BigNum):
+        """
+        Initializes an Umbral private key.
+        """
+        self.bn_key = bn_key
+
+    @classmethod
+    def load_key(cls, key_data: str, params: UmbralParameters):
+        """
+        Loads an Umbral private key from a urlsafe base64 encoded string.
+        """
+        key_bytes = base64.urlsafe_b64decode(key_data)
+
+        bn_key = BigNum.from_bytes(key_bytes, params.curve)
+        return cls(bn_key)
 
 
 class UmbralPublicKey(object):
-    pass
+    def __init__(self, point_key):
+        """
+        Initializes an Umbral public key.
+        """
+        self.point_key = point_key
+
+    @classmethod
+    def load_key(cls, key_data: str, params: UmbralParameters):
+        """
+        Loads an Umbral public key from a urlsafe base64 encoded string.
+        """
+        key_bytes = base64.urlsafe_b64decode(key_data)
+
+        point_key = Point.from_bytes(key_bytes, params.curve)
+        return cls(point_key)

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -97,3 +97,12 @@ class UmbralPublicKey(object):
 
         point_key = Point.from_bytes(key_bytes, params.curve)
         return cls(point_key)
+
+    def save_key(self):
+        """
+        Returns an Umbral public key as a urlsafe base64 encoded string.
+        """
+        umbral_pub_key = self.point_key.to_bytes()
+
+        encoded_key = base64.urlsafe_b64encode(umbral_pub_key)
+        return encoded_key

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -232,6 +232,8 @@ class Point(object):
 
         return Point(prod, self.curve_nid, self.group)
 
+    __rmul__ = __mul__
+
     def __add__(self, other):
         """
         Performs an EC_POINT_add on two EC_POINTS.

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -381,7 +381,11 @@ class PRE(object):
         h = hash_to_bn([pub_r, pub_u], self.params)
         s = priv_u + (priv_r * h)
 
-        shared_key = (priv_r + priv_u) * pub_key
+        dh_point = pub_key * (priv_r + priv_u)
+
+        shared_key_x, _ = dh_point.to_affine()
+        shared_key = int.to_bytes(shared_key_x, key_length, 'big')
+
         # Key to be used for symmetric encryption
         key = kdf(shared_key, key_length)
 
@@ -390,7 +394,11 @@ class PRE(object):
     def decapsulate_original(self, priv_key, capsule, key_length=32):
         """Derive the same symmetric key"""
 
-        shared_key = priv_key * (capsule.point_eph_e + capsule.point_eph_v)
+        dh_point = (capsule.point_eph_e + capsule.point_eph_v) * priv_key
+
+        shared_key_x, _ = dh_point.to_affine()
+        shared_key = int.to_bytes(shared_key_x, key_length, 'big')
+
         key = kdf(shared_key, key_length)
 
         # Check correctness of original ciphertext (check nº 2) at the end
@@ -408,7 +416,11 @@ class PRE(object):
         e_prime = recapsule.point_eph_e_prime
         v_prime = recapsule.point_eph_v_prime
 
-        shared_key = d * (e_prime + v_prime)
+        dh_point = (e_prime + v_prime) * d
+
+        shared_key_x, _ = dh_point.to_affine()
+        shared_key = int.to_bytes(shared_key_x, key_length, 'big')
+
         key = kdf(shared_key, key_length)
 
         e = original_capsule.point_eph_e

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -55,10 +55,7 @@ def hash_to_bn(list, params):
  
     return res
 
-def kdf(ecpoint, key_length):
-    data = ecpoint.to_bytes()
-
-    # TODO: Handle salt somehow
+def kdf(data, key_length):
     return HKDF(
         algorithm=hashes.SHA512(),
         length=key_length,


### PR DESCRIPTION
### What this does:
1. Adds the key classes `UmbralPrivateKey` and `UmbralPublicKey`.
2. Implements Scrypt-Salsa20-Poly1305 encryption/decryption for the private key, optionally.
3. Adds tests for `UmbralPrivateKey` and `UmbralPublicKey`.
4. Implements `__rmul__` on `Point` for proper scalar multiplication.
5. Fixes the notation for all scalar multiplication operations.

### Dependency additions:
1. PyNaCl -- (https://pynacl.readthedocs.io/en/stable/)