### PR TITLE
Have Umbral keys not require UmbralParameters to be passed

### DIFF
--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,47 +1,46 @@
 import pytest
 
 from umbral import umbral, keys
+from umbral.params import UmbralParameters
 
 
 def test_gen_key():
-    umbral_priv_key = keys.UmbralPrivateKey.gen_key(umbral.UmbralParameters())
+    # Pass in the parameters to test that manual param selection works
+    umbral_priv_key = keys.UmbralPrivateKey.gen_key(UmbralParameters())
     assert type(umbral_priv_key) == keys.UmbralPrivateKey
 
-    umbral_pub_key = umbral_priv_key.get_pub_key(umbral.UmbralParameters())
+    umbral_pub_key = umbral_priv_key.get_pub_key(UmbralParameters())
     assert type(umbral_pub_key) == keys.UmbralPublicKey
 
 
 def test_private_key_serialization():
-    pre = umbral.PRE(umbral.UmbralParameters())
+    pre = umbral.PRE()
 
     priv_key = pre.gen_priv()
     umbral_key = keys.UmbralPrivateKey(priv_key)
 
     encoded_key = umbral_key.save_key()
 
-    decoded_key = keys.UmbralPrivateKey.load_key(encoded_key,
-                                                 umbral.UmbralParameters())
+    decoded_key = keys.UmbralPrivateKey.load_key(encoded_key)
 
     assert priv_key == decoded_key.bn_key
 
 
 def test_private_key_serialization_with_encryption():
-    pre = umbral.PRE(umbral.UmbralParameters())
+    pre = umbral.PRE()
 
     priv_key = pre.gen_priv()
     umbral_key = keys.UmbralPrivateKey(priv_key)
 
     encoded_key = umbral_key.save_key(password=b'test')
 
-    decoded_key = keys.UmbralPrivateKey.load_key(encoded_key,
-                                                 umbral.UmbralParameters(),
-                                                 password=b'test')
+    decoded_key = keys.UmbralPrivateKey.load_key(encoded_key, password=b'test')
 
     assert priv_key == decoded_key.bn_key
 
 
 def test_public_key_serialization():
-    pre = umbral.PRE(umbral.UmbralParameters())
+    pre = umbral.PRE()
 
     priv_key = pre.gen_priv()
     pub_key = pre.priv2pub(priv_key)
@@ -50,7 +49,6 @@ def test_public_key_serialization():
 
     encoded_key = umbral_key.save_key()
 
-    decoded_key = keys.UmbralPublicKey.load_key(encoded_key,
-                                                umbral.UmbralParameters())
+    decoded_key = keys.UmbralPublicKey.load_key(encoded_key)
 
     assert pub_key == decoded_key.point_key

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -6,6 +6,7 @@ from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 from cryptography.hazmat.backends import default_backend
 from nacl.secret import SecretBox
 from umbral.point import Point, BigNum
+from umbral.params import UmbralParameters
 
 
 class UmbralPrivateKey(object):
@@ -16,15 +17,18 @@ class UmbralPrivateKey(object):
         self.bn_key = bn_key
 
     @classmethod
-    def gen_key(cls, params):
+    def gen_key(cls, params: UmbralParameters=None):
         """
         Generates a private key and returns it.
         """
+        if params is None:
+            params = UmbralParameters()
+
         bn_key = BigNum.gen_rand(params.curve)
         return cls(bn_key)
 
     @classmethod
-    def load_key(cls, key_data: str, params,
+    def load_key(cls, key_data: str, params: UmbralParameters=None,
                  password: bytes=None, _scrypt_cost: int=20):
         """
         Loads an Umbral private key from a urlsafe base64 encoded string.
@@ -36,6 +40,9 @@ class UmbralPrivateKey(object):
         not change it here. It is NOT recommended to change the `_scrypt_cost`
         value unless you know what you're doing.
         """
+        if params is None:
+            params = UmbralParameters()
+
         key_bytes = base64.urlsafe_b64decode(key_data)
 
         if password:
@@ -87,10 +94,13 @@ class UmbralPrivateKey(object):
         encoded_key = base64.urlsafe_b64encode(umbral_priv_key)
         return encoded_key
 
-    def get_pub_key(self, params):
+    def get_pub_key(self, params: UmbralParameters=None):
         """
         Calculates and returns the public key of the private key.
         """
+        if params is None:
+            params = UmbralParameters()
+
         return UmbralPublicKey(self.bn_key * params.g)
 
 
@@ -102,10 +112,13 @@ class UmbralPublicKey(object):
         self.point_key = point_key
 
     @classmethod
-    def load_key(cls, key_data: str, params):
+    def load_key(cls, key_data: str, params: UmbralParameters=None):
         """
         Loads an Umbral public key from a urlsafe base64 encoded string.
         """
+        if params is None:
+            params = UmbralParameters()
+
         key_bytes = base64.urlsafe_b64decode(key_data)
 
         point_key = Point.from_bytes(key_bytes, params.curve)

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -1,0 +1,18 @@
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from umbral.point import Point
+from umbral.utils import unsafe_hash_to_point
+
+
+class UmbralParameters(object):
+    def __init__(self):
+        self.curve = ec.SECP256K1()
+        self.g = Point.get_generator_from_curve(self.curve)
+        self.order = Point.get_order_from_curve(self.curve)
+
+        g_bytes = self.g.to_bytes(is_compressed=True)
+
+        domain_seed = b'NuCypherKMS/UmbralParameters/'
+
+        self.h = unsafe_hash_to_point(self.curve, g_bytes, domain_seed + b'h')
+        self.u = unsafe_hash_to_point(self.curve, g_bytes, domain_seed + b'u')

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -5,21 +5,9 @@ from umbral.bignum import BigNum
 from umbral.dem import UmbralDEM
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
 from umbral.point import Point
-from umbral.utils import poly_eval, lambda_coeff, hash_to_bn, kdf, unsafe_hash_to_point
+from umbral.params import UmbralParameters
+from umbral.utils import poly_eval, lambda_coeff, hash_to_bn, kdf
 
-
-class UmbralParameters(object):
-    def __init__(self):
-        self.curve = ec.SECP256K1()
-        self.g = Point.get_generator_from_curve(self.curve)
-        self.order = Point.get_order_from_curve(self.curve)
-        
-        g_bytes = self.g.to_bytes(is_compressed=True)
-
-        domain_seed = b'NuCypherKMS/UmbralParameters/'
-
-        self.h = unsafe_hash_to_point(self.curve, g_bytes, domain_seed + b'h')
-        self.u = unsafe_hash_to_point(self.curve, g_bytes, domain_seed + b'u')
 
 class KFrag(object):
     def __init__(self, id_, key, x, u1, z1, z2):

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -474,7 +474,7 @@ class PRE(object):
 
         This will often be a symmetric key.
         """
-        recp_pub_key = opener_private_key.get_pub_key(pre.params)
+        recp_pub_key = opener_private_key.get_pub_key()
         capsule._reconstruct()
 
         key = pre.decapsulate_reencrypted(


### PR DESCRIPTION
## What this does:
1. Moves `UmbralParameters` to its own file `params.py`.
2. Uses default `UmbralParameters` object in the `keys` API (if none provided) for generating keypairs.
3. Adds tests for the above changes.