### PR TITLE
Implement Simple API to PRE and add UmbralDEM class

### DIFF
--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -3,6 +3,14 @@ import pytest
 from umbral import umbral, keys
 
 
+def test_gen_key():
+    umbral_priv_key = keys.UmbralPrivateKey.gen_key(umbral.UmbralParameters())
+    assert type(umbral_priv_key) == keys.UmbralPrivateKey
+
+    umbral_pub_key = keys.UmbralPublicKey.gen_key(umbral.UmbralParameters())
+    assert type(umbral_pub_key) == keys.UmbralPublicKey
+
+
 def test_private_key_serialization():
     pre = umbral.PRE(umbral.UmbralParameters())
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -7,7 +7,7 @@ def test_gen_key():
     umbral_priv_key = keys.UmbralPrivateKey.gen_key(umbral.UmbralParameters())
     assert type(umbral_priv_key) == keys.UmbralPrivateKey
 
-    umbral_pub_key = keys.UmbralPublicKey.gen_key(umbral.UmbralParameters())
+    umbral_pub_key = umbral_priv_key.get_pub_key(umbral.UmbralParameters())
     assert type(umbral_pub_key) == keys.UmbralPublicKey
 
 

--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -45,7 +45,7 @@ def test_simple_api(N, threshold):
     dec_data = pre.decrypt(priv_key_alice, capsule, enc_data)
     assert dec_data == plain_data
 
-    rekeys, _ = pre.split_rekey(priv_key_alice, pub_key_bob, threshold, N)
+    rekeys, _unused_vkeys = pre.split_rekey(priv_key_alice, pub_key_bob, threshold, N)
     for rekey in rekeys:
         cFrag = pre.reencrypt(rekey, capsule)
         capsule.attach_cfrag(cFrag)
@@ -91,7 +91,7 @@ def test_kfrag_serialization():
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
 
-    kfrags, _ = pre.split_rekey(priv_key, pub_key, 1, 2)
+    kfrags, _unused_vkeys = pre.split_rekey(priv_key, pub_key, 1, 2)
     kfrag_bytes = kfrags[0].to_bytes()
 
     # A KFrag can be represented as the 194 total bytes of two Points (33 each) and four BigNums (32 each).
@@ -113,8 +113,8 @@ def test_cfrag_serialization():
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
 
-    _, capsule = pre._encapsulate(pub_key)
-    kfrags, _ = pre.split_rekey(priv_key, pub_key, 1, 2)
+    _unused_key, capsule = pre._encapsulate(pub_key)
+    kfrags, _unused_vkeys = pre.split_rekey(priv_key, pub_key, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule)
     cfrag_bytes = cfrag.to_bytes()
@@ -156,8 +156,8 @@ def test_reconstructed_capsule_serialization():
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
 
-    _, capsule = pre._encapsulate(pub_key)
-    kfrags, _ = pre.split_rekey(priv_key, pub_key, 1, 2)
+    _unused_key, capsule = pre._encapsulate(pub_key)
+    kfrags, _unused_vkeys = pre.split_rekey(priv_key, pub_key, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule)
 
@@ -183,8 +183,8 @@ def test_challenge_response_serialization():
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
 
-    _, capsule = pre._encapsulate(pub_key)
-    kfrags, _ = pre.split_rekey(priv_key, pub_key, 1, 2)
+    _unused_key, capsule = pre._encapsulate(pub_key)
+    kfrags, _unused_vkeys = pre.split_rekey(priv_key, pub_key, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule)
 

--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -33,25 +33,25 @@ def test_simple_api(N, threshold):
     params = umbral.UmbralParameters()
     pre = umbral.PRE(params)
 
-    priv_key = keys.UmbralPrivateKey.gen_key(params)
-    pub_key = priv_key.get_pub_key(params)
+    priv_key_alice = keys.UmbralPrivateKey.gen_key(params)
+    pub_key_alice = priv_key_alice.get_pub_key(params)
 
     priv_key_bob = keys.UmbralPrivateKey.gen_key(params)
     pub_key_bob = priv_key_bob.get_pub_key(params)
 
     plain_data = b'attack at dawn'
-    enc_data, capsule = pre.encrypt(pub_key, plain_data)
+    enc_data, capsule = pre.encrypt(pub_key_alice, plain_data)
 
-    dec_data = pre.decrypt(priv_key, capsule, enc_data)
+    dec_data = pre.decrypt(priv_key_alice, capsule, enc_data)
     assert dec_data == plain_data
 
-    rekeys, _ = pre.split_rekey(priv_key, pub_key_bob, threshold, N)
+    rekeys, _ = pre.split_rekey(priv_key_alice, pub_key_bob, threshold, N)
     for rekey in rekeys:
         cFrag = pre.reencrypt(rekey, capsule)
         capsule.attach_cfrag(cFrag)
 
     reenc_dec_data = pre.decrypt_reencrypted(
-        priv_key_bob, pub_key_bob, pub_key, capsule, enc_data
+        priv_key_bob, pub_key_bob, pub_key_alice, capsule, enc_data
     )
     assert reenc_dec_data == plain_data
 

--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -51,7 +51,7 @@ def test_simple_api(N, threshold):
         capsule.attach_cfrag(cFrag)
 
     reenc_dec_data = pre.decrypt_reencrypted(
-        priv_key_bob, pub_key_bob, pub_key_alice, capsule, enc_data
+        priv_key_bob, pub_key_alice, capsule, enc_data
     )
     assert reenc_dec_data == plain_data
 

--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -1,6 +1,7 @@
 import pytest
 
-from umbral import umbral
+from umbral import umbral, keys
+
 
 # (N,threshold)
 parameters = [
@@ -18,13 +19,41 @@ def test_decapsulation_by_alice():
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
 
-    sym_key, capsule = pre.encapsulate(pub_key)
+    sym_key, capsule = pre._encapsulate(pub_key)
     assert len(sym_key) == 32
 
     # The symmetric key sym_key is perhaps used for block cipher here in a real-world scenario.
 
-    sym_key_2 = pre.decapsulate_original(priv_key, capsule)
+    sym_key_2 = pre._decapsulate_original(priv_key, capsule)
     assert sym_key_2 == sym_key
+
+
+@pytest.mark.parametrize("N,threshold", parameters)
+def test_simple_api(N, threshold):
+    params = umbral.UmbralParameters()
+    pre = umbral.PRE(params)
+
+    priv_key = keys.UmbralPrivateKey.gen_key(params)
+    pub_key = priv_key.get_pub_key(params)
+
+    priv_key_bob = keys.UmbralPrivateKey.gen_key(params)
+    pub_key_bob = priv_key_bob.get_pub_key(params)
+
+    plain_data = b'attack at dawn'
+    enc_data, capsule = pre.encrypt(pub_key, plain_data)
+
+    dec_data = pre.decrypt(priv_key, capsule, enc_data)
+    assert dec_data == plain_data
+
+    rekeys, _ = pre.split_rekey(priv_key, pub_key_bob, threshold, N)
+    for rekey in rekeys:
+        cFrag = pre.reencrypt(rekey, capsule)
+        capsule.attach_cfrag(cFrag)
+
+    reenc_dec_data = pre.decrypt_reencrypted(
+        priv_key_bob, pub_key_bob, pub_key, capsule, enc_data
+    )
+    assert reenc_dec_data == plain_data
 
 
 @pytest.mark.parametrize("N,threshold", parameters)
@@ -35,7 +64,7 @@ def test_m_of_n(N, threshold):
     priv_bob = pre.gen_priv()
     pub_bob = pre.priv2pub(priv_bob)
 
-    sym_key, capsule_alice = pre.encapsulate(pub_alice)
+    sym_key, capsule_alice = pre._encapsulate(pub_alice)
 
     kfrags, vkeys = pre.split_rekey(priv_alice, pub_bob, threshold, N)
 
@@ -51,7 +80,7 @@ def test_m_of_n(N, threshold):
 
     capsule_bob = capsule_alice.reconstruct()
 
-    sym_key_2 = pre.decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, capsule_bob, capsule_alice)
+    sym_key_2 = pre._decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, capsule_bob, capsule_alice)
 
     assert sym_key_2 == sym_key
 
@@ -84,7 +113,7 @@ def test_cfrag_serialization():
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
 
-    _, capsule = pre.encapsulate(pub_key)
+    _, capsule = pre._encapsulate(pub_key)
     kfrags, _ = pre.split_rekey(priv_key, pub_key, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule)
@@ -107,7 +136,7 @@ def test_capsule_serialization():
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
 
-    _symmetric_key, capsule = pre.encapsulate(pub_key)
+    _symmetric_key, capsule = pre._encapsulate(pub_key)
     capsule_bytes = capsule.to_bytes()
 
     # A Capsule can be represented as the 98 total bytes of two Points (33 each) and a BigNum (32).
@@ -127,7 +156,7 @@ def test_reconstructed_capsule_serialization():
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
 
-    _, capsule = pre.encapsulate(pub_key)
+    _, capsule = pre._encapsulate(pub_key)
     kfrags, _ = pre.split_rekey(priv_key, pub_key, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule)
@@ -154,7 +183,7 @@ def test_challenge_response_serialization():
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
 
-    _, capsule = pre.encapsulate(pub_key)
+    _, capsule = pre._encapsulate(pub_key)
     kfrags, _ = pre.split_rekey(priv_key, pub_key, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule)
@@ -185,8 +214,8 @@ def test_challenge_response_serialization():
 #     priv_bob = pre.gen_priv()
 #     pub_bob = pre.priv2pub(priv_bob)
 
-#     sym_key, capsule_alice = pre.encapsulate(pub_alice)
-#     _, other_capsule_alice = pre.encapsulate(pub_alice)
+#     sym_key, capsule_alice = pre._encapsulate(pub_alice)
+#     _, other_capsule_alice = pre._encapsulate(pub_alice)
 
 #     kfrags, vkeys = pre.split_rekey(priv_alice, pub_bob, threshold, N)
 
@@ -210,7 +239,7 @@ def test_challenge_response_serialization():
 
 #     try:
 #         # This line should always raise an AssertionError ("Generic Umbral Error")
-#         sym_key_2 = pre.decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, capsule_bob, capsule_alice)
+#         sym_key_2 = pre._decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, capsule_bob, capsule_alice)
 #         assert not sym_key_2 == sym_key
 #     except AssertionError as e:
 #         assert str(e) == "Generic Umbral Error"   
@@ -229,7 +258,7 @@ def test_challenge_response_serialization():
 #     priv_bob = pre.gen_priv()
 #     pub_bob = pre.priv2pub(priv_bob)
 
-#     sym_key, capsule_alice = pre.encapsulate(pub_alice)
+#     sym_key, capsule_alice = pre._encapsulate(pub_alice)
 
 #     kfrags, vkeys = pre.split_rekey(priv_alice, priv_bob, threshold, N)
 
@@ -255,7 +284,7 @@ def test_challenge_response_serialization():
 
 #     try:
 #         # This line should always raise an AssertionError ("Generic Umbral Error")
-#         sym_key_2 = pre.decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, capsule_bob, capsule_alice)
+#         sym_key_2 = pre._decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, capsule_bob, capsule_alice)
 #         assert not sym_key_2 == sym_key
 #     except AssertionError as e:
 #         assert str(e) == "Generic Umbral Error"
@@ -273,7 +302,7 @@ def test_challenge_response_serialization():
 #     pub_alice = pre.priv2pub(priv_alice)
 #     priv_bob = pre.gen_priv()
 
-#     sym_key, capsule_alice = pre.encapsulate(pub_alice)
+#     sym_key, capsule_alice = pre._encapsulate(pub_alice)
 
 #     kfrags, vkeys = pre.split_rekey(priv_alice, priv_bob, threshold, N)
 

--- a/umbral/dem.py
+++ b/umbral/dem.py
@@ -1,26 +1,31 @@
-from umbral.umbral import UmbralParameters
-from umbral.keys import UmbralPrivateKey, UmbralPublicKey
+from nacl.secret import SecretBox
 
 
 class UmbralDEM(object):
-    def __init__(self, params: UmbralParameters, recp_pub_key: UmbralPublicKey):
-        self.params = params
-        self.recp_pub_key = recp_pub_key
+    def __init__(self, symm_key: bytes):
+        """
+        Initializes an UmbralDEM object. Requires a key to perform
+        Salsa20-Poly1305.
+        """
+        self.KEYSIZE = SecretBox.KEY_SIZE
 
-    def encrypt(self):
-        pass
+        if len(symm_key) != self.KEYSIZE
+            raise ValueError(
+                "Invalid key size, must be {} bytes".format(SecretBox.KEY_SIZE)
+            )
 
-    def decrypt(self):
-        pass
+        self.cipher = SecretBox(symm_key)
 
-    def decrypt_reencrypted(self):
-        pass
+    def encrypt(self, data: bytes):
+        """
+        Encrypts data using NaCl's Salsa20-Poly1305 secret box symmetric cipher.
+        """
+        enc_data = self.cipher.encrypt(data)
+        return enc_data
 
-    def split_rekey(self):
-        pass
-
-    def reencrypt(self):
-        pass
-
-    def reconstruct(self):
-        pass
+    def decrypt(self, enc_data: bytes):
+        """
+        Decrypts data using NaCl's Salsa20-Poly1305 secret box symmetric cipher.
+        """
+        plaintext = self.cipher.decrypt(enc_data)
+        return plaintext

--- a/umbral/dem.py
+++ b/umbral/dem.py
@@ -7,9 +7,7 @@ class UmbralDEM(object):
         Initializes an UmbralDEM object. Requires a key to perform
         Salsa20-Poly1305.
         """
-        self.KEYSIZE = SecretBox.KEY_SIZE
-
-        if len(symm_key) != self.KEYSIZE
+        if len(symm_key) != SecretBox.KEY_SIZE:
             raise ValueError(
                 "Invalid key size, must be {} bytes".format(SecretBox.KEY_SIZE)
             )

--- a/umbral/dem.py
+++ b/umbral/dem.py
@@ -1,0 +1,26 @@
+from umbral.umbral import UmbralParameters
+from umbral.keys import UmbralPrivateKey, UmbralPublicKey
+
+
+class UmbralDEM(object):
+    def __init__(self, params: UmbralParameters, recp_pub_key: UmbralPublicKey):
+        self.params = params
+        self.recp_pub_key = recp_pub_key
+
+    def encrypt(self):
+        pass
+
+    def decrypt(self):
+        pass
+
+    def decrypt_reencrypted(self):
+        pass
+
+    def split_rekey(self):
+        pass
+
+    def reencrypt(self):
+        pass
+
+    def reconstruct(self):
+        pass

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -17,6 +17,14 @@ class UmbralPrivateKey(object):
         self.bn_key = bn_key
 
     @classmethod
+    def gen_key(cls, params: UmbralParameters):
+        """
+        Generates a private key and returns it.
+        """
+        bn_key = BigNum.gen_rand(params.curve)
+        return cls(bn_key)
+
+    @classmethod
     def load_key(cls, key_data: str, params: UmbralParameters,
                  password: bytes=None, _scrypt_cost: int=20):
         """
@@ -87,6 +95,14 @@ class UmbralPublicKey(object):
         Initializes an Umbral public key.
         """
         self.point_key = point_key
+
+    @classmethod
+    def gen_key(cls, params: UmbralParameters):
+        """
+        Generates a public key and returns it.
+        """
+        point_key = Point.gen_rand(params.curve)
+        return cls(point_key)
 
     @classmethod
     def load_key(cls, key_data: str, params: UmbralParameters):

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -5,7 +5,6 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 from cryptography.hazmat.backends import default_backend
 from nacl.secret import SecretBox
-from umbral.umbral import UmbralParameters
 from umbral.point import Point, BigNum
 
 
@@ -17,7 +16,7 @@ class UmbralPrivateKey(object):
         self.bn_key = bn_key
 
     @classmethod
-    def gen_key(cls, params: UmbralParameters):
+    def gen_key(cls, params):
         """
         Generates a private key and returns it.
         """
@@ -25,7 +24,7 @@ class UmbralPrivateKey(object):
         return cls(bn_key)
 
     @classmethod
-    def load_key(cls, key_data: str, params: UmbralParameters,
+    def load_key(cls, key_data: str, params,
                  password: bytes=None, _scrypt_cost: int=20):
         """
         Loads an Umbral private key from a urlsafe base64 encoded string.
@@ -88,6 +87,12 @@ class UmbralPrivateKey(object):
         encoded_key = base64.urlsafe_b64encode(umbral_priv_key)
         return encoded_key
 
+    def get_pub_key(self, params):
+        """
+        Calculates and returns the public key of the private key.
+        """
+        return UmbralPublicKey(self.bn_key * params.g)
+
 
 class UmbralPublicKey(object):
     def __init__(self, point_key):
@@ -97,15 +102,7 @@ class UmbralPublicKey(object):
         self.point_key = point_key
 
     @classmethod
-    def gen_key(cls, params: UmbralParameters):
-        """
-        Generates a public key and returns it.
-        """
-        point_key = Point.gen_rand(params.curve)
-        return cls(point_key)
-
-    @classmethod
-    def load_key(cls, key_data: str, params: UmbralParameters):
+    def load_key(cls, key_data: str, params):
         """
         Loads an Umbral public key from a urlsafe base64 encoded string.
         """

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -467,7 +467,6 @@ class PRE(object):
         return plaintext
 
     def decrypt_reencrypted(self, recp_priv_key: UmbralPrivateKey,
-                            recp_pub_key: UmbralPublicKey,
                             sender_pub_key: UmbralPublicKey,
                             capsule: Capsule, enc_data: bytes):
         """
@@ -476,7 +475,7 @@ class PRE(object):
 
         Returns the plaintext of the data.
         """
-        # TODO: Do we take only the recipient's private key and form pubkey?
+        recp_pub_key = recp_priv_key.get_pub_key(self.params)
         new_capsule = capsule.reconstruct()
 
         key = self._decapsulate_reencrypted(


### PR DESCRIPTION
### What this does:
1. Implements a simple API with the following methods:
   - `encrypt` -- Encrypts data using KEM/DEM.
   - `decrypt` -- Decrypts data using KEM/DEM.
   - `decrypt_reencrypted` -- Decrypts threshold encrypted data using KEM/DEM.
   - `reencrypt` -- Already in the `PRE` class.
   - `split_rekey` -- Already in the `PRE` class. NOTE: Returns `vKeys`, disregard this for the time being via `_` operator.
   - `reconstruct` -- Already in the `Capsule` class. It is required to use the above methods; therefore is exposed in a similar fashion already.
2. Modifies input of the `split_rekey` method to allow for `UmbralPrivateKey` and `UmbralPublicKey` use.
3. Adds `gen_key` method to `UmbralPrivateKey`.
   - Adds method `get_pub_key` to `UmbralPrivateKey` to calculate public key for the private key.
4. Privatizes the following methods in `PRE`:
    - `_encapsulate`
    - `_decapsulate_reencrypted`
5. Adds `UmbralDEM`:
    - Handles symmetric encryption using NaCl's Salsa20-Poly1305.
         - Maybe switch to a cipher that allows authenticated data? This needs to be scoped/researched.
    - Left to the user to read data from filesystem.
6. Fixes a circular import with `UmbralParameters`.
7. Adds tests for all these things.

---

@cygnusv and I had a call around 02:00MST/01:00PST and discussed the needs for the `UmbralDEM` class as well as the simple API implemented here.

The simple API is implemented in the core Umbral class `PRE`. Subpaths need to be handled on the KMS side. This does not implement or use any challenge methods.

##### NOTE: This merges to the `kms-depend` branch. After merging this branch, continue to merge to the `master` branch.

Good night.