### PR TITLE
Changing "_reconstruct" to "_reconstruct_shamirs_secret" and all instances of "reconstructed" to "activated".

### DIFF
--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -86,11 +86,11 @@ def test_two_unequal_capsules():
 
     assert one_capsule != another_capsule
 
-    reconstructed_capsule = Capsule(e_prime=Point.gen_rand(curve=pre.params.curve),
+    activated_capsule = Capsule(e_prime=Point.gen_rand(curve=pre.params.curve),
                                     v_prime=Point.gen_rand(curve=pre.params.curve),
                                     noninteractive_point=Point.gen_rand(curve=pre.params.curve))
 
-    assert reconstructed_capsule != one_capsule
+    assert activated_capsule != one_capsule
 
 
 @pytest.mark.parametrize("N,threshold", parameters)
@@ -117,7 +117,7 @@ def test_m_of_n(N, threshold):
     # assert capsule.is_openable_by_bob()  # TODO: Is it possible to check here if >= m cFrags have been attached?
     # capsule.open(pub_bob, priv_bob, pub_alice)
 
-    capsule._reconstruct()
+    capsule._activate()
     sym_key_from_capsule = pre.decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, capsule)
     assert sym_key == sym_key_from_capsule
 
@@ -186,7 +186,7 @@ def test_capsule_serialization():
     # First, the public approach for the Capsule.  Simply:
     new_capsule == capsule
 
-    # Second, we show that the original components (which is all we have here since we haven't reconstructed) are the same:
+    # Second, we show that the original components (which is all we have here since we haven't activated) are the same:
     assert new_capsule.original_components() == capsule.original_components()
 
     # Third, we can directly compare the private original component attributes (though this is not a supported approach):
@@ -195,7 +195,7 @@ def test_capsule_serialization():
     assert new_capsule._bn_sig == capsule._bn_sig
 
 
-def test_reconstructed_capsule_serialization():
+def test_activated_capsule_serialization():
     pre = umbral.PRE(umbral.UmbralParameters())
 
     priv_key = pre.gen_priv()
@@ -208,10 +208,10 @@ def test_reconstructed_capsule_serialization():
 
     capsule.attach_cfrag(cfrag)
 
-    capsule._reconstruct()
+    capsule._activate()
     rec_capsule_bytes = capsule.to_bytes()
 
-    # A reconstructed Capsule is:
+    # An activated Capsule is:
     # three points, representable as 33 bytes each (the original), and
     # two points and a bignum (32 bytes) (the activated components), for 197 total.
     assert len(rec_capsule_bytes) == (33 * 3) + (33 + 33 + 32)
@@ -223,7 +223,7 @@ def test_reconstructed_capsule_serialization():
     # Again, the same three perspectives on equality. 
     new_rec_capsule == capsule
 
-    assert new_rec_capsule.reconstructed_components() == capsule.reconstructed_components()
+    assert new_rec_capsule.activated_components() == capsule.activated_components()
 
     assert new_rec_capsule._point_eph_e_prime == capsule._point_eph_e_prime
     assert new_rec_capsule._point_eph_v_prime == capsule._point_eph_v_prime
@@ -288,7 +288,7 @@ def test_challenge_response_serialization():
 #     # Let's put the re-encryption of a different Alice ciphertext
 #     cfrags[0] = pre.reencrypt(kfrags[0], other_capsule_alice)
 
-#     capsule_bob = pre.reconstruct_capsule(cfrags)
+#     capsule_bob = pre.activate_capsule(cfrags)
 
 #     try:
 #         # This line should always raise an AssertionError ("Generic Umbral Error")
@@ -333,7 +333,7 @@ def test_challenge_response_serialization():
 #     cfrags[0].point_eph_v1 = Point.gen_rand(pre.curve)
 
 
-#     capsule_bob = pre.reconstruct_capsule(cfrags)
+#     capsule_bob = pre.activate_capsule(cfrags)
 
 #     try:
 #         # This line should always raise an AssertionError ("Generic Umbral Error")

--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -117,7 +117,7 @@ def test_m_of_n(N, threshold):
     # assert capsule.is_openable_by_bob()  # TODO: Is it possible to check here if >= m cFrags have been attached?
     # capsule.open(pub_bob, priv_bob, pub_alice)
 
-    capsule._activate()
+    capsule._recontruct_shamirs_secret()
     sym_key_from_capsule = pre.decapsulate_reencrypted(pub_bob, priv_bob, pub_alice, capsule)
     assert sym_key == sym_key_from_capsule
 
@@ -208,7 +208,7 @@ def test_activated_capsule_serialization():
 
     capsule.attach_cfrag(cfrag)
 
-    capsule._activate()
+    capsule._recontruct_shamirs_secret()
     rec_capsule_bytes = capsule.to_bytes()
 
     # An activated Capsule is:

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -167,8 +167,8 @@ class Capsule(object):
         Serialize the Capsule into a bytestring.
         """
         bytes_representation = bytes().join(c.to_bytes() for c in self.original_components())
-        if all(self.reconstructed_components()):
-            bytes_representation += bytes().join(c.to_bytes() for c in self.reconstructed_components())
+        if all(self.activated_components()):
+            bytes_representation += bytes().join(c.to_bytes() for c in self.activated_components())
         return bytes_representation
 
     def verify(self, params: UmbralParameters):
@@ -186,10 +186,10 @@ class Capsule(object):
     def original_components(self):
         return self._point_eph_e, self._point_eph_v, self._bn_sig
 
-    def reconstructed_components(self):
+    def activated_components(self):
         return self._point_eph_e_prime, self._point_eph_v_prime, self._point_noninteractive
 
-    def _reconstruct(self):
+    def _activate(self):
         id_cfrag_pairs = list(self._attached_cfrags.items())
         id_0, cfrag_0 = id_cfrag_pairs[0]
         if len(id_cfrag_pairs) > 1:
@@ -214,9 +214,9 @@ class Capsule(object):
         self.to_bytes()
 
     def __eq__(self, other):
-        if all(self.reconstructed_components() + other.reconstructed_components()):
-            reconstructed_match = self.reconstructed_components() == other.reconstructed_components()
-            return reconstructed_match
+        if all(self.activated_components() + other.activated_components()):
+            activated_match = self.activated_components() == other.activated_components()
+            return activated_match
         elif all(self.original_components() + other.original_components()):
             original_match = self.original_components() == other.original_components()
             return original_match
@@ -475,7 +475,7 @@ class PRE(object):
         This will often be a symmetric key.
         """
         recp_pub_key = bob_private_key.get_pub_key()
-        capsule._reconstruct()
+        capsule._activate()
 
         key = self.decapsulate_reencrypted(
             recp_pub_key.point_key, bob_private_key.bn_key,

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -189,7 +189,7 @@ class Capsule(object):
     def activated_components(self):
         return self._point_eph_e_prime, self._point_eph_v_prime, self._point_noninteractive
 
-    def _activate(self):
+    def _recontruct_shamirs_secret(self):
         id_cfrag_pairs = list(self._attached_cfrags.items())
         id_0, cfrag_0 = id_cfrag_pairs[0]
         if len(id_cfrag_pairs) > 1:
@@ -475,7 +475,7 @@ class PRE(object):
         This will often be a symmetric key.
         """
         recp_pub_key = bob_private_key.get_pub_key()
-        capsule._activate()
+        capsule._recontruct_shamirs_secret()
 
         key = self.decapsulate_reencrypted(
             recp_pub_key.point_key, bob_private_key.bn_key,


### PR DESCRIPTION
The `Capsule` metaphor has metaphor has evolved a bit.  We originally conceived that the `Capsule` is shattered into fragments and had to be "recontructed."  Now, however, the story is more like this: `Bob` carries the `Capsule` around with him as he follows the `TreasureMap`, showing it to different `Ursulas` and collecting fragments.  He plugs those fragments into the `Capsule` and *it activates* - comes alive, glowing an orange-ish color so that he can provide his key and complete the decryption.