### PR TITLE
Use params injection on necessary functions

### DIFF
--- a/tests/test_capsule/test_capsule_operations.py
+++ b/tests/test_capsule/test_capsule_operations.py
@@ -85,7 +85,7 @@ def test_capsule_as_dict_key(alices_keys):
     capsule.attach_cfrag(cfrag)
 
     # Even if we activate the capsule, it still serves as the same key.
-    cleartext = pre.decrypt(ciphertext, capsule, alices_keys.priv, alices_keys.pub)
+    cleartext = pre.decrypt(capsule, alices_keys.priv, ciphertext, alices_keys.pub)
     assert some_dict[capsule] == "Thing that Bob wants to try per-Capsule"
     assert cleartext == plain_data
 

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -26,9 +26,9 @@ def test_simple_api(N, M, curve=default_curve()):
     pub_key_bob = priv_key_bob.get_pubkey()
 
     plain_data = b'peace at dawn'
-    ciphertext, capsule = pre.encrypt(pub_key_alice, plain_data)
+    ciphertext, capsule = pre.encrypt(pub_key_alice, plain_data, params=params)
 
-    cleartext = pre.decrypt(ciphertext, capsule, priv_key_alice)
+    cleartext = pre.decrypt(capsule, priv_key_alice, ciphertext, pub_key_alice, params=params)
     assert cleartext == plain_data
 
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N, params=params)
@@ -36,11 +36,10 @@ def test_simple_api(N, M, curve=default_curve()):
         cfrag = pre.reencrypt(kfrag, capsule, params=params)
         capsule.attach_cfrag(cfrag)
 
-    reenc_cleartext = pre.decrypt(ciphertext, capsule, priv_key_bob, pub_key_alice)
+    reenc_cleartext = pre.decrypt(capsule, priv_key_bob, ciphertext, pub_key_alice, params=params)
     assert reenc_cleartext == plain_data
 
 
-@pytest.mark.xfail(raises=InvalidTag)    # remove this mark to fail instead of ignore
 @pytest.mark.parametrize("curve", secp_curves)
 @pytest.mark.parametrize("N, M", parameters)
 def test_simple_api_on_multiple_curves(N, M, curve):
@@ -51,5 +50,5 @@ def test_public_key_encryption(alices_keys):
     priv_key_alice, pub_key_alice = alices_keys
     plain_data = b'peace at dawn'
     ciphertext, capsule = pre.encrypt(pub_key_alice, plain_data)
-    cleartext = pre.decrypt(ciphertext, capsule, priv_key_alice)
+    cleartext = pre.decrypt(capsule, priv_key_alice, ciphertext)
     assert cleartext == plain_data


### PR DESCRIPTION
### What this does:
1. Adds `params` arg to a few calls, primarily `encrypt`, `decrypt`, `_open_capsule`, `_encapsulate`, `_decapsulate_original`, `_decapsulate_reencrypted`, and `_reconstruct_shamirs_secret`. (resolves #99)
2. Updates API for tests for use on multiple curves. (resolves #54)