### PR TITLE
use abstract class to gain type safety

### DIFF
--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -1,10 +1,7 @@
 import os
 import base64
 
-from typing import Union
-
 from nacl.secret import SecretBox
-from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.backends.openssl.ec import (
@@ -14,9 +11,10 @@ from cryptography.hazmat.backends.openssl.ec import (
 from umbral.config import default_params
 from umbral.point import Point, BigNum
 from umbral.params import UmbralParameters
+from umbral.utils import AbstractCryptoEntity
 
 
-class UmbralPrivateKey(object):
+class UmbralPrivateKey(AbstractCryptoEntity):
     def __init__(self, bn_key: BigNum, params: UmbralParameters=None):
         """
         Initializes an Umbral private key.

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -5,10 +5,10 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.exceptions import InternalError
 
 from umbral.config import default_curve
-from umbral.utils import get_curve_keysize_bytes
+from umbral.utils import get_curve_keysize_bytes, AbstractCryptoEntity
+from umbral.utils import AbstractCryptoEntity
 
-
-class Point(object):
+class Point(AbstractCryptoEntity):
     """
     Represents an OpenSSL EC_POINT except more Pythonic
     """

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -13,10 +13,9 @@ from umbral.fragments import KFrag, CapsuleFrag
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
 from umbral.params import UmbralParameters
 from umbral.point import Point
-from umbral.utils import poly_eval, lambda_coeff, kdf, get_curve_keysize_bytes
+from umbral.utils import poly_eval, lambda_coeff, kdf, get_curve_keysize_bytes, AbstractCryptoEntity
 
 from io import BytesIO
-
 
 CHACHA20_KEY_SIZE = 32
 
@@ -25,7 +24,7 @@ class GenericUmbralError(Exception):
     pass
 
 
-class Capsule(object):
+class Capsule(AbstractCryptoEntity):
 
     def __init__(self,
                  point_eph_e=None,
@@ -166,9 +165,6 @@ class Capsule(object):
         self._point_eph_v_prime = v
         self._point_noninteractive = cfrag_0.point_eph_ni
 
-    def __bytes__(self):
-        return self.to_bytes()
-
     def __eq__(self, other):
         """
         If both Capsules are activated, we compare only the activated components.
@@ -199,7 +195,7 @@ class Capsule(object):
         return hash(component_bytes)
 
 
-class ChallengeResponse(object):
+class ChallengeResponse(AbstractCryptoEntity):
     def __init__(self, e2, v2, u1, u2, z1, z2, z3):
         self.point_eph_e2 = e2
         self.point_eph_v2 = v2
@@ -251,9 +247,6 @@ class ChallengeResponse(object):
             + sig
 
         return result
-
-    def __bytes__(self):
-        return self.to_bytes()
 
 
 def split_rekey(priv_a: Union[UmbralPrivateKey, BigNum],

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -1,7 +1,9 @@
 import math
+from abc import ABC, abstractmethod
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 
@@ -42,3 +44,23 @@ def kdf(ecpoint, key_length):
 
 def get_curve_keysize_bytes(curve):
     return int(math.ceil(curve.key_size / 8.00))
+
+
+class AbstractCryptoEntity(ABC):
+    @classmethod
+    @abstractmethod
+    def from_bytes(cls, *args, **kwargs):
+        """
+        Instantiate a split-key fragment object from the serialised data.
+        """
+        raise NotImplementedError("Derived classes should implement this method")
+
+    @abstractmethod
+    def to_bytes(self):
+        """
+        Serialize a split-key into a bytestring.
+        """
+        raise NotImplementedError("Derived classes should implement this method")
+
+    def __bytes__(self):
+        return self.to_bytes()


### PR DESCRIPTION
Hi,

I looked through the code and I thought that there was a repeated pattern.

You could use an abstract class that defines the methods `from_bytes`, `to_bytes` and `__bytes__`, and make `from_bytes` and `to_bytes` abstract methods. This means that any derived class (of the abstract class) needs to implement the abstract methods and if not, you get immediately a runtime error. This is useful as a way to ensure that your refactoring doesn't delete those methods by mistake

In this code, the abstract class contains a method `__bytes__` that is not always used in all the classes but, as far as I can see, it should present no problems. 

I could not run the code to test it but I hope that the main idea is understood.

P.S. I have removed imports that PyCharm claims to not be used.