### PR TITLE
Improvements to reconstruction and challenge protocol. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,13 +63,6 @@ extending the traditional cryptological narrative of "Alice and Bob" by introduc
                           ciphertext, alices_public_key)
 
 
-Features
-==========
-- Proxy Re-encryption Toolkit
-- Re-encryption Key Fragmentation
-- Elliptic Curve Arithmetic
-
-
 Quick Installation
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ extending the traditional cryptological narrative of "Alice and Bob" by introduc
 .. _OpenSSL: https://www.openssl.org/
 
 
-**Encapsulation**
+**Encryption**
 
 .. code-block:: python
 
@@ -45,7 +45,7 @@ extending the traditional cryptological narrative of "Alice and Bob" by introduc
     bobs_public_key = private_key.get_pubkey()
 
     # Alice generates split re-encryption keys for Bob with "M of N".
-    kfrags, _ = umbral.split_rekey(alices_private_key, bobs_public_key, 10, 20)
+    kfrags = umbral.split_rekey(alices_private_key, bobs_public_key, 10, 20)
 
 
 **Re-encryption**
@@ -94,7 +94,7 @@ Academic Whitepaper
 The Umbral scheme academic whitepaper and cryptographic specifications
 are availible on GitHub_.
 
-  "Umbral A Threshold Proxy Re-Encryption Scheme"
+  "Umbral: A Threshold Proxy Re-Encryption Scheme"
   *by David Nuñez*
   https://github.com/nucypher/umbral-doc/blob/master/umbral-doc.pdf
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ pyUmbral
 .. image:: https://travis-ci.org/nucypher/pyUmbral.svg?branch=master
     :target: https://travis-ci.org/nucypher/pyUmbral
 
-pyUmbral is a python implementation of David Nuñez's threshold proxy rencryption scheme: Umbral_.
+pyUmbral is a python implementation of David Nuñez's threshold proxy re-encryption scheme: Umbral_.
 Implemented with OpenSSL_ and Cryptography.io_, pyUmbral is a referential and open-source cryptography library
 extending the traditional cryptological narrative of "Alice and Bob" by introducing a new actor,
 *Ursula*, who has the ability to take secrets encrypted for Alice and *re-encrypt* them for Bob.
@@ -65,9 +65,8 @@ extending the traditional cryptological narrative of "Alice and Bob" by introduc
 
 Features
 ==========
-- Re-encryption Toolkit
+- Proxy Re-encryption Toolkit
 - Re-encryption Key Fragmentation
-- Key Encapsulation
 - Elliptic Curve Arithmetic
 
 
@@ -82,7 +81,7 @@ The recommended installation procedure is as follows:
     $ sudo pip3 install pipenv
     $ pipenv install
 
-Post-installation, you can activate the project virtual enviorment
+Post-installation, you can activate the project virtual environment
 in your current terminal session by running :bash:`pipenv shell`.
 
 For more information on pipenv, find the official documentation here: https://docs.pipenv.org/.
@@ -92,7 +91,7 @@ Academic Whitepaper
 ====================
 
 The Umbral scheme academic whitepaper and cryptographic specifications
-are availible on GitHub_.
+are available on GitHub_.
 
   "Umbral: A Threshold Proxy Re-Encryption Scheme"
   *by David Nuñez*

--- a/tests/test_capsule/test_capsule_operations.py
+++ b/tests/test_capsule/test_capsule_operations.py
@@ -93,31 +93,3 @@ def test_capsule_as_dict_key(alices_keys):
     some_dict[capsule] = "Bob has changed his mind."
     assert some_dict[capsule] == "Bob has changed his mind."
     assert len(some_dict.keys()) == 1
-
-
-@pytest.mark.parametrize("N, M", parameters)
-def test_alice_sends_fake_kfrag_to_ursula(N, M):
-
-    priv_key_alice = keys.UmbralPrivateKey.gen_key()
-    pub_key_alice = priv_key_alice.get_pubkey()
-
-    priv_key_bob = keys.UmbralPrivateKey.gen_key()
-    pub_key_bob = priv_key_bob.get_pubkey()
-
-    plaintext = b'peace at dawn'
-    ciphertext, capsule = pre.encrypt(pub_key_alice, plaintext)
-
-    cleartext = pre.decrypt(capsule, priv_key_alice, ciphertext)
-    assert cleartext == plaintext
-
-    k_frags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
-
-    # Alice tries to frame the first Ursula by sending her a random kFrag
-    k_frags[0].bn_key = BigNum.gen_rand()
-
-    for k_frag in k_frags:
-        c_frag = pre.reencrypt(k_frag, capsule)
-        capsule.attach_cfrag(c_frag)
-
-    with pytest.raises(pre.GenericUmbralError):
-        _ = pre.decrypt(capsule, priv_key_bob, ciphertext, pub_key_alice)

--- a/tests/test_capsule/test_capsule_operations.py
+++ b/tests/test_capsule/test_capsule_operations.py
@@ -119,5 +119,5 @@ def test_alice_sends_fake_kfrag_to_ursula(N, M):
         c_frag = pre.reencrypt(k_frag, capsule)
         capsule.attach_cfrag(c_frag)
 
-    with pytest.raises(Exception):
+    with pytest.raises(pre.GenericUmbralError):
         _ = pre.decrypt(capsule, priv_key_bob, ciphertext, pub_key_alice)

--- a/tests/test_capsule/test_capsule_operations.py
+++ b/tests/test_capsule/test_capsule_operations.py
@@ -85,7 +85,7 @@ def test_capsule_as_dict_key(alices_keys):
     capsule.attach_cfrag(cfrag)
 
     # Even if we activate the capsule, it still serves as the same key.
-    cleartext = pre.decrypt(capsule, alices_keys.priv, ciphertext, alices_keys.pub)
+    cleartext = pre.decrypt(ciphertext, capsule, alices_keys.priv, alices_keys.pub)
     assert some_dict[capsule] == "Thing that Bob wants to try per-Capsule"
     assert cleartext == plain_data
 

--- a/tests/test_capsule/test_capsule_serializers.py
+++ b/tests/test_capsule/test_capsule_serializers.py
@@ -32,13 +32,11 @@ def test_capsule_serialization(alices_keys):
     assert new_capsule._bn_sig == capsule._bn_sig
 
 
-def test_activated_capsule_serialization(alices_keys):
+def test_activated_capsule_serialization(alices_keys, bobs_keys):
     priv_key_alice, pub_key_alice = alices_keys
+    priv_key_bob, pub_key_bob = bobs_keys
 
-    priv_key_bob = pre.gen_priv()
-    pub_key_bob = pre.priv2pub(priv_key_bob)
-
-    _unused_key, capsule = pre._encapsulate(pub_key_bob)
+    _unused_key, capsule = pre._encapsulate(pub_key_bob.point_key)
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule)

--- a/tests/test_capsule/test_capsule_serializers.py
+++ b/tests/test_capsule/test_capsule_serializers.py
@@ -32,18 +32,20 @@ def test_capsule_serialization(alices_keys):
     assert new_capsule._bn_sig == capsule._bn_sig
 
 
-def test_activated_capsule_serialization():
-    priv_key = pre.gen_priv()
-    pub_key = pre.priv2pub(priv_key)
+def test_activated_capsule_serialization(alices_keys):
+    priv_key_alice, pub_key_alice = alices_keys
 
-    _unused_key, capsule = pre._encapsulate(pub_key)
-    kfrags = pre.split_rekey(priv_key, pub_key, 1, 2)
+    priv_key_bob = pre.gen_priv()
+    pub_key_bob = pre.priv2pub(priv_key_bob)
+
+    _unused_key, capsule = pre._encapsulate(pub_key_bob)
+    kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule)
 
     capsule.attach_cfrag(cfrag)
 
-    capsule._reconstruct_shamirs_secret()
+    capsule._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)
     rec_capsule_bytes = capsule.to_bytes()
 
     # An activated Capsule is:

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -60,7 +60,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
         challenges.append(challenge)
         c_frags.append(c_frag)
 
-    capsule_alice1._reconstruct_shamirs_secret()    # activate capsule
+    capsule_alice1._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    # activate capsule
 
     with pytest.raises(pre.GenericUmbralError):
         sym_key = pre.decapsulate_reencrypted(pub_key_bob.point_key,
@@ -119,7 +119,7 @@ def test_cheating_ursula_sends_garbage(N, M):
     c_frags[0].point_eph_e1 = Point.gen_rand()
     c_frags[0].point_eph_v1 = Point.gen_rand()
 
-    capsule_alice._reconstruct_shamirs_secret()    # activate capsule
+    capsule_alice._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    # activate capsule
 
     with pytest.raises(pre.GenericUmbralError):
         sym_key2 = pre.decapsulate_reencrypted(pub_key_bob.point_key,
@@ -155,7 +155,7 @@ def test_m_of_n(N, M, alices_keys, bobs_keys):
     # assert capsule.is_openable_by_bob()  # TODO: Is it possible to check here if >= m cFrags have been attached?
     # capsule.open(pub_bob, priv_bob, pub_alice)
 
-    capsule._reconstruct_shamirs_secret()
+    capsule._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)
     sym_key_from_capsule = pre.decapsulate_reencrypted(pub_key_bob.point_key,
                                                        priv_key_bob.bn_key,
                                                        pub_key_alice.point_key,

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -75,7 +75,6 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
                                               priv_key_bob.bn_key,
                                               pub_key_alice.point_key,
                                               capsule_alice1)
-        assert not sym_key == sym_key_alice1
 
     metadata = b"Challenge metadata: index 0"
 
@@ -142,8 +141,7 @@ def test_cheating_ursula_sends_garbage(N, M):
                                                priv_key_bob.bn_key,
                                                pub_key_alice.point_key,
                                                capsule_alice)
-        assert sym_key2 != sym_key
-        
+
     metadata = b"Challenge metadata: index 0"
     assert not pre.check_challenge(capsule_alice, 
                                    c_frags[0], 

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -77,28 +77,28 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
                                               capsule_alice1)
         assert not sym_key == sym_key_alice1
 
-        metadata = b"Challenge metadata: index 0"
+    metadata = b"Challenge metadata: index 0"
 
-        assert not pre.check_challenge(capsule_alice1,
-                                       c_frags[0],
-                                       challenges[0],
-                                       pub_key_alice.point_key,
-                                       pub_key_bob.point_key,
-                                       metadata
-                                       )
+    assert not pre.check_challenge(capsule_alice1,
+                                   c_frags[0],
+                                   challenges[0],
+                                   pub_key_alice.point_key,
+                                   pub_key_bob.point_key,
+                                   metadata
+                                   )
 
-        # The response of cheating Ursula is in capsules[0],
-        # so the rest of challenges chould be correct:
-        for i, challenge in enumerate(challenges, 1):
-            c_frag = c_frags[i]
-            metadata = ("Challenge metadata: index {}".format(i)).encode()
-            assert pre.check_challenge(capsule_alice1,
-                                       c_frag,
-                                       ch,
-                                       pub_key_alice.point_key,
-                                       pub_key_bob.point_key,
-                                       metadata
-                                       )
+    # The response of cheating Ursula is in capsules[0],
+    # so the rest of challenges chould be correct:
+    for i, challenge in enumerate(challenges[1:], 1):
+        c_frag = c_frags[i]
+        metadata = ("Challenge metadata: index {}".format(i)).encode()
+        assert pre.check_challenge(capsule_alice1,
+                                   c_frag,
+                                   challenge,
+                                   pub_key_alice.point_key,
+                                   pub_key_bob.point_key,
+                                   metadata
+                                   )
 
 
 @pytest.mark.parametrize("N, M", parameters)
@@ -143,27 +143,28 @@ def test_cheating_ursula_sends_garbage(N, M):
                                                pub_key_alice.point_key,
                                                capsule_alice)
         assert sym_key2 != sym_key
-        metadata = b"Challenge metadata: index 0"
-        assert not pre.check_challenge(capsule_alice, 
-                                       c_frags[0], 
-                                       challenges[0], 
-                                       pub_key_alice.point_key, 
-                                       pub_key_bob.point_key,
-                                       metadata
-                                       )
+        
+    metadata = b"Challenge metadata: index 0"
+    assert not pre.check_challenge(capsule_alice, 
+                                   c_frags[0], 
+                                   challenges[0], 
+                                   pub_key_alice.point_key, 
+                                   pub_key_bob.point_key,
+                                   metadata
+                                   )
 
-        # The response of cheating Ursula is in capsules[0],
-        # so the rest of challenges chould be correct:
-        for i, challenge in enumerate(challenges, 1):
-            c_frag = c_frags[i]
-            metadata = ("Challenge metadata: index {}".format(i)).encode()
-            assert pre.check_challenge(capsule_alice, 
-                                       c_frag, 
-                                       ch, 
-                                       pub_key_alice.point_key, 
-                                       pub_key_bob.point_key,
-                                       metadata
-                                       )
+    # The response of cheating Ursula is in capsules[0],
+    # so the rest of challenges chould be correct:
+    for i, challenge in enumerate(challenges[1:], 1):
+        c_frag = c_frags[i]
+        metadata = ("Challenge metadata: index {}".format(i)).encode()
+        assert pre.check_challenge(capsule_alice, 
+                                   c_frag, 
+                                   challenge, 
+                                   pub_key_alice.point_key, 
+                                   pub_key_bob.point_key,
+                                   metadata
+                                   )
 
 
 @pytest.mark.parametrize("N, M", parameters)

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -20,7 +20,7 @@ def test_challenge_response_serialization():
     capsule.attach_cfrag(cfrag)
 
     metadata = b"Challenge metadata"
-    ch_resp = pre.challenge(kfrags[0], capsule, cfrag, metadata)
+    ch_resp = pre._challenge(kfrags[0], capsule, cfrag, metadata)
 
     ch_resp_bytes = ch_resp.to_bytes()
 
@@ -61,7 +61,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
 
         metadata = ("Challenge metadata: index {}".format(index)).encode()
 
-        challenge = pre.challenge(kfrag, capsule_alice1, cfrag, metadata)
+        challenge = pre._challenge(kfrag, capsule_alice1, cfrag, metadata)
         capsule_alice1.attach_cfrag(cfrag)
 
         challenges.append(challenge)
@@ -78,7 +78,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
 
     metadata = b"Challenge metadata: index 0"
 
-    assert not pre.check_challenge(capsule_alice1,
+    assert not pre._check_challenge(capsule_alice1,
                                    cfrags[0],
                                    challenges[0],
                                    pub_key_alice.point_key,
@@ -91,7 +91,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
     for i, challenge in enumerate(challenges[1:], 1):
         cfrag = cfrags[i]
         metadata = ("Challenge metadata: index {}".format(i)).encode()
-        assert pre.check_challenge(capsule_alice1,
+        assert pre._check_challenge(capsule_alice1,
                                    cfrag,
                                    challenge,
                                    pub_key_alice.point_key,
@@ -116,10 +116,10 @@ def test_cheating_ursula_sends_garbage(N, M):
     for i, kfrag in enumerate(kfrags[:M]):
         cfrag = pre.reencrypt(kfrag, capsule_alice)
         metadata = ("Challenge metadata: index {}".format(i)).encode()
-        challenge = pre.challenge(kfrag, capsule_alice, cfrag, metadata)
+        challenge = pre._challenge(kfrag, capsule_alice, cfrag, metadata)
         capsule_alice.attach_cfrag(cfrag)
 
-        assert pre.check_challenge(capsule_alice,
+        assert pre._check_challenge(capsule_alice,
                                    cfrag,
                                    challenge,
                                    pub_key_alice.point_key,
@@ -143,7 +143,7 @@ def test_cheating_ursula_sends_garbage(N, M):
                                                capsule_alice)
 
     metadata = b"Challenge metadata: index 0"
-    assert not pre.check_challenge(capsule_alice, 
+    assert not pre._check_challenge(capsule_alice, 
                                    cfrags[0], 
                                    challenges[0], 
                                    pub_key_alice.point_key, 
@@ -156,7 +156,7 @@ def test_cheating_ursula_sends_garbage(N, M):
     for i, challenge in enumerate(challenges[1:], 1):
         cfrag = cfrags[i]
         metadata = ("Challenge metadata: index {}".format(i)).encode()
-        assert pre.check_challenge(capsule_alice, 
+        assert pre._check_challenge(capsule_alice, 
                                    cfrag, 
                                    challenge, 
                                    pub_key_alice.point_key, 
@@ -180,9 +180,9 @@ def test_m_of_n(N, M, alices_keys, bobs_keys):
         cfrag = pre.reencrypt(kfrag, capsule)
         capsule.attach_cfrag(cfrag)
         metadata = ("Challenge metadata: index {}".format(i)).encode()
-        ch = pre.challenge(kfrag, capsule, cfrag, metadata)
+        ch = pre._challenge(kfrag, capsule, cfrag, metadata)
 
-        assert pre.check_challenge(capsule, 
+        assert pre._check_challenge(capsule, 
                                    cfrag, 
                                    ch, 
                                    pub_key_alice.point_key, 

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -71,7 +71,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
     capsule_alice1._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    
 
     with pytest.raises(pre.GenericUmbralError):
-        sym_key = pre.decapsulate_reencrypted(pub_key_bob.point_key,
+        sym_key = pre._decapsulate_reencrypted(pub_key_bob.point_key,
                                               priv_key_bob.bn_key,
                                               pub_key_alice.point_key,
                                               capsule_alice1)
@@ -137,7 +137,7 @@ def test_cheating_ursula_sends_garbage(N, M):
     capsule_alice._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    # activate capsule
 
     with pytest.raises(pre.GenericUmbralError):
-        sym_key2 = pre.decapsulate_reencrypted(pub_key_bob.point_key,
+        sym_key2 = pre._decapsulate_reencrypted(pub_key_bob.point_key,
                                                priv_key_bob.bn_key,
                                                pub_key_alice.point_key,
                                                capsule_alice)
@@ -194,7 +194,7 @@ def test_m_of_n(N, M, alices_keys, bobs_keys):
     # capsule.open(pub_bob, priv_bob, pub_alice)
 
     capsule._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)
-    sym_key_from_capsule = pre.decapsulate_reencrypted(pub_key_bob.point_key,
+    sym_key_from_capsule = pre._decapsulate_reencrypted(pub_key_bob.point_key,
                                                        priv_key_bob.bn_key,
                                                        pub_key_alice.point_key,
                                                        capsule)

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -49,23 +49,23 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
     sym_key_alice1, capsule_alice1 = pre._encapsulate(pub_key_alice.point_key)
     sym_key_alice2, capsule_alice2 = pre._encapsulate(pub_key_alice.point_key)
 
-    k_frags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
+    kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
 
-    c_frags, challenges = [], []
-    for index, k_frag in enumerate(k_frags):
+    cfrags, challenges = [], []
+    for index, kfrag in enumerate(kfrags):
         if index == 0:
             # Let's put the re-encryption of a different Alice ciphertext
-            c_frag = pre.reencrypt(k_frag, capsule_alice2)
+            cfrag = pre.reencrypt(kfrag, capsule_alice2)
         else:
-            c_frag = pre.reencrypt(k_frag, capsule_alice1)
+            cfrag = pre.reencrypt(kfrag, capsule_alice1)
 
         metadata = ("Challenge metadata: index {}".format(index)).encode()
 
-        challenge = pre.challenge(k_frag, capsule_alice1, c_frag, metadata)
-        capsule_alice1.attach_cfrag(c_frag)
+        challenge = pre.challenge(kfrag, capsule_alice1, cfrag, metadata)
+        capsule_alice1.attach_cfrag(cfrag)
 
         challenges.append(challenge)
-        c_frags.append(c_frag)
+        cfrags.append(cfrag)
 
     # Let's activate the capsule
     capsule_alice1._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    
@@ -79,7 +79,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
     metadata = b"Challenge metadata: index 0"
 
     assert not pre.check_challenge(capsule_alice1,
-                                   c_frags[0],
+                                   cfrags[0],
                                    challenges[0],
                                    pub_key_alice.point_key,
                                    pub_key_bob.point_key,
@@ -89,10 +89,10 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
     # The response of cheating Ursula is in capsules[0],
     # so the rest of challenges chould be correct:
     for i, challenge in enumerate(challenges[1:], 1):
-        c_frag = c_frags[i]
+        cfrag = cfrags[i]
         metadata = ("Challenge metadata: index {}".format(i)).encode()
         assert pre.check_challenge(capsule_alice1,
-                                   c_frag,
+                                   cfrag,
                                    challenge,
                                    pub_key_alice.point_key,
                                    pub_key_bob.point_key,
@@ -110,29 +110,29 @@ def test_cheating_ursula_sends_garbage(N, M):
     pub_key_bob = priv_key_bob.get_pubkey()
 
     sym_key, capsule_alice = pre._encapsulate(pub_key_alice.point_key)
-    k_frags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
+    kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
 
-    c_frags, challenges = [], []
-    for i, k_frag in enumerate(k_frags[:M]):
-        c_frag = pre.reencrypt(k_frag, capsule_alice)
+    cfrags, challenges = [], []
+    for i, kfrag in enumerate(kfrags[:M]):
+        cfrag = pre.reencrypt(kfrag, capsule_alice)
         metadata = ("Challenge metadata: index {}".format(i)).encode()
-        challenge = pre.challenge(k_frag, capsule_alice, c_frag, metadata)
-        capsule_alice.attach_cfrag(c_frag)
+        challenge = pre.challenge(kfrag, capsule_alice, cfrag, metadata)
+        capsule_alice.attach_cfrag(cfrag)
 
         assert pre.check_challenge(capsule_alice,
-                                   c_frag,
+                                   cfrag,
                                    challenge,
                                    pub_key_alice.point_key,
                                    pub_key_bob.point_key,
                                    metadata
                                    )
 
-        c_frags.append(c_frag)
+        cfrags.append(cfrag)
         challenges.append(challenge)
 
-    # Let's put random garbage in one of the c_frags
-    c_frags[0].point_eph_e1 = Point.gen_rand()
-    c_frags[0].point_eph_v1 = Point.gen_rand()
+    # Let's put random garbage in one of the cfrags
+    cfrags[0].point_eph_e1 = Point.gen_rand()
+    cfrags[0].point_eph_v1 = Point.gen_rand()
 
     capsule_alice._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    # activate capsule
 
@@ -144,7 +144,7 @@ def test_cheating_ursula_sends_garbage(N, M):
 
     metadata = b"Challenge metadata: index 0"
     assert not pre.check_challenge(capsule_alice, 
-                                   c_frags[0], 
+                                   cfrags[0], 
                                    challenges[0], 
                                    pub_key_alice.point_key, 
                                    pub_key_bob.point_key,
@@ -154,10 +154,10 @@ def test_cheating_ursula_sends_garbage(N, M):
     # The response of cheating Ursula is in capsules[0],
     # so the rest of challenges chould be correct:
     for i, challenge in enumerate(challenges[1:], 1):
-        c_frag = c_frags[i]
+        cfrag = cfrags[i]
         metadata = ("Challenge metadata: index {}".format(i)).encode()
         assert pre.check_challenge(capsule_alice, 
-                                   c_frag, 
+                                   cfrag, 
                                    challenge, 
                                    pub_key_alice.point_key, 
                                    pub_key_bob.point_key,

--- a/tests/test_keys/test_umbral_keys.py
+++ b/tests/test_keys/test_umbral_keys.py
@@ -1,5 +1,5 @@
 from umbral import pre, keys
-
+from umbral.config import default_params
 
 def test_gen_key():
     # Pass in the parameters to test that manual param selection works
@@ -10,8 +10,8 @@ def test_gen_key():
     assert type(umbral_pub_key) == keys.UmbralPublicKey
 
 
-def test_private_key_serialization():
-    priv_key = pre.gen_priv()
+def test_private_key_serialization(random_ec_bignum1):
+    priv_key = random_ec_bignum1
     umbral_key = keys.UmbralPrivateKey(priv_key)
 
     encoded_key = umbral_key.to_bytes()
@@ -20,8 +20,8 @@ def test_private_key_serialization():
     assert priv_key == decoded_key.bn_key
 
 
-def test_private_key_serialization_with_encryption():
-    priv_key = pre.gen_priv()
+def test_private_key_serialization_with_encryption(random_ec_bignum1):
+    priv_key = random_ec_bignum1
     umbral_key = keys.UmbralPrivateKey(priv_key)
 
     encoded_key = umbral_key.to_bytes(password=b'test')
@@ -30,9 +30,11 @@ def test_private_key_serialization_with_encryption():
     assert priv_key == decoded_key.bn_key
 
 
-def test_public_key_serialization():
-    priv_key = pre.gen_priv()
-    pub_key = pre.priv2pub(priv_key)
+def test_public_key_serialization(random_ec_bignum1):
+    priv_key = random_ec_bignum1
+
+    params = default_params()
+    pub_key = priv_key * params.g
 
     umbral_key = keys.UmbralPublicKey(pub_key)
 
@@ -42,9 +44,11 @@ def test_public_key_serialization():
     assert pub_key == decoded_key.point_key
 
 
-def test_public_key_to_bytes():
-    priv_key = pre.gen_priv()
-    pub_key = pre.priv2pub(priv_key)
+def test_public_key_to_bytes(random_ec_bignum1):
+    priv_key = random_ec_bignum1
+    
+    params = default_params()
+    pub_key = priv_key * params.g
 
     umbral_key = keys.UmbralPublicKey(pub_key)
     key_bytes = bytes(umbral_key)

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -28,7 +28,7 @@ def test_simple_api(N, M, curve=default_curve()):
     plain_data = b'peace at dawn'
     ciphertext, capsule = pre.encrypt(pub_key_alice, plain_data)
 
-    cleartext = pre.decrypt(capsule, priv_key_alice, ciphertext)
+    cleartext = pre.decrypt(ciphertext, capsule, priv_key_alice)
     assert cleartext == plain_data
 
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N, params=params)
@@ -36,7 +36,7 @@ def test_simple_api(N, M, curve=default_curve()):
         cfrag = pre.reencrypt(kfrag, capsule, params=params)
         capsule.attach_cfrag(cfrag)
 
-    reenc_cleartext = pre.decrypt(capsule, priv_key_bob, ciphertext, pub_key_alice)
+    reenc_cleartext = pre.decrypt(ciphertext, capsule, priv_key_bob, pub_key_alice)
     assert reenc_cleartext == plain_data
 
 
@@ -51,5 +51,5 @@ def test_public_key_encryption(alices_keys):
     priv_key_alice, pub_key_alice = alices_keys
     plain_data = b'peace at dawn'
     ciphertext, capsule = pre.encrypt(pub_key_alice, plain_data)
-    cleartext = pre.decrypt(capsule, priv_key_alice, ciphertext)
+    cleartext = pre.decrypt(ciphertext, capsule, priv_key_alice)
     assert cleartext == plain_data

--- a/umbral/bignum.py
+++ b/umbral/bignum.py
@@ -257,20 +257,20 @@ class BigNum(object):
 
 
 def hash_to_bn(crypto_items, params):
-    sha_512 = hashes.Hash(hashes.SHA512(), backend=backend)
+    blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
     for item in crypto_items:
         try:
             data_bytes = item.to_bytes()
         except AttributeError:
             data_bytes = item
-        sha_512.update(data_bytes)
+        blake2b.update(data_bytes)
 
     i = 0
     h = 0
-    while h < params.CURVE_MINVAL_SHA512:
-        sha_512_i = sha_512.copy()
-        sha_512_i.update(i.to_bytes(params.CURVE_KEY_SIZE_BYTES, 'big'))
-        hash_digest = sha_512_i.finalize()
+    while h < params.CURVE_MINVAL_HASH_512:
+        blake2b_i = blake2b.copy()
+        blake2b_i.update(i.to_bytes(params.CURVE_KEY_SIZE_BYTES, 'big'))
+        hash_digest = blake2b_i.finalize()
         h = int.from_bytes(hash_digest, byteorder='big', signed=False)
         i += 1
     hash_bn = h % int(params.order)

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -61,7 +61,7 @@ class KFrag(object):
         x = self.point_eph_ni
         key = self.bn_key
 
-        # We check that the commitment u1 is in fact 
+        # We check that the commitment u1 is well-formed
         check_kfrag_1 = u1 == key * u
 
         # We check the Schnorr signature over the kfrag components

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -13,7 +13,7 @@ class UmbralParameters(object):
 
         g_bytes = self.g.to_bytes(is_compressed=True)
 
-        self.CURVE_MINVAL_SHA512 = (1 << 512) % int(self.order)
+        self.CURVE_MINVAL_HASH_512 = (1 << 512) % int(self.order)
         self.CURVE_KEY_SIZE_BYTES = get_curve_keysize_bytes(self.curve)
 
         parameters_seed = b'NuCypherKMS/UmbralParameters/'

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -294,7 +294,7 @@ def unsafe_hash_to_point(data, params, label=None):
     It uses SHA256 as the internal hash function.
 
     WARNING: Do not use when the input data is secret, as this implementation is not
-    in label time, and hence, it is not safe with respect to timing attacks.
+    in constant time, and hence, it is not safe with respect to timing attacks.
 
     TODO: Check how to uniformly generate ycoords. Currently, it only outputs points
     where ycoord is even (i.e., starting with 0x02 in compressed notation)

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -515,8 +515,8 @@ def _open_capsule(capsule: Capsule, bob_private_key: UmbralPrivateKey,
     return key
 
 
-def decrypt(capsule: Capsule, priv_key: UmbralPrivateKey,
-            ciphertext: bytes, alice_pub_key: UmbralPublicKey=None) -> bytes:
+def decrypt(ciphertext: bytes, capsule: Capsule, 
+        priv_key: UmbralPrivateKey, alice_pub_key: UmbralPublicKey=None) -> bytes:
     """
     Opens the capsule and gets what's inside.
 

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -328,7 +328,7 @@ def reencrypt(k_frag: KFrag, capsule: Capsule,
     return c_frag
 
 
-def challenge(k_frag: KFrag, capsule: Capsule, 
+def _challenge(k_frag: KFrag, capsule: Capsule, 
               c_frag: CapsuleFrag, challenge_metadata: bytes=None,
               params: UmbralParameters=None) -> ChallengeResponse:
     params = params if params is not None else default_params()
@@ -366,7 +366,7 @@ def challenge(k_frag: KFrag, capsule: Capsule,
     return ch_resp
 
 
-def check_challenge(capsule: Capsule, c_frag: CapsuleFrag,
+def _check_challenge(capsule: Capsule, c_frag: CapsuleFrag,
                     challenge_resp: ChallengeResponse, 
                     pub_a: Point, pub_b: Point, challenge_metadata: bytes=None,
                     params: UmbralParameters=None) -> bool:

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -338,7 +338,8 @@ def reencrypt(k_frag: KFrag, capsule: Capsule,
     return c_frag
 
 
-def challenge(k_frag: KFrag, capsule: Capsule, c_frag: CapsuleFrag,
+def challenge(k_frag: KFrag, capsule: Capsule, 
+              c_frag: CapsuleFrag, challenge_metadata: bytes=None,
               params: UmbralParameters=None) -> ChallengeResponse:
     params = params if params is not None else default_params()
 
@@ -356,7 +357,11 @@ def challenge(k_frag: KFrag, capsule: Capsule, c_frag: CapsuleFrag,
     v2 = t * v
     u2 = t * u
 
-    h = hash_to_bn([e, e1, e2, v, v1, v2, u, u1, u2], params)
+    hash_input = [e, e1, e2, v, v1, v2, u, u1, u2]
+    if challenge_metadata is not None:
+        hash_input.append(challenge_metadata)
+    
+    h = hash_to_bn(hash_input, params)
 
     z3 = t + h * k_frag.bn_key
 
@@ -372,8 +377,8 @@ def challenge(k_frag: KFrag, capsule: Capsule, c_frag: CapsuleFrag,
 
 
 def check_challenge(capsule: Capsule, c_frag: CapsuleFrag,
-                    challenge_resp: ChallengeResponse,
-                    pub_a: Point, pub_b: Point,
+                    challenge_resp: ChallengeResponse, 
+                    pub_a: Point, pub_b: Point, challenge_metadata: bytes=None,
                     params: UmbralParameters=None) -> bool:
     params = params if params is not None else default_params()
 
@@ -400,7 +405,11 @@ def check_challenge(capsule: Capsule, c_frag: CapsuleFrag,
 
     g_y = (z2 * g) + (z1 * pub_a)
 
-    h = hash_to_bn([e, e1, e2, v, v1, v2, u, u1, u2], params)
+    hash_input = [e, e1, e2, v, v1, v2, u, u1, u2]
+    if challenge_metadata is not None:
+        hash_input.append(challenge_metadata)
+    
+    h = hash_to_bn(hash_input, params)
 
     check31 = z1 == hash_to_bn([g_y, kfrag_id, pub_a, pub_b, u1, xcomp], params)
     check32 = z3 * e == e2 + (h * e1)

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -542,6 +542,7 @@ def decrypt(capsule: Capsule, priv_key: UmbralPrivateKey,
         original_capsule_bytes = capsule._original_to_bytes()
         cleartext = dem.decrypt(ciphertext, authenticated_data=original_capsule_bytes)
     else:
+        # Since there aren't cfrags attached, we assume this is Alice opening the Capsule.
         key = _decapsulate_original(priv_key.bn_key, capsule)
         dem = UmbralDEM(key)
 

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -133,8 +133,8 @@ class Capsule(object):
             pub_a = pub_a.point_key
 
         g = params.g
-        pub_b = g * priv_b
-        g_ab = pub_a * priv_b
+        pub_b = priv_b * g
+        g_ab = priv_b * pub_a
 
         blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
         blake2b.update(pub_a.to_bytes())
@@ -296,7 +296,7 @@ def split_rekey(priv_a: Union[UmbralPrivateKey, BigNum],
 
     u = params.u
 
-    g_ab = pub_b * priv_a
+    g_ab = priv_a * pub_b
 
     blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
     blake2b.update(pub_a.to_bytes())
@@ -466,7 +466,7 @@ def decapsulate_reencrypted(pub_key: Point, priv_key: BigNum,
     params = params if params is not None else default_params()
 
     xcomp = capsule._point_noninteractive
-    d = hash_to_bn([xcomp, pub_key, xcomp * priv_key], params)
+    d = hash_to_bn([xcomp, pub_key, priv_key * xcomp], params)
 
     e_prime = capsule._point_eph_e_prime
     v_prime = capsule._point_eph_v_prime
@@ -515,7 +515,7 @@ def _open_capsule(capsule: Capsule, bob_private_key: UmbralPrivateKey,
     params = default_params()
 
     priv_b = bob_private_key.bn_key
-    pub_b = params.g * priv_b
+    pub_b = priv_b * params.g
 
     pub_a = alice_pub_key.point_key
 

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -136,11 +136,11 @@ class Capsule(object):
         pub_b = g * priv_b
         g_ab = pub_a * priv_b
 
-        sha_512 = hashes.Hash(hashes.SHA512(), backend=backend)
-        sha_512.update(pub_a.to_bytes())
-        sha_512.update(pub_b.to_bytes())
-        sha_512.update(g_ab.to_bytes())
-        hashed_dh_tuple = sha_512.finalize()
+        blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
+        blake2b.update(pub_a.to_bytes())
+        blake2b.update(pub_b.to_bytes())
+        blake2b.update(g_ab.to_bytes())
+        hashed_dh_tuple = blake2b.finalize()
 
         id_cfrag_pairs = list(self._attached_cfrags.items())
         id_0, cfrag_0 = id_cfrag_pairs[0]
@@ -298,11 +298,11 @@ def split_rekey(priv_a: Union[UmbralPrivateKey, BigNum],
 
     g_ab = pub_b * priv_a
 
-    sha_512 = hashes.Hash(hashes.SHA512(), backend=backend)
-    sha_512.update(pub_a.to_bytes())
-    sha_512.update(pub_b.to_bytes())
-    sha_512.update(g_ab.to_bytes())
-    hashed_dh_tuple = sha_512.finalize()
+    blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
+    blake2b.update(pub_a.to_bytes())
+    blake2b.update(pub_b.to_bytes())
+    blake2b.update(g_ab.to_bytes())
+    hashed_dh_tuple = blake2b.finalize()
 
     kfrags = []
     for _ in range(N):

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -255,16 +255,6 @@ class ChallengeResponse(object):
         return self.to_bytes()
 
 
-def gen_priv(curve: ec.EllipticCurve=None) -> BigNum:
-    curve = curve if curve is not None else default_curve()
-    return BigNum.gen_rand(curve)
-
-
-def priv2pub(priv: BigNum, params: UmbralParameters=None) -> Point:
-    params = params if params is not None else default_params()
-    return priv * params.g
-
-
 def split_rekey(priv_a: Union[UmbralPrivateKey, BigNum],
                 pub_b: Union[UmbralPublicKey, Point],
                 threshold: int, N: int,

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -314,33 +314,33 @@ def split_rekey(priv_a: Union[UmbralPrivateKey, BigNum],
     return kfrags
 
 
-def reencrypt(k_frag: KFrag, capsule: Capsule,
+def reencrypt(kfrag: KFrag, capsule: Capsule,
               params: UmbralParameters=None) -> CapsuleFrag:
     params = params if params is not None else default_params()
 
     if not capsule.verify(params):
         raise capsule.NotValid
 
-    e1 = k_frag.bn_key * capsule._point_eph_e
-    v1 = k_frag.bn_key * capsule._point_eph_v
+    e1 = kfrag.bn_key * capsule._point_eph_e
+    v1 = kfrag.bn_key * capsule._point_eph_v
 
-    c_frag = CapsuleFrag(e1=e1, v1=v1, id_=k_frag.bn_id, x=k_frag.point_eph_ni)
-    return c_frag
+    cfrag = CapsuleFrag(e1=e1, v1=v1, id_=kfrag.bn_id, x=kfrag.point_eph_ni)
+    return cfrag
 
 
-def _challenge(k_frag: KFrag, capsule: Capsule, 
-              c_frag: CapsuleFrag, challenge_metadata: bytes=None,
+def _challenge(kfrag: KFrag, capsule: Capsule, 
+              cfrag: CapsuleFrag, challenge_metadata: bytes=None,
               params: UmbralParameters=None) -> ChallengeResponse:
     params = params if params is not None else default_params()
 
-    e1 = c_frag.point_eph_e1
-    v1 = c_frag.point_eph_v1
+    e1 = cfrag.point_eph_e1
+    v1 = cfrag.point_eph_v1
 
     e = capsule._point_eph_e
     v = capsule._point_eph_v
 
     u = params.u
-    u1 = k_frag.point_commitment
+    u1 = kfrag.point_commitment
 
     t = BigNum.gen_rand(params.curve)
     e2 = t * e
@@ -353,10 +353,10 @@ def _challenge(k_frag: KFrag, capsule: Capsule,
     
     h = hash_to_bn(hash_input, params)
 
-    z3 = t + h * k_frag.bn_key
+    z3 = t + h * kfrag.bn_key
 
     ch_resp = ChallengeResponse(e2=e2, v2=v2, u1=u1, u2=u2,
-                                z1=k_frag.bn_sig1, z2=k_frag.bn_sig2, z3=z3)
+                                z1=kfrag.bn_sig1, z2=kfrag.bn_sig2, z3=z3)
 
     # Check correctness of original ciphertext (check nº 2) at the end
     # to avoid timing oracles
@@ -366,7 +366,7 @@ def _challenge(k_frag: KFrag, capsule: Capsule,
     return ch_resp
 
 
-def _check_challenge(capsule: Capsule, c_frag: CapsuleFrag,
+def _check_challenge(capsule: Capsule, cfrag: CapsuleFrag,
                     challenge_resp: ChallengeResponse, 
                     pub_a: Point, pub_b: Point, challenge_metadata: bytes=None,
                     params: UmbralParameters=None) -> bool:
@@ -375,10 +375,10 @@ def _check_challenge(capsule: Capsule, c_frag: CapsuleFrag,
     e = capsule._point_eph_e
     v = capsule._point_eph_v
 
-    e1 = c_frag.point_eph_e1
-    v1 = c_frag.point_eph_v1
-    xcomp = c_frag.point_eph_ni
-    kfrag_id = c_frag.bn_kfrag_id
+    e1 = cfrag.point_eph_e1
+    v1 = cfrag.point_eph_v1
+    xcomp = cfrag.point_eph_ni
+    kfrag_id = cfrag.bn_kfrag_id
 
     e2 = challenge_resp.point_eph_e2
     v2 = challenge_resp.point_eph_v2

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -449,7 +449,7 @@ def _decapsulate_original(priv_key: BigNum, capsule: Capsule, key_length=32,
     return key
 
 
-def decapsulate_reencrypted(pub_key: Point, priv_key: BigNum,
+def _decapsulate_reencrypted(pub_key: Point, priv_key: BigNum,
                             orig_pub_key: Point, capsule: Capsule,
                             key_length=32, params: UmbralParameters=None) -> bytes:
     """Derive the same symmetric key"""
@@ -511,7 +511,7 @@ def _open_capsule(capsule: Capsule, bob_private_key: UmbralPrivateKey,
 
     capsule._reconstruct_shamirs_secret(pub_a, priv_b)
 
-    key = decapsulate_reencrypted(pub_b, priv_b, pub_a, capsule)
+    key = _decapsulate_reencrypted(pub_b, priv_b, pub_a, capsule)
     return key
 
 

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -32,7 +32,7 @@ def kdf(ecpoint, key_length):
     data = ecpoint.to_bytes(is_compressed=True)
 
     return HKDF(
-        algorithm=hashes.SHA512(),
+        algorithm=hashes.BLAKE2b(64),
         length=key_length,
         salt=None,
         info=None,


### PR DESCRIPTION
# What this does:

- KFrag ids can only be computed by Bob now
- Added metadata as optional input to the challenge protocol
- Changed SHA512 by BLAKE2b (Resolves #60)
- Dropped pre.gen_priv() and pre.priv2pub() (Resolves #90)
- Fixed some undesired behaviors in tests (Resolves #87)
- Fixed notation, variable names, method visibility, etc
- Some fixes to the README