### PR TITLE
[NO-MERGE] Unified Capsule instead of ReconstructedCapsule

### DIFF
--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -113,7 +113,7 @@ def test_capsule_serialization():
     # TODO: Do we want to include the cfrags as well?  See #20.
     assert len(capsule_bytes) == 33 + 33 + 32 == 98
 
-    new_capsule = umbral.Capsule.from_bytes(capsule_bytes,
+    new_capsule = umbral.Capsule.from_original_bytes(capsule_bytes,
                                             umbral.UmbralParameters().curve)
     # TODO: Have method that gives us these attributes instead of needing to access them directly.
     assert new_capsule._point_eph_e == capsule._point_eph_e

--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -35,7 +35,7 @@ def test_m_of_n(N, threshold):
     priv_bob = pre.gen_priv()
     pub_bob = pre.priv2pub(priv_bob)
 
-    sym_key, capsule_alice = pre.encapsulate(pub_alice)
+    sym_key, capsule = pre.encapsulate(pub_alice)
 
     kfrags, vkeys = pre.split_rekey(priv_alice, pub_bob, threshold, N)
 
@@ -44,16 +44,15 @@ def test_m_of_n(N, threshold):
         assert kfrag.is_consistent(vkeys, pre.params)
 
     for kfrag in kfrags[:threshold]:
-        cfrag = pre.reencrypt(kfrag, capsule_alice)
-        capsule_alice.attach_cfrag(cfrag)
-        ch = pre.challenge(kfrag, capsule_alice, cfrag)
-        assert pre.check_challenge(capsule_alice, cfrag, ch, pub_alice, pub_bob)
+        cfrag = pre.reencrypt(kfrag, capsule)
+        capsule.attach_cfrag(cfrag)
+        ch = pre.challenge(kfrag, capsule, cfrag)
+        assert pre.check_challenge(capsule, cfrag, ch, pub_alice, pub_bob)
 
-    capsule_bob = capsule_alice.reconstruct()
+    # assert capsule.is_openable_by_bob()  # TODO: Is it possible to check here if >= m cFrags have been attached?
+    capsule.open(pub_bob, priv_bob, pub_alice)
 
-    sym_key_2 = pre.decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, capsule_bob, capsule_alice)
-
-    assert sym_key_2 == sym_key
+    assert sym_key == capsule.contents
 
 
 def test_kfrag_serialization():

--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -115,9 +115,10 @@ def test_capsule_serialization():
 
     new_capsule = umbral.Capsule.from_bytes(capsule_bytes,
                                             umbral.UmbralParameters().curve)
-    assert new_capsule.point_eph_e == capsule.point_eph_e
-    assert new_capsule.point_eph_v == capsule.point_eph_v
-    assert new_capsule.bn_sig == capsule.bn_sig
+    # TODO: Have method that gives us these attributes instead of needing to access them directly.
+    assert new_capsule._point_eph_e == capsule._point_eph_e
+    assert new_capsule._point_eph_v == capsule._point_eph_v
+    assert new_capsule._bn_sig == capsule._bn_sig
 
 
 def test_reconstructed_capsule_serialization():
@@ -133,18 +134,19 @@ def test_reconstructed_capsule_serialization():
 
     capsule.attach_cfrag(cfrag)
 
-    rec_capsule = capsule.reconstruct()
-    rec_capsule_bytes = rec_capsule.to_bytes()
+    capsule._reconstruct(pre=pre)
+    rec_capsule_bytes = capsule._reconstructed_bytes()
 
     # A reconstructed Capsule is three points, representable as 33 bytes each.
     assert len(rec_capsule_bytes) == 99
 
-    new_rec_capsule = umbral.ReconstructedCapsule.from_bytes(
+    new_rec_capsule = umbral.Capsule.from_reconstructed_bytes(
                                 rec_capsule_bytes,
                                 umbral.UmbralParameters().curve)
-    assert new_rec_capsule.point_eph_e_prime == rec_capsule.point_eph_e_prime
-    assert new_rec_capsule.point_eph_v_prime == rec_capsule.point_eph_v_prime
-    assert new_rec_capsule.point_eph_ni == rec_capsule.point_eph_ni
+    # TODO: Have method that gives us these attributes instead of needing to access them directly.
+    assert new_rec_capsule._point_eph_e_prime == capsule._point_eph_e_prime
+    assert new_rec_capsule._point_eph_v_prime == capsule._point_eph_v_prime
+    assert new_rec_capsule._point_noninteractive == capsule._point_noninteractive
 
 
 def test_challenge_response_serialization():

--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -116,10 +116,7 @@ def test_capsule_serialization():
     new_capsule = umbral.Capsule.from_original_bytes(capsule_bytes,
                                             umbral.UmbralParameters().curve)
     # TODO: Have method that gives us these attributes instead of needing to access them directly.
-    assert new_capsule._point_eph_e == capsule._point_eph_e
-    assert new_capsule._point_eph_v == capsule._point_eph_v
-    assert new_capsule._bn_sig == capsule._bn_sig
-
+    assert new_capsule.original_components() == capsule.original_components()
 
 def test_reconstructed_capsule_serialization():
     pre = umbral.PRE(umbral.UmbralParameters())

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -96,7 +96,7 @@ class Point(object):
         return (backend._bn_to_int(affine_x), backend._bn_to_int(affine_y))
 
     @classmethod
-    def from_bytes(self, data, curve):
+    def from_bytes(cls, data, curve):
         """
         Returns a Point object from the given byte data on the curve provided.
         """
@@ -125,7 +125,7 @@ class Point(object):
                 )
                 backend.openssl_assert(res == 1)
 
-            return Point(ec_point, curve_nid, affine_x.group)
+            return cls(ec_point, curve_nid, affine_x.group)
 
         # Handle uncompressed point
         elif data[0] == 4:
@@ -176,7 +176,7 @@ class Point(object):
         generator = backend._lib.EC_GROUP_get0_generator(group)
         backend.openssl_assert(generator != backend._ffi.NULL)
 
-        return Point(generator, curve_nid, group)
+        return cls(generator, curve_nid, group)
 
     @classmethod
     def get_order_from_curve(cls, curve):

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -424,7 +424,7 @@ class PRE(object):
     def decapsulate_original(self, priv_key, capsule, key_length=32):
         """Derive the same symmetric key"""
 
-        shared_key = (capsule.point_eph_e + capsule.point_eph_v) * priv_key
+        shared_key = capsule.original_ephemeral_points() * priv_key
         key = kdf(shared_key, key_length)
 
         # Check correctness of original ciphertext (check nº 2) at the end 

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -13,6 +13,7 @@ class UmbralParameters(object):
         self.h = Point.gen_rand(self.curve)
         self.u = Point.gen_rand(self.curve)
 
+
 class KFrag(object):
     def __init__(self, id_, key, x, u1, z1, z2):
         self.bn_id = id_
@@ -54,12 +55,12 @@ class KFrag(object):
         u1 = self.point_commitment
         z1 = self.bn_sig1
         z2 = self.bn_sig2
-        x  = self.point_eph_ni
+        x = self.point_eph_ni
 
         g_y = (params.g * z2) + (pub_a * z1)
 
         return z1 == hash_to_bn([g_y, self.bn_id, pub_a, pub_b, u1, x], params)
-    
+
     def is_consistent(self, vKeys, params: UmbralParameters):
         if vKeys is None or len(vKeys) == 0:
             raise ValueError('vKeys must not be empty')

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -140,8 +140,8 @@ class Capsule(object):
         self.cfrags = {}
         self._contents = None
 
-    @staticmethod
-    def from_bytes(data: bytes, curve: ec.EllipticCurve):
+    @classmethod
+    def from_original_bytes(cls, data: bytes, curve: ec.EllipticCurve):
         """
         Instantiates a Capsule object from the serialized data.
         """
@@ -149,7 +149,25 @@ class Capsule(object):
         eph_v = Point.from_bytes(data[33:66], curve)
         sig = BigNum.from_bytes(data[66:98], curve)
 
-        return Capsule(eph_e, eph_v, sig)
+        return cls(eph_e, eph_v, sig)
+
+    @classmethod
+    def from_reconstructed_bytes(cls, data: bytes, curve: ec.EllipticCurve):
+        """
+        Instantiate a Capsule from serialized data after reconstruction has occurred.
+
+        The most obvious use case is Bob affixing at least m cFrags and then serializing the Capsule.
+        """
+        # TODO: Seems like a job for BytestringSplitter ?
+        e_prime = Point.from_bytes(data[0:33], curve)
+        v_prime = Point.from_bytes(data[33:66], curve)
+        eph_ni = Point.from_bytes(data[66:99], curve)
+
+        return cls(e_prime=e_prime, v_prime=v_prime, noninteractive_point=eph_ni)
+
+    @property
+    def contents(self):
+        return self._contents
 
     def to_bytes(self):
         """

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -173,17 +173,17 @@ class Capsule(object):
         """
         Serialize the Capsule into a bytestring.
         """
-        eph_e = self.point_eph_e.to_bytes()
-        eph_v = self.point_eph_v.to_bytes()
-        sig = self.bn_sig.to_bytes()
+        eph_e = self._point_eph_e.to_bytes()
+        eph_v = self._point_eph_v.to_bytes()
+        sig = self._bn_sig.to_bytes()
 
         return eph_e + eph_v + sig
 
     def verify(self, params: UmbralParameters):
 
-        e = self.point_eph_e
-        v = self.point_eph_v
-        s = self.bn_sig
+        e = self._point_eph_e
+        v = self._point_eph_v
+        s = self._bn_sig
         h = hash_to_bn([e, v], params)
 
         return params.g * s == v + (e * h)

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -1,9 +1,9 @@
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from umbral.bignum import BigNum
 from umbral.point import Point
 from umbral.utils import poly_eval, lambda_coeff, hash_to_bn, kdf
+
 
 class UmbralParameters(object):
     def __init__(self):

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -209,6 +209,9 @@ class Capsule(object):
             newly_opened = False
         return self.contents, newly_opened
 
+    def original_components(self):
+        return self._point_eph_e, self._point_eph_v, self._bn_sig
+
     def _reconstruct(self, pre):
         id_cfrag_pairs = list(self.cfrags.items())
         id_0, cfrag_0 = id_cfrag_pairs[0]

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -191,58 +191,57 @@ class Capsule(object):
     def attach_cfrag(self, cfrag: CapsuleFrag):
         self.cfrags[cfrag.bn_kfrag_id] = cfrag
 
-    def reconstruct(self):
+    def original_ephemeral_points(self):
+        return self._point_eph_e + self._point_eph_v
+
+    def reconstructed_ephemeral_points(self):
+        return self._point_eph_e_prime + self._point_eph_v_prime
+
+    def open(self, pub_bob, priv_bob, pub_alice, force_reopen=False, pre=None):
+        # TODO: Raise an error here if Bob has gathered enough cFrags.
+        if self.contents and not force_reopen:
+            newly_opened = True
+        else:
+            self._reconstruct(pre=pre)
+            if not pre:
+                pre = PRE(UmbralParameters())
+            self._contents = pre._decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, self)
+            newly_opened = False
+        return self.contents, newly_opened
+
+    def _reconstruct(self, pre):
         id_cfrag_pairs = list(self.cfrags.items())
         id_0, cfrag_0 = id_cfrag_pairs[0]
         if len(id_cfrag_pairs) > 1:
-            ids = self.cfrags.keys() 
+            ids = self.cfrags.keys()
             lambda_0 = lambda_coeff(id_0, ids)
             e = cfrag_0.point_eph_e1 * lambda_0
             v = cfrag_0.point_eph_v1 * lambda_0
-            
-            for id_i,cfrag in id_cfrag_pairs[1:]:
+
+            for id_i, cfrag in id_cfrag_pairs[1:]:
                 lambda_i = lambda_coeff(id_i, ids)
                 e = e + (cfrag.point_eph_e1 * lambda_i)
                 v = v + (cfrag.point_eph_v1 * lambda_i)
         else:
             e = cfrag_0.point_eph_e1
             v = cfrag_0.point_eph_v1
-        
-        return ReconstructedCapsule(e_prime=e, v_prime=v, x=cfrag_0.point_eph_ni)
+
+        self._point_eph_e_prime = e
+        self._point_eph_v_prime = v
+        self._point_noninteractive = cfrag_0.point_eph_ni
+
+    def _reconstructed_bytes(self):
+        """
+        Serialize the reconstruction components into a bytestring.
+        """
+        eph_e = self._point_eph_e_prime
+        eph_v = self._point_eph_v_prime
+        point_noninter = self._point_noninteractive
+
+        return eph_e.to_bytes() + eph_v.to_bytes() + point_noninter.to_bytes()
 
     def __bytes__(self):
         self.to_bytes()
-
-
-class ReconstructedCapsule(object):
-    def __init__(self, e_prime, v_prime, x):
-        self.point_eph_e_prime = e_prime
-        self.point_eph_v_prime = v_prime
-        self.point_eph_ni = x
-
-    @staticmethod
-    def from_bytes(data: bytes, curve: ec.EllipticCurve):
-        """
-        Instantiate ReconstructedCapsule from serialized data.
-        """
-        e_prime = Point.from_bytes(data[0:33], curve)
-        v_prime = Point.from_bytes(data[33:66], curve)
-        eph_ni = Point.from_bytes(data[66:99], curve)
-
-        return ReconstructedCapsule(e_prime, v_prime, eph_ni)
-
-    def to_bytes(self):
-        """
-        Serialize the ReconstructedCapsule to a bytestring.
-        """
-        e_prime = self.point_eph_e_prime.to_bytes()
-        v_prime = self.point_eph_v_prime.to_bytes()
-        eph_ni = self.point_eph_ni.to_bytes()
-
-        return e_prime + v_prime + eph_ni
-
-    def __bytes__(self):
-        return self.to_bytes()
 
 
 class ChallengeResponse(object):
@@ -337,21 +336,19 @@ class PRE(object):
     def reencrypt(self, kFrag, capsule):
         # TODO: Put the assert at the end, but exponentiate by a randon number when false?
         assert capsule.verify(self.params), "Generic Umbral Error"
-        
-        e1 = capsule.point_eph_e * kFrag.bn_key
-        v1 = capsule.point_eph_v * kFrag.bn_key
+
+        e1 = capsule._point_eph_e * kFrag.bn_key
+        v1 = capsule._point_eph_v * kFrag.bn_key
 
         cFrag = CapsuleFrag(e1=e1, v1=v1, id_=kFrag.bn_id, x=kFrag.point_eph_ni)
         return cFrag
 
     def challenge(self, rk, capsule, cFrag):
-
-
         e1 = cFrag.point_eph_e1
         v1 = cFrag.point_eph_v1
 
-        e = capsule.point_eph_e
-        v = capsule.point_eph_v
+        e = capsule._point_eph_e
+        v = capsule._point_eph_v
 
         u = self.params.u
         u1 = rk.point_commitment
@@ -373,8 +370,8 @@ class PRE(object):
         return ch_resp
 
     def check_challenge(self, capsule, cFrag, challenge_resp, pub_a, pub_b):
-        e = capsule.point_eph_e
-        v = capsule.point_eph_v
+        e = capsule._point_eph_e
+        v = capsule._point_eph_v
 
         e1 = cFrag.point_eph_e1
         v1 = cFrag.point_eph_v1
@@ -423,7 +420,6 @@ class PRE(object):
         key = kdf(shared_key, key_length)
 
         return key, Capsule(point_eph_e=pub_r, point_eph_v=pub_u, bn_sig=s)
-
 
     def decapsulate_original(self, priv_key, capsule, key_length=32):
         """Derive the same symmetric key"""

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -116,12 +116,29 @@ class CapsuleFrag(object):
 
 
 class Capsule(object):
-    def __init__(self, point_eph_e, point_eph_v, bn_sig):
-        self.point_eph_e = point_eph_e
-        self.point_eph_v = point_eph_v
-        self.bn_sig = bn_sig
+    def __init__(self,
+                 point_eph_e=None,
+                 point_eph_v=None,
+                 bn_sig=None,
+                 e_prime=None,
+                 v_prime=None,
+                 noninteractive_point=None):
+
+        if not point_eph_e and not e_prime:
+            raise ValueError(
+                "Can't make a Capsule from nothing.  Pass either Alice's data (ie, point_eph_e) or Bob's (e_prime). \
+                Passing both is also fine.")
+
+        self._point_eph_e = point_eph_e
+        self._point_eph_v = point_eph_v
+        self._bn_sig = bn_sig
+
+        self._point_eph_e_prime = e_prime
+        self._point_eph_v_prime = v_prime
+        self._point_noninteractive = noninteractive_point
 
         self.cfrags = {}
+        self._contents = None
 
     @staticmethod
     def from_bytes(data: bytes, curve: ec.EllipticCurve):


### PR DESCRIPTION
### What this does:
1. Removes ReconstructedCapsule
2. Provides facilities for instantiating a Capsule from reconstructed components
3. Establishes public interfaces for Bob to open the capsule and get the contents inside.