### PR TITLE
Implement curve agnostic behaviors in operations

### DIFF
--- a/tests/test_bignum.py
+++ b/tests/test_bignum.py
@@ -1,6 +1,7 @@
 from umbral.bignum import BigNum
 from cryptography.hazmat.primitives.asymmetric import ec
 
+
 def test_from_to_int():
     curve = ec.SECP256K1()
     x = BigNum.gen_rand(curve)
@@ -10,3 +11,12 @@ def test_from_to_int():
     y = BigNum.from_int(xint, curve)
 
     assert x == y
+
+
+def test_bn_to_cryptography_privkey():
+    curve = ec.SECP256K1()
+    bn = BigNum.gen_rand(curve)
+
+    crypto_privkey = bn.to_cryptography_priv_key()
+
+    assert int(bn) == crypto_privkey.private_numbers().private_value 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -3,6 +3,7 @@ from umbral.bignum import BigNum
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.exceptions import InternalError
 
+
 def test_from_to_bytes():
     curve = ec.SECP256K1()
     p = Point.gen_rand(curve)
@@ -16,6 +17,22 @@ def test_from_to_bytes():
     q = Point.from_bytes(pbytes, curve)
 
     assert p == q
+
+
+def test_point_to_cryptography_pubkey():
+    curve = ec.SECP256K1()
+    p = Point.gen_rand(curve)
+
+    crypto_pub_key = p.to_cryptography_pub_key()
+
+    p_affine = p.to_affine()
+    crypto_affine = (
+        crypto_pub_key.public_numbers().x,
+        crypto_pub_key.public_numbers().y
+    )
+
+    assert p_affine == crypto_affine
+
 
 def test_invalid_points():
     curve = ec.SECP256K1()
@@ -39,6 +56,7 @@ def test_invalid_points():
             assert False
     else:
         assert False
+
 
 def test_generator():
     curve = ec.SECP256K1()

--- a/tests/test_umbral.py
+++ b/tests/test_umbral.py
@@ -54,6 +54,20 @@ def test_simple_api(N, threshold):
     assert reenc_cleartext == plain_data
 
 
+def test_pub_key_encryption():
+    priv_key_alice = keys.UmbralPrivateKey.gen_key()
+    pub_key_alice = priv_key_alice.get_pub_key()
+
+    priv_key_bob = keys.UmbralPrivateKey.gen_key()
+    pub_key_bob = priv_key_bob.get_pub_key()
+
+    plain_data = b'attack at dawn'
+    ciphertext, capsule = umbral.encrypt(pub_key_bob, plain_data)
+
+    cleartext = umbral.decrypt(capsule, priv_key_bob, ciphertext)
+    assert cleartext == plain_data
+
+
 def test_bad_capsule_fails_reencryption():
     priv_key_alice = keys.UmbralPrivateKey.gen_key()
     pub_key_alice = priv_key_alice.get_pub_key()

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -5,6 +5,8 @@ from umbral.config import default_curve, default_params
 from umbral.point import Point
 from umbral.utils import hash_to_bn
 
+from io import BytesIO
+
 
 class KFrag(object):
     def __init__(self, id_, key, x, u1, z1, z2):
@@ -21,13 +23,17 @@ class KFrag(object):
         Instantiate a KFrag object from the serialized data.
         """
         curve = curve if curve is not None else default_curve()
+        key_size = curve.key_size // 8
+        data = BytesIO(data)
 
-        id = BigNum.from_bytes(data[0:32], curve)
-        key = BigNum.from_bytes(data[32:64], curve)
-        eph_ni = Point.from_bytes(data[64:97], curve)
-        commitment = Point.from_bytes(data[97:130], curve)
-        sig1 = BigNum.from_bytes(data[130:162], curve)
-        sig2 = BigNum.from_bytes(data[162:194], curve)
+        # BigNums are the keysize in bytes, Points are compressed and the
+        # keysize + 1 bytes long.
+        id = BigNum.from_bytes(data.read(key_size), curve)
+        key = BigNum.from_bytes(data.read(key_size), curve)
+        eph_ni = Point.from_bytes(data.read(key_size + 1), curve)
+        commitment = Point.from_bytes(data.read(key_size + 1), curve)
+        sig1 = BigNum.from_bytes(data.read(key_size), curve)
+        sig2 = BigNum.from_bytes(data.read(key_size), curve)
 
         return KFrag(id, key, eph_ni, commitment, sig1, sig2)
 
@@ -90,10 +96,15 @@ class CapsuleFrag(object):
         Instantiates a CapsuleFrag object from the serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        e1 = Point.from_bytes(data[0:33], curve)
-        v1 = Point.from_bytes(data[33:66], curve)
-        kfrag_id = BigNum.from_bytes(data[66:98], curve)
-        eph_ni = Point.from_bytes(data[98:131], curve)
+        key_size = curve.key_size // 8
+        data = BytesIO(data)
+
+        # BigNums are the keysize in bytes, Points are compressed and the
+        # keysize + 1 bytes long.
+        e1 = Point.from_bytes(data.read(key_size + 1), curve)
+        v1 = Point.from_bytes(data.read(key_size + 1), curve)
+        kfrag_id = BigNum.from_bytes(data.read(key_size), curve)
+        eph_ni = Point.from_bytes(data.read(key_size + 1), curve)
 
         return CapsuleFrag(e1, v1, kfrag_id, eph_ni)
 

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -1,9 +1,9 @@
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from umbral.bignum import BigNum
+from umbral.bignum import BigNum, hash_to_bn
 from umbral.config import default_curve, default_params
 from umbral.point import Point
-from umbral.utils import hash_to_bn
+from umbral.utils import get_curve_keysize_bytes
 
 from io import BytesIO
 
@@ -23,7 +23,7 @@ class KFrag(object):
         Instantiate a KFrag object from the serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = curve.key_size // 8
+        key_size = get_curve_keysize_bytes(curve)
         data = BytesIO(data)
 
         # BigNums are the keysize in bytes, Points are compressed and the
@@ -96,7 +96,7 @@ class CapsuleFrag(object):
         Instantiates a CapsuleFrag object from the serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = curve.key_size // 8
+        key_size = get_curve_keysize_bytes(curve)
         data = BytesIO(data)
 
         # BigNums are the keysize in bytes, Points are compressed and the

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -13,9 +13,9 @@ class UmbralParameters(object):
 
         g_bytes = self.g.to_bytes(is_compressed=True)
 
+        self.CURVE_MINVAL_SHA512 = (1 << 512) % int(self.order)
+        self.CURVE_KEY_SIZE_BYTES = self.curve.key_size // 8
+
         domain_seed = b'NuCypherKMS/UmbralParameters/'
-
-        self.h = unsafe_hash_to_point(self.curve, g_bytes, domain_seed + b'h')
-        self.u = unsafe_hash_to_point(self.curve, g_bytes, domain_seed + b'u')
-
-        CURVE_MINVAL_SHA512 = (1 << 512) % self.order
+        self.h = unsafe_hash_to_point(self, g_bytes, domain_seed + b'h')
+        self.u = unsafe_hash_to_point(self, g_bytes, domain_seed + b'u')

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -17,5 +17,5 @@ class UmbralParameters(object):
         self.CURVE_KEY_SIZE_BYTES = get_curve_keysize_bytes(self.curve)
 
         parameters_seed = b'NuCypherKMS/UmbralParameters/'
-        self.h = unsafe_hash_to_point(self, g_bytes, domain_seed + b'h')
-        self.u = unsafe_hash_to_point(self, g_bytes, domain_seed + b'u')
+        self.h = unsafe_hash_to_point(g_bytes, self, parameters_seed + b'h')
+        self.u = unsafe_hash_to_point(g_bytes, self, parameters_seed + b'u')

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -16,6 +16,6 @@ class UmbralParameters(object):
         self.CURVE_MINVAL_SHA512 = (1 << 512) % int(self.order)
         self.CURVE_KEY_SIZE_BYTES = get_curve_keysize_bytes(self.curve)
 
-        domain_seed = b'NuCypherKMS/UmbralParameters/'
+        parameters_seed = b'NuCypherKMS/UmbralParameters/'
         self.h = unsafe_hash_to_point(self, g_bytes, domain_seed + b'h')
         self.u = unsafe_hash_to_point(self, g_bytes, domain_seed + b'u')

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -17,3 +17,5 @@ class UmbralParameters(object):
 
         self.h = unsafe_hash_to_point(self.curve, g_bytes, domain_seed + b'h')
         self.u = unsafe_hash_to_point(self.curve, g_bytes, domain_seed + b'u')
+
+        CURVE_MINVAL_SHA512 = (1 << 512) % self.order

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -3,8 +3,8 @@ from cryptography.hazmat.primitives.asymmetric import ec
 
 class UmbralParameters(object):
     def __init__(self, curve: ec.EllipticCurve):
-        from umbral.point import Point
-        from umbral.utils import unsafe_hash_to_point
+        from umbral.point import Point, unsafe_hash_to_point
+        from umbral.utils import get_curve_keysize_bytes
 
         self.curve = curve
 
@@ -14,7 +14,7 @@ class UmbralParameters(object):
         g_bytes = self.g.to_bytes(is_compressed=True)
 
         self.CURVE_MINVAL_SHA512 = (1 << 512) % int(self.order)
-        self.CURVE_KEY_SIZE_BYTES = self.curve.key_size // 8
+        self.CURVE_KEY_SIZE_BYTES = get_curve_keysize_bytes(self.curve)
 
         domain_seed = b'NuCypherKMS/UmbralParameters/'
         self.h = unsafe_hash_to_point(self, g_bytes, domain_seed + b'h')

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -284,7 +284,7 @@ class Point(object):
         return Point(inv, self.curve_nid, self.group)
 
 
-def unsafe_hash_to_point(params, data, label=None):
+def unsafe_hash_to_point(data, params, label=None):
     """
     Hashes arbitrary data into a valid EC point of the specified curve,
     using the try-and-increment method.

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -3,6 +3,7 @@ from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import hashes
 from cryptography.exceptions import InternalError
+from cryptography.hazmat.backends.openssl.ec import _EllipticCurvePublicKey
 
 from umbral.config import default_curve
 from umbral.utils import get_curve_keysize_bytes
@@ -212,6 +213,26 @@ class Point(object):
             backend.openssl_assert(res == 1)
 
         return BigNum(order, curve_nid, group, order)
+
+    def to_cryptography_pub_key(self):
+        """
+        Converts the Point object to a cryptography.io EllipticCurvePublicKey
+        """
+        backend.openssl_assert(self.group != backend._ffi.NULL)
+        backend.openssl_assert(self.ec_point != backend._ffi.NULL)
+
+        ec_key = backend._lib.EC_KEY_new()
+        backend.openssl_assert(ec_key != backend._ffi.NULL)
+        ec_key = backend._ffi.gc(ec_key, backend._lib.EC_KEY_free)
+
+        res = backend._lib.EC_KEY_set_group(ec_key, self.group)
+        backend.openssl_assert(res == 1)
+
+        res = backend._lib.EC_KEY_set_public_key(ec_key, self.ec_point)
+        backend.openssl_assert(res == 1)
+
+        evp_pkey = backend._ec_cdata_to_evp_pkey(ec_key)
+        return _EllipticCurvePublicKey(backend, ec_key, evp_pkey)
 
     def __eq__(self, other):
         """

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -1,8 +1,11 @@
 from umbral.bignum import BigNum
 from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import hashes
+from cryptography.exceptions import InternalError
 
 from umbral.config import default_curve
+from umbral.utils import get_curve_keysize_bytes
 
 
 class Point(object):
@@ -116,7 +119,7 @@ class Point(object):
         if data[0] in [2, 3]:
             type_y = data[0] - 2
 
-            if len(data[1:]) > curve.key_size // 8:
+            if len(data[1:]) > get_curve_keysize_bytes(curve):
                 raise ValueError("X coordinate too large for curve.")
 
             affine_x = BigNum.from_bytes(data[1:], curve)
@@ -135,7 +138,7 @@ class Point(object):
 
         # Handle uncompressed point
         elif data[0] == 4:
-            key_size = curve.key_size // 8
+            key_size = get_curve_keysize_bytes(curve)
             affine_x = int.from_bytes(data[1:key_size+1], 'big')
             affine_y = int.from_bytes(data[1+key_size:], 'big')
 
@@ -279,3 +282,49 @@ class Point(object):
             backend.openssl_assert(res == 1)
 
         return Point(inv, self.curve_nid, self.group)
+
+
+def unsafe_hash_to_point(params, data, label=None):
+    """
+    Hashes arbitrary data into a valid EC point of the specified curve,
+    using the try-and-increment method.
+    It admits an optional label as an additional input to the hash function.
+    It uses SHA256 as the internal hash function.
+
+    WARNING: Do not use when the input data is secret, as this implementation is not
+    in label time, and hence, it is not safe with respect to timing attacks.
+
+    TODO: Check how to uniformly generate ycoords. Currently, it only outputs points
+    where ycoord is even (i.e., starting with 0x02 in compressed notation)
+    """
+    if label is None:
+        label = []
+
+    # We use a 32-bit counter as additional input
+    i = 1
+    while i < 2**32:
+        ibytes = i.to_bytes(4, byteorder='big')
+        sha_512 = hashes.Hash(hashes.SHA512(), backend=backend)
+        sha_512.update(label + ibytes + data)
+        hash_digest = sha_512.finalize()[:params.CURVE_KEY_SIZE_BYTES]
+
+        compressed02 = b"\x02" + hash_digest
+
+        try:
+            h = Point.from_bytes(compressed02, params.curve)
+            return h
+        except InternalError as e:
+            # We want to catch specific InternalExceptions:
+            # - Point not in the curve (code 107)
+            # - Invalid compressed point (code 110)
+            # https://github.com/openssl/openssl/blob/master/include/openssl/ecerr.h#L228
+            if e.err_code[0].reason in (107, 110):
+                pass
+            else:
+                # Any other exception, we raise it
+                raise e
+
+        i += 1
+
+    # Only happens with probability 2^(-32)
+    raise ValueError('Could not hash input into the curve')

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -1,14 +1,14 @@
 from cryptography.hazmat.primitives.asymmetric import ec
 from nacl.secret import SecretBox
 
-from umbral.bignum import BigNum
+from umbral.bignum import BigNum, hash_to_bn
 from umbral.config import default_params, default_curve
 from umbral.dem import UmbralDEM
 from umbral.fragments import KFrag, CapsuleFrag
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
 from umbral.params import UmbralParameters
 from umbral.point import Point
-from umbral.utils import poly_eval, lambda_coeff, hash_to_bn, kdf
+from umbral.utils import poly_eval, lambda_coeff, kdf, get_curve_keysize_bytes
 
 from io import BytesIO
 
@@ -49,7 +49,7 @@ class Capsule(object):
         Instantiates a Capsule object from the serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = curve.key_size // 8
+        key_size = get_curve_keysize_bytes(curve)
         capsule_buff = BytesIO(capsule_bytes)
 
         # BigNums are the keysize in bytes, Points are compressed and the
@@ -149,7 +149,7 @@ class ChallengeResponse(object):
         Instantiate ChallengeResponse from serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = curve.key_size // 8
+        key_size = get_curve_keysize_bytes(curve)
         data = BytesIO(data)
 
         # BigNums are the keysize in bytes, Points are compressed and the

--- a/umbral/umbral.py
+++ b/umbral/umbral.py
@@ -13,6 +13,176 @@ from umbral.utils import poly_eval, lambda_coeff, kdf, get_curve_keysize_bytes
 from io import BytesIO
 
 
+class Capsule(object):
+    def __init__(self,
+                 point_eph_e=None,
+                 point_eph_v=None,
+                 bn_sig=None,
+                 e_prime=None,
+                 v_prime=None,
+                 noninteractive_point=None):
+
+        if not point_eph_e and not e_prime:
+            raise ValueError(
+                "Can't make a Capsule from nothing.  Pass either Alice's data (ie, point_eph_e) or Bob's (e_prime). \
+                Passing both is also fine.")
+
+        self._point_eph_e = point_eph_e
+        self._point_eph_v = point_eph_v
+        self._bn_sig = bn_sig
+
+        self._point_eph_e_prime = e_prime
+        self._point_eph_v_prime = v_prime
+        self._point_noninteractive = noninteractive_point
+
+        self._attached_cfrags = {}
+        self._contents = None
+
+    class NotValid(ValueError):
+        """
+        raised if the capusle does not pass verification.
+        """
+
+    @classmethod
+    def from_bytes(cls, capsule_bytes: bytes, curve: ec.EllipticCurve = None):
+        """
+        Instantiates a Capsule object from the serialized data.
+        """
+        curve = curve if curve is not None else default_curve()
+        key_size = get_curve_keysize_bytes(curve)
+        capsule_buff = BytesIO(capsule_bytes)
+
+        # BigNums are the keysize in bytes, Points are compressed and the
+        # keysize + 1 bytes long.
+        if len(capsule_bytes) == 197:
+            eph_e = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
+            eph_v = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
+            sig = BigNum.from_bytes(capsule_buff.read(key_size), curve)
+            e_prime = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
+            v_prime = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
+            eph_ni = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
+        else:
+            eph_e = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
+            eph_v = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
+            sig = BigNum.from_bytes(capsule_buff.read(key_size), curve)
+            e_prime = v_prime = eph_ni = None
+
+        return cls(point_eph_e=eph_e, point_eph_v=eph_v, bn_sig=sig,
+                   e_prime=e_prime, v_prime=v_prime, noninteractive_point=eph_ni)
+
+    def to_bytes(self):
+        """
+        Serialize the Capsule into a bytestring.
+        """
+        bytes_representation = bytes().join(c.to_bytes() for c in self.original_components())
+        if all(self.activated_components()):
+            bytes_representation += bytes().join(c.to_bytes() for c in self.activated_components())
+        return bytes_representation
+
+    def verify(self, params: UmbralParameters=None):
+        params = params if params is not None else default_params()
+
+        e = self._point_eph_e
+        v = self._point_eph_v
+        s = self._bn_sig
+        h = hash_to_bn([e, v], params)
+
+        return s * params.g == v + (h * e)
+
+    def attach_cfrag(self, cfrag: CapsuleFrag):
+        self._attached_cfrags[cfrag.bn_kfrag_id] = cfrag
+
+    def original_components(self):
+        return self._point_eph_e, self._point_eph_v, self._bn_sig
+
+    def activated_components(self):
+        return self._point_eph_e_prime, self._point_eph_v_prime, self._point_noninteractive
+
+    def _reconstruct_shamirs_secret(self):
+        id_cfrag_pairs = list(self._attached_cfrags.items())
+        id_0, cfrag_0 = id_cfrag_pairs[0]
+        if len(id_cfrag_pairs) > 1:
+            ids = self._attached_cfrags.keys()
+            lambda_0 = lambda_coeff(id_0, ids)
+            e = lambda_0 * cfrag_0.point_eph_e1
+            v = lambda_0 * cfrag_0.point_eph_v1
+
+            for id_i, cfrag in id_cfrag_pairs[1:]:
+                lambda_i = lambda_coeff(id_i, ids)
+                e = e + (lambda_i * cfrag.point_eph_e1)
+                v = v + (lambda_i * cfrag.point_eph_v1)
+        else:
+            e = cfrag_0.point_eph_e1
+            v = cfrag_0.point_eph_v1
+
+        self._point_eph_e_prime = e
+        self._point_eph_v_prime = v
+        self._point_noninteractive = cfrag_0.point_eph_ni
+
+    def __bytes__(self):
+        self.to_bytes()
+
+    def __eq__(self, other):
+        if all(self.activated_components() + other.activated_components()):
+            activated_match = self.activated_components() == other.activated_components()
+            return activated_match
+        elif all(self.original_components() + other.original_components()):
+            original_match = self.original_components() == other.original_components()
+            return original_match
+        else:
+            return False
+
+
+class ChallengeResponse(object):
+    def __init__(self, e2, v2, u1, u2, z1, z2, z3):
+        self.point_eph_e2 = e2
+        self.point_eph_v2 = v2
+        self.point_kfrag_commitment = u1
+        self.point_kfrag_pok = u2
+        self.bn_kfrag_sig1 = z1
+        self.bn_kfrag_sig2 = z2
+        self.bn_sig = z3
+
+    @classmethod
+    def from_bytes(cls, data: bytes, curve: ec.EllipticCurve = None):
+        """
+        Instantiate ChallengeResponse from serialized data.
+        """
+        curve = curve if curve is not None else default_curve()
+        key_size = get_curve_keysize_bytes(curve)
+        data = BytesIO(data)
+
+        # BigNums are the keysize in bytes, Points are compressed and the
+        # keysize + 1 bytes long.
+        e2 = Point.from_bytes(data.read(key_size + 1), curve)
+        v2 = Point.from_bytes(data.read(key_size + 1), curve)
+        kfrag_commitment = Point.from_bytes(data.read(key_size + 1), curve)
+        kfrag_pok = Point.from_bytes(data.read(key_size + 1), curve)
+        kfrag_sig1 = BigNum.from_bytes(data.read(key_size), curve)
+        kfrag_sig2 = BigNum.from_bytes(data.read(key_size), curve)
+        sig = BigNum.from_bytes(data.read(key_size), curve)
+
+        return cls(e2, v2, kfrag_commitment, kfrag_pok, kfrag_sig1, kfrag_sig2, sig)
+
+    def to_bytes(self):
+        """
+        Serialize the ChallengeResponse to a bytestring.
+        """
+        e2 = self.point_eph_e2.to_bytes()
+        v2 = self.point_eph_v2.to_bytes()
+        kfrag_commitment = self.point_kfrag_commitment.to_bytes()
+        kfrag_pok = self.point_kfrag_pok.to_bytes()
+        kfrag_sig1 = self.bn_kfrag_sig1.to_bytes()
+        kfrag_sig2 = self.bn_kfrag_sig2.to_bytes()
+        sig = self.bn_sig.to_bytes()
+
+        return (e2 + v2 + kfrag_commitment + kfrag_pok + kfrag_sig1
+                + kfrag_sig2 + sig)
+
+    def __bytes__(self):
+        return self.to_bytes()
+
+
 def gen_priv(curve: ec.EllipticCurve=None):
     curve = curve if curve is not None else default_curve()
     return BigNum.gen_rand(curve)
@@ -259,179 +429,7 @@ def decrypt(capsule, priv_key: UmbralPrivateKey,
         cleartext = dem.decrypt(ciphertext)
         return cleartext
     else:
-        # Without cfrags, only Alice can open this Capsule.
-        alice_priv_key = priv_key
-        key = _decapsulate_original(alice_priv_key.bn_key, capsule)
+        key = _decapsulate_original(priv_key.bn_key, capsule)
         dem = UmbralDEM(key)
         cleartext = dem.decrypt(ciphertext)
         return cleartext
-
-
-class Capsule(object):
-    def __init__(self,
-                 point_eph_e=None,
-                 point_eph_v=None,
-                 bn_sig=None,
-                 e_prime=None,
-                 v_prime=None,
-                 noninteractive_point=None):
-
-        if not point_eph_e and not e_prime:
-            raise ValueError(
-                "Can't make a Capsule from nothing.  Pass either Alice's data (ie, point_eph_e) or Bob's (e_prime). \
-                Passing both is also fine.")
-
-        self._point_eph_e = point_eph_e
-        self._point_eph_v = point_eph_v
-        self._bn_sig = bn_sig
-
-        self._point_eph_e_prime = e_prime
-        self._point_eph_v_prime = v_prime
-        self._point_noninteractive = noninteractive_point
-
-        self._attached_cfrags = {}
-        self._contents = None
-
-    class NotValid(ValueError):
-        """
-        raised if the capusle does not pass verification.
-        """
-
-    @classmethod
-    def from_bytes(cls, capsule_bytes: bytes, curve: ec.EllipticCurve = None):
-        """
-        Instantiates a Capsule object from the serialized data.
-        """
-        curve = curve if curve is not None else default_curve()
-        key_size = get_curve_keysize_bytes(curve)
-        capsule_buff = BytesIO(capsule_bytes)
-
-        # BigNums are the keysize in bytes, Points are compressed and the
-        # keysize + 1 bytes long.
-        if len(capsule_bytes) == 197:
-            eph_e = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
-            eph_v = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
-            sig = BigNum.from_bytes(capsule_buff.read(key_size), curve)
-            e_prime = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
-            v_prime = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
-            eph_ni = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
-        else:
-            eph_e = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
-            eph_v = Point.from_bytes(capsule_buff.read(key_size + 1), curve)
-            sig = BigNum.from_bytes(capsule_buff.read(key_size), curve)
-            e_prime = v_prime = eph_ni = None
-
-        return cls(point_eph_e=eph_e, point_eph_v=eph_v, bn_sig=sig,
-                   e_prime=e_prime, v_prime=v_prime, noninteractive_point=eph_ni)
-
-    def to_bytes(self):
-        """
-        Serialize the Capsule into a bytestring.
-        """
-        bytes_representation = bytes().join(c.to_bytes() for c in self.original_components())
-        if all(self.activated_components()):
-            bytes_representation += bytes().join(c.to_bytes() for c in self.activated_components())
-        return bytes_representation
-
-    def verify(self, params: UmbralParameters=None):
-        params = params if params is not None else default_params()
-
-        e = self._point_eph_e
-        v = self._point_eph_v
-        s = self._bn_sig
-        h = hash_to_bn([e, v], params)
-
-        return s * params.g == v + (h * e)
-
-    def attach_cfrag(self, cfrag: CapsuleFrag):
-        self._attached_cfrags[cfrag.bn_kfrag_id] = cfrag
-
-    def original_components(self):
-        return self._point_eph_e, self._point_eph_v, self._bn_sig
-
-    def activated_components(self):
-        return self._point_eph_e_prime, self._point_eph_v_prime, self._point_noninteractive
-
-    def _reconstruct_shamirs_secret(self):
-        id_cfrag_pairs = list(self._attached_cfrags.items())
-        id_0, cfrag_0 = id_cfrag_pairs[0]
-        if len(id_cfrag_pairs) > 1:
-            ids = self._attached_cfrags.keys()
-            lambda_0 = lambda_coeff(id_0, ids)
-            e = lambda_0 * cfrag_0.point_eph_e1
-            v = lambda_0 * cfrag_0.point_eph_v1
-
-            for id_i, cfrag in id_cfrag_pairs[1:]:
-                lambda_i = lambda_coeff(id_i, ids)
-                e = e + (lambda_i * cfrag.point_eph_e1)
-                v = v + (lambda_i * cfrag.point_eph_v1)
-        else:
-            e = cfrag_0.point_eph_e1
-            v = cfrag_0.point_eph_v1
-
-        self._point_eph_e_prime = e
-        self._point_eph_v_prime = v
-        self._point_noninteractive = cfrag_0.point_eph_ni
-
-    def __bytes__(self):
-        self.to_bytes()
-
-    def __eq__(self, other):
-        if all(self.activated_components() + other.activated_components()):
-            activated_match = self.activated_components() == other.activated_components()
-            return activated_match
-        elif all(self.original_components() + other.original_components()):
-            original_match = self.original_components() == other.original_components()
-            return original_match
-        else:
-            return False
-
-
-class ChallengeResponse(object):
-    def __init__(self, e2, v2, u1, u2, z1, z2, z3):
-        self.point_eph_e2 = e2
-        self.point_eph_v2 = v2
-        self.point_kfrag_commitment = u1
-        self.point_kfrag_pok = u2
-        self.bn_kfrag_sig1 = z1
-        self.bn_kfrag_sig2 = z2
-        self.bn_sig = z3
-
-    @classmethod
-    def from_bytes(cls, data: bytes, curve: ec.EllipticCurve = None):
-        """
-        Instantiate ChallengeResponse from serialized data.
-        """
-        curve = curve if curve is not None else default_curve()
-        key_size = get_curve_keysize_bytes(curve)
-        data = BytesIO(data)
-
-        # BigNums are the keysize in bytes, Points are compressed and the
-        # keysize + 1 bytes long.
-        e2 = Point.from_bytes(data.read(key_size + 1), curve)
-        v2 = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_commitment = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_pok = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_sig1 = BigNum.from_bytes(data.read(key_size), curve)
-        kfrag_sig2 = BigNum.from_bytes(data.read(key_size), curve)
-        sig = BigNum.from_bytes(data.read(key_size), curve)
-
-        return cls(e2, v2, kfrag_commitment, kfrag_pok, kfrag_sig1, kfrag_sig2, sig)
-
-    def to_bytes(self):
-        """
-        Serialize the ChallengeResponse to a bytestring.
-        """
-        e2 = self.point_eph_e2.to_bytes()
-        v2 = self.point_eph_v2.to_bytes()
-        kfrag_commitment = self.point_kfrag_commitment.to_bytes()
-        kfrag_pok = self.point_kfrag_pok.to_bytes()
-        kfrag_sig1 = self.bn_kfrag_sig1.to_bytes()
-        kfrag_sig2 = self.bn_kfrag_sig2.to_bytes()
-        sig = self.bn_sig.to_bytes()
-
-        return (e2 + v2 + kfrag_commitment + kfrag_pok + kfrag_sig1
-                + kfrag_sig2 + sig)
-
-    def __bytes__(self):
-        return self.to_bytes()

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -3,10 +3,6 @@ import math
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from cryptography.exceptions import InternalError
-
-from umbral.bignum import BigNum
-from umbral.point import Point
 
 
 def lambda_coeff(id_i, selected_ids):
@@ -30,77 +26,6 @@ def poly_eval(coeff, x):
         result = ((result * x) + coeff[i])
 
     return result
-
-
-def hash_to_bn(crypto_items, params):
-    sha_512 = hashes.Hash(hashes.SHA512(), backend=default_backend())
-    for item in crypto_items:
-        if isinstance(item, Point):
-            data_bytes = item.to_bytes()
-        elif isinstance(item, BigNum):
-            data_bytes = int(item).to_bytes(params.CURVE_KEY_SIZE_BYTES, 'big')
-        else:
-            data_bytes = item
-        sha_512.update(data_bytes)
-
-    i = 0
-    h = 0
-    while h < params.CURVE_MINVAL_SHA512:
-        sha_512_i = sha_512.copy()
-        sha_512_i.update(i.to_bytes(params.CURVE_KEY_SIZE_BYTES, 'big'))
-        hash_digest = sha_512_i.finalize()
-        h = int.from_bytes(hash_digest, byteorder='big', signed=False)
-        i += 1
-    hash_bn = h % int(params.order)
- 
-    res = BigNum.from_int(hash_bn, params.curve)
- 
-    return res
-
-def unsafe_hash_to_point(params, data, label=None):
-    """
-    Hashes arbitrary data into a valid EC point of the specified curve,
-    using the try-and-increment method.
-    It admits an optional label as an additional input to the hash function.
-    It uses SHA256 as the internal hash function. 
-
-    WARNING: Do not use when the input data is secret, as this implementation is not 
-    in label time, and hence, it is not safe with respect to timing attacks.
-
-    TODO: Check how to uniformly generate ycoords. Currently, it only outputs points 
-    where ycoord is even (i.e., starting with 0x02 in compressed notation)
-    """
-    if label is None:
-        label = []
-
-    # We use a 32-bit counter as additional input
-    i = 1
-    while i < 2**32:
-        ibytes = i.to_bytes(4, byteorder='big')
-        sha_512 = hashes.Hash(hashes.SHA512(), backend=default_backend())
-        sha_512.update(label + ibytes + data)
-        hash_digest = sha_512.finalize()[:params.CURVE_KEY_SIZE_BYTES]
-
-        compressed02 = b"\x02" + hash_digest
-
-        try:
-            h = Point.from_bytes(compressed02, params.curve)
-            return h
-        except InternalError as e:
-            # We want to catch specific InternalExceptions: 
-            # - Point not in the curve (code 107)
-            # - Invalid compressed point (code 110)
-            # https://github.com/openssl/openssl/blob/master/include/openssl/ecerr.h#L228
-            if e.err_code[0].reason in (107, 110):
-                pass
-            else:
-                # Any other exception, we raise it
-                raise e
-        
-        i += 1
-
-    # Only happens with probability 2^(-32)
-    raise ValueError('Could not hash input into the curve')
 
 
 def kdf(ecpoint, key_length):

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -1,3 +1,5 @@
+import math
+
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -111,3 +113,7 @@ def kdf(ecpoint, key_length):
         info=None,
         backend=default_backend()
     ).derive(data)
+
+
+def get_curve_keysize_bytes(curve):
+    return int(math.ceil(curve.key_size / 8.00))


### PR DESCRIPTION
### What this does:
1. Use SHA512 in the cryptographic material hashing functions (`hash_to_bn` and `unsafe_hash_to_point`).
2. Implement `CURVE_KEY_SIZE_BYTES` and `CURVE_MINVAL_SHA512` in `UmbralParameters`.
3. Use `BytesIO` to deserialize fragment objects based on curve keysize.
4. Move `unsafe_hash_to_bn` and `hash_to_bn` to the point and bignum modules, respectively.
    - This solves a circular import issue.
5. Add a `get_curve_keysize_bytes` function to `utils` which accurately returns keysizes for a specific curve.
6. Some reorganization changes.
7. Adds `to_cryptography_priv_key` and `to_cryptography_pub_key` on `BigNum` and `Point`.
8. Adds tests for the above ^.