### PR TITLE
Implement methods to convert Umbral keys to cryptography.io keys in `keys` and some other changes.

### DIFF
--- a/tests/test_keys/test_umbral_keys.py
+++ b/tests/test_keys/test_umbral_keys.py
@@ -50,3 +50,16 @@ def test_public_key_to_bytes():
     key_bytes = bytes(umbral_key)
 
     assert type(key_bytes) == bytes
+
+
+def test_umbral_key_to_cryptography_keys():
+    umbral_priv_key = keys.UmbralPrivateKey.gen_key()
+    umbral_pub_key = umbral_priv_key.get_pubkey()
+
+    crypto_privkey = umbral_priv_key.to_cryptography_privkey()
+    assert int(umbral_priv_key.bn_key) == crypto_privkey.private_numbers().private_value
+
+    crypto_pubkey = umbral_pub_key.to_cryptography_pubkey()
+    umbral_affine = umbral_pub_key.point_key.to_affine()
+    x, y = crypto_pubkey.public_numbers().x, crypto_pubkey.public_numbers().y
+    assert umbral_affine == (x, y)

--- a/tests/test_primitives/test_bignum/test_bignum_methods.py
+++ b/tests/test_primitives/test_bignum/test_bignum_methods.py
@@ -11,9 +11,3 @@ def test_cast_bignum_to_int():
 
     y = BigNum.from_int(x)
     assert x == y
-
-
-def test_bignum_to_cryptography_privkey():
-    bn = BigNum.gen_rand()
-    crypto_privkey = bn.to_cryptography_priv_key()
-    assert int(bn) == crypto_privkey.private_numbers().private_value

--- a/tests/test_primitives/test_point/test_point_serializers.py
+++ b/tests/test_primitives/test_point/test_point_serializers.py
@@ -65,14 +65,6 @@ def test_affine(point_affine, nid, curve):
     assert point_affine == point_affine2
 
 
-def test_point_to_cryptography_pubkey(random_ec_point2):
-    crypto_pub_key = random_ec_point2.to_cryptography_pub_key()
-    p_affine = random_ec_point2.to_affine()
-    x, y = crypto_pub_key.public_numbers().x, crypto_pub_key.public_numbers().y
-    crypto_affine = (x, y)
-    assert p_affine == crypto_affine
-
-
 def test_invalid_points(random_ec_point2):
 
     point_bytes = bytearray(random_ec_point2.to_bytes(is_compressed=False))

--- a/umbral/bignum.py
+++ b/umbral/bignum.py
@@ -3,7 +3,6 @@ import os
 from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.backends.openssl.ec import _EllipticCurvePrivateKey
 
 from umbral.config import default_curve
 from umbral.utils import get_curve_keysize_bytes
@@ -104,41 +103,6 @@ class BigNum(object):
         size = backend._lib.BN_num_bytes(self.order)
 
         return int.to_bytes(int(self), size, 'big')
-
-    def to_cryptography_priv_key(self):
-        """
-        Converts the BigNum object to a cryptography.io EllipticCurvePrivateKey
-        """
-        backend.openssl_assert(self.group != backend._ffi.NULL)
-        backend.openssl_assert(self.bignum != backend._ffi.NULL)
-
-        ec_key = backend._lib.EC_KEY_new()
-        backend.openssl_assert(ec_key != backend._ffi.NULL)
-        ec_key = backend._ffi.gc(ec_key, backend._lib.EC_KEY_free)
-
-        res = backend._lib.EC_KEY_set_group(ec_key, self.group)
-        backend.openssl_assert(res == 1)
-
-        res = backend._lib.EC_KEY_set_private_key(ec_key, self.bignum)
-        backend.openssl_assert(res == 1)
-
-        # Get public key
-        point = backend._lib.EC_POINT_new(self.group)
-        backend.openssl_assert(point != backend._ffi.NULL)
-        point = backend._ffi.gc(point, backend._lib.EC_POINT_free)
-
-        with backend._tmp_bn_ctx() as bn_ctx:
-            res = backend._lib.EC_POINT_mul(
-                self.group, point, self.bignum, backend._ffi.NULL,
-                backend._ffi.NULL, bn_ctx
-            )
-            backend.openssl_assert(res == 1)
-
-            res = backend._lib.EC_KEY_set_public_key(ec_key, point)
-            backend.openssl_assert(res == 1)
-
-        evp_pkey = backend._ec_cdata_to_evp_pkey(ec_key)
-        return _EllipticCurvePrivateKey(backend, ec_key, evp_pkey)
 
     def __int__(self):
         """

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -209,11 +209,15 @@ class UmbralPublicKey(object):
         backend.openssl_assert(ec_key != backend._ffi.NULL)
         ec_key = backend._ffi.gc(ec_key, backend._lib.EC_KEY_free)
 
-        res = backend._lib.EC_KEY_set_group(ec_key, self.point_key.group)
-        backend.openssl_assert(res == 1)
+        set_group_result = backend._lib.EC_KEY_set_group(
+            ec_key, self.point_key.group
+        )
+        backend.openssl_assert(set_group_result == 1)
 
-        res = backend._lib.EC_KEY_set_public_key(ec_key, self.point_key.ec_point)
-        backend.openssl_assert(res == 1)
+        set_pubkey_result = backend._lib.EC_KEY_set_public_key(
+            ec_key, self.point_key.ec_point
+        )
+        backend.openssl_assert(set_pubkey_result == 1)
 
         evp_pkey = backend._ec_cdata_to_evp_pkey(ec_key)
         return _EllipticCurvePublicKey(backend, ec_key, evp_pkey)

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -120,30 +120,34 @@ class UmbralPrivateKey(object):
         backend.openssl_assert(self.bn_key.group != backend._ffi.NULL)
         backend.openssl_assert(self.bn_key.bignum != backend._ffi.NULL)
 
-        new_ec_key = backend._lib.EC_KEY_new()
-        backend.openssl_assert(new_ec_key != backend._ffi.NULL)
-        ec_key = backend._ffi.gc(new_ec_key, backend._lib.EC_KEY_free)
+        ec_key = backend._lib.EC_KEY_new()
+        backend.openssl_assert(ec_key != backend._ffi.NULL)
+        ec_key = backend._ffi.gc(ec_key, backend._lib.EC_KEY_free)
 
-        set_group_result = backend._lib.EC_KEY_set_group(ec_key, self.bn_key.group)
+        set_group_result = backend._lib.EC_KEY_set_group(
+            ec_key, self.bn_key.group
+        )
         backend.openssl_assert(set_group_result == 1)
 
-        set_private_key_result = backend._lib.EC_KEY_set_private_key(ec_key, self.bn_key.bignum)
-        backend.openssl_assert(set_private_key_result == 1)
+        set_privkey_result = backend._lib.EC_KEY_set_private_key(
+            ec_key, self.bn_key.bignum
+        )
+        backend.openssl_assert(set_privkey_result == 1)
 
         # Get public key
-        new_point = backend._lib.EC_POINT_new(self.bn_key.group)
-        backend.openssl_assert(new_point != backend._ffi.NULL)
-        point = backend._ffi.gc(new_point, backend._lib.EC_POINT_free)
+        point = backend._lib.EC_POINT_new(self.bn_key.group)
+        backend.openssl_assert(point != backend._ffi.NULL)
+        point = backend._ffi.gc(point, backend._lib.EC_POINT_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
-            multiplication_result = backend._lib.EC_POINT_mul(
+            mult_result = backend._lib.EC_POINT_mul(
                 self.bn_key.group, point, self.bn_key.bignum, backend._ffi.NULL,
                 backend._ffi.NULL, bn_ctx
             )
-        backend.openssl_assert(multiplication_result == 1)
+            backend.openssl_assert(mult_result == 1)
 
-        set_public_key_result = backend._lib.EC_KEY_set_public_key(ec_key, point)
-        backend.openssl_assert(set_public_key_result == 1)
+        set_pubkey_result = backend._lib.EC_KEY_set_public_key(ec_key, point)
+        backend.openssl_assert(set_pubkey_result == 1)
 
         evp_pkey = backend._ec_cdata_to_evp_pkey(ec_key)
         return _EllipticCurvePrivateKey(backend, ec_key, evp_pkey)

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -3,10 +3,13 @@ import base64
 
 from typing import Union
 
+from nacl.secret import SecretBox
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 from cryptography.hazmat.backends import default_backend
-from nacl.secret import SecretBox
+from cryptography.hazmat.backends.openssl.ec import (
+    _EllipticCurvePublicKey, _EllipticCurvePrivateKey
+)
 
 from umbral.config import default_params
 from umbral.point import Point, BigNum
@@ -108,6 +111,43 @@ class UmbralPrivateKey(object):
         """
         return UmbralPublicKey(self.bn_key * self.params.g)
 
+    def to_cryptography_privkey(self):
+        """
+        Returns a cryptography.io EllipticCurvePrivateKey from the Umbral key.
+        """
+        backend = default_backend()
+
+        backend.openssl_assert(self.bn_key.group != backend._ffi.NULL)
+        backend.openssl_assert(self.bn_key.bignum != backend._ffi.NULL)
+
+        ec_key = backend._lib.EC_KEY_new()
+        backend.openssl_assert(ec_key != backend._ffi.NULL)
+        ec_key = backend._ffi.gc(ec_key, backend._lib.EC_KEY_free)
+
+        res = backend._lib.EC_KEY_set_group(ec_key, self.bn_key.group)
+        backend.openssl_assert(res == 1)
+
+        res = backend._lib.EC_KEY_set_private_key(ec_key, self.bn_key.bignum)
+        backend.openssl_assert(res == 1)
+
+        # Get public key
+        point = backend._lib.EC_POINT_new(self.bn_key.group)
+        backend.openssl_assert(point != backend._ffi.NULL)
+        point = backend._ffi.gc(point, backend._lib.EC_POINT_free)
+
+        with backend._tmp_bn_ctx() as bn_ctx:
+            res = backend._lib.EC_POINT_mul(
+                self.bn_key.group, point, self.bn_key.bignum, backend._ffi.NULL,
+                backend._ffi.NULL, bn_ctx
+            )
+            backend.openssl_assert(res == 1)
+
+            res = backend._lib.EC_KEY_set_public_key(ec_key, point)
+            backend.openssl_assert(res == 1)
+
+        evp_pkey = backend._ec_cdata_to_evp_pkey(ec_key)
+        return _EllipticCurvePrivateKey(backend, ec_key, evp_pkey)
+
 
 class UmbralPublicKey(object):
     def __init__(self, point_key, params: UmbralParameters=None):
@@ -151,6 +191,28 @@ class UmbralPublicKey(object):
 
     def get_pubkey(self):
         raise NotImplementedError
+
+    def to_cryptography_pubkey(self):
+        """
+        Returns a cryptography.io EllipticCurvePublicKey from the Umbral key.
+        """
+        backend = default_backend()
+
+        backend.openssl_assert(self.point_key.group != backend._ffi.NULL)
+        backend.openssl_assert(self.point_key.ec_point != backend._ffi.NULL)
+
+        ec_key = backend._lib.EC_KEY_new()
+        backend.openssl_assert(ec_key != backend._ffi.NULL)
+        ec_key = backend._ffi.gc(ec_key, backend._lib.EC_KEY_free)
+
+        res = backend._lib.EC_KEY_set_group(ec_key, self.point_key.group)
+        backend.openssl_assert(res == 1)
+
+        res = backend._lib.EC_KEY_set_public_key(ec_key, self.point_key.ec_point)
+        backend.openssl_assert(res == 1)
+
+        evp_pkey = backend._ec_cdata_to_evp_pkey(ec_key)
+        return _EllipticCurvePublicKey(backend, ec_key, evp_pkey)
 
     def __bytes__(self):
         """

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -3,7 +3,6 @@ from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import hashes
 from cryptography.exceptions import InternalError
-from cryptography.hazmat.backends.openssl.ec import _EllipticCurvePublicKey
 
 from umbral.config import default_curve
 from umbral.utils import get_curve_keysize_bytes
@@ -213,26 +212,6 @@ class Point(object):
             backend.openssl_assert(res == 1)
 
         return BigNum(order, curve_nid, group, order)
-
-    def to_cryptography_pub_key(self):
-        """
-        Converts the Point object to a cryptography.io EllipticCurvePublicKey
-        """
-        backend.openssl_assert(self.group != backend._ffi.NULL)
-        backend.openssl_assert(self.ec_point != backend._ffi.NULL)
-
-        ec_key = backend._lib.EC_KEY_new()
-        backend.openssl_assert(ec_key != backend._ffi.NULL)
-        ec_key = backend._ffi.gc(ec_key, backend._lib.EC_KEY_free)
-
-        res = backend._lib.EC_KEY_set_group(ec_key, self.group)
-        backend.openssl_assert(res == 1)
-
-        res = backend._lib.EC_KEY_set_public_key(ec_key, self.ec_point)
-        backend.openssl_assert(res == 1)
-
-        evp_pkey = backend._ec_cdata_to_evp_pkey(ec_key)
-        return _EllipticCurvePublicKey(backend, ec_key, evp_pkey)
 
     def __eq__(self, other):
         """

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -3,7 +3,6 @@ import hmac
 from typing import Tuple, Union, List
 
 from cryptography.hazmat.primitives.asymmetric import ec
-from nacl.secret import SecretBox
 
 from umbral.bignum import BigNum, hash_to_bn
 from umbral.config import default_params, default_curve
@@ -15,6 +14,9 @@ from umbral.point import Point
 from umbral.utils import poly_eval, lambda_coeff, kdf, get_curve_keysize_bytes
 
 from io import BytesIO
+
+
+CHACHA20_KEY_SIZE = 32
 
 
 class GenericUmbralError(Exception):
@@ -445,7 +447,7 @@ def encrypt(alice_pubkey: UmbralPublicKey, plaintext: bytes) -> Tuple[bytes, Cap
 
     Returns the ciphertext and the KEM Capsule.
     """
-    key, capsule = _encapsulate(alice_pubkey.point_key, SecretBox.KEY_SIZE)
+    key, capsule = _encapsulate(alice_pubkey.point_key, CHACHA20_KEY_SIZE)
 
     capsule_bytes = bytes(capsule)
 


### PR DESCRIPTION
### What this does:
1. Moves `to_cryptography_pubkey` and `to_cryptography_privkey` to `UmbralPublicKey` and `UmbralPrivateKey` respectively.
2. Adds tests in `test_umbral_keys`.
3. Creates and uses a constant `CHACHA20_KEY_SIZE` for encapsulation instead of the unused `SecretBox.KEY_SIZE` constant.
3. Resolves #84 
4. Resolves #74

### What needs to be done:
1. Update `nucypher-kms` to handle these changes.
2. ~Make an issue with cryptography.io to add key size constants for their specific AEAD and symmetric ciphers.~ [Done](https://github.com/pyca/cryptography/issues/4137)