### PR TITLE
Add encoder/decoder params to to_bytes and from_bytes for Umbral keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,3 +98,8 @@ Support & Contribute
 
 - Issue Tracker: https://github.com/nucypher/pyUmbral/issues
 - Source Code: https://github.com/nucypher/pyUmbral
+
+OFAC Sanctions Disclaimer
+=========================
+
+By using this software, you hereby affirm you are not an individual or entity subject to economic sanctions administered by the U.S. Government or any other applicable authority, including but not limited to, sanctioned party lists administered by the U.S. Treasury Department’s Office of Foreign Assets Control (OFAC), the U.S. State Department, and the U.S. Commerce Department.  You further affirm you are not located in, or ordinarily resident in, any country, territory or region subject to comprehensive economic sanctions administered by OFAC, which are subject to change but currently include Cuba, Iran, North Korea, Syria and the Crimea region.

--- a/tests/test_keys/test_umbral_keys.py
+++ b/tests/test_keys/test_umbral_keys.py
@@ -1,5 +1,8 @@
+import base64
+
 from umbral import pre, keys
 from umbral.config import default_params
+
 
 def test_gen_key():
     # Pass in the parameters to test that manual param selection works
@@ -54,6 +57,17 @@ def test_public_key_to_bytes(random_ec_bignum1):
     key_bytes = bytes(umbral_key)
 
     assert type(key_bytes) == bytes
+
+
+def test_key_encoder_decoder(random_ec_bignum1):
+    priv_key = random_ec_bignum1
+    umbral_key = keys.UmbralPrivateKey(priv_key)
+
+    encoded_key = umbral_key.to_bytes(encoder=base64.urlsafe_b64encode)
+
+    decoded_key = keys.UmbralPrivateKey.from_bytes(encoded_key,
+                                                   decoder=base64.urlsafe_b64decode)
+    assert decoded_key.to_bytes() == umbral_key.to_bytes()
 
 
 def test_umbral_key_to_cryptography_keys():

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -1,7 +1,7 @@
 import os
 import base64
 
-from typing import Union, Callable
+from typing import Callable
 
 from nacl.secret import SecretBox
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -43,7 +43,9 @@ class UmbralPrivateKey(object):
                    password: bytes=None, _scrypt_cost: int=20,
                    decoder: Callable=None):
         """
-        Loads an Umbral private key from a urlsafe base64 encoded string.
+        Loads an Umbral private key from bytes.
+        Optionally, allows a decoder function to be passed as a param to decode
+        the data provided before converting to an Umbral key.
         Optionally, if a password is provided it will decrypt the key using
         nacl's Salsa20-Poly1305 and Scrypt key derivation.
 
@@ -79,10 +81,11 @@ class UmbralPrivateKey(object):
     def to_bytes(self, password: bytes=None, _scrypt_cost: int=20,
                  encoder: Callable=None):
         """
-        Returns an Umbral private key as a urlsafe base64 encoded string with
-        optional symmetric encryption via nacl's Salsa20-Poly1305 and Scrypt
-        key derivation. If a password is provided, the user must encode it to
-        bytes.
+        Returns an Umbral private key as bytes optional symmetric encryption
+        via nacl's Salsa20-Poly1305 and Scrypt key derivation. If a password
+        is provided, the user must encode it to bytes.
+        Optionally, allows an encoder to be passed in as a param to encode the
+        data before returning it.
 
         WARNING: RFC7914 recommends that you use a 2^20 cost value for sensitive
         files. It is NOT recommended to change the `_scrypt_cost` value unless
@@ -177,7 +180,9 @@ class UmbralPublicKey(object):
     def from_bytes(cls, key_bytes: bytes, params: UmbralParameters=None,
                    decoder: Callable=None):
         """
-        Loads an Umbral public key from a urlsafe base64 encoded string or bytes.
+        Loads an Umbral public key from bytes.
+        Optionally, if an decoder function is provided it will be used to decode
+        the data before returning it as an Umbral key.
         """
         if params is None:
             params = default_params()
@@ -190,7 +195,9 @@ class UmbralPublicKey(object):
 
     def to_bytes(self, encoder: Callable=None):
         """
-        Returns an Umbral public key as a urlsafe base64 encoded string.
+        Returns an Umbral public key as bytes.
+        Optionally, if an encoder function is provided it will be used to encode
+        the data before returning it.
         """
         umbral_pubkey = self.point_key.to_bytes()
 


### PR DESCRIPTION
### What this does:
1. Adds `encoder` and `decoder` params to `to_bytes` and `from_bytes` on `UmbralPrivateKey` and `UmbralPublicKey` for more explicit serialization.
2. Adds a test `test_key_encoder_decoder` to `test_umbral_keys`.

This allows for more explicit and flexible serialization when it comes to Umbral keys.