### PR TITLE
Implement arg packing in hash_to_bn

### DIFF
--- a/tests/test_keys/test_umbral_keys.py
+++ b/tests/test_keys/test_umbral_keys.py
@@ -95,3 +95,21 @@ def test_umbral_key_to_cryptography_keys():
     umbral_affine = umbral_pub_key.point_key.to_affine()
     x, y = crypto_pubkey.public_numbers().x, crypto_pubkey.public_numbers().y
     assert umbral_affine == (x, y)
+
+def test_keying_material_serialization():
+    umbral_keying_material = keys.UmbralKeyingMaterial()
+
+    encoded_key = umbral_keying_material.to_bytes()
+
+    decoded_key = keys.UmbralKeyingMaterial.from_bytes(encoded_key)
+    assert umbral_keying_material.keying_material == decoded_key.keying_material
+
+
+def test_keying_material_serialization_with_encryption():
+    
+    umbral_keying_material = keys.UmbralKeyingMaterial()
+
+    encoded_key = umbral_keying_material.to_bytes(password=b'test')
+
+    decoded_key = keys.UmbralKeyingMaterial.from_bytes(encoded_key, password=b'test')
+    assert umbral_keying_material.keying_material == decoded_key.keying_material

--- a/tests/test_keys/test_umbral_keys.py
+++ b/tests/test_keys/test_umbral_keys.py
@@ -9,6 +9,32 @@ def test_gen_key():
     umbral_pub_key = umbral_priv_key.get_pubkey()
     assert type(umbral_pub_key) == keys.UmbralPublicKey
 
+def test_derive_key_from_label():
+    master_secret = b"random master secret"
+    label = b"my_healthcare_information"
+
+    priv_key1 = keys.UmbralPrivateKey.derive_key_from_label(master_secret, label)
+    assert type(priv_key1) == keys.UmbralPrivateKey
+
+    pub_key1 = priv_key1.get_pubkey()
+    assert type(pub_key1) == keys.UmbralPublicKey
+
+
+    priv_key2 = keys.UmbralPrivateKey.derive_key_from_label(master_secret, label)
+    pub_key2 = priv_key2.get_pubkey()
+    assert priv_key1.bn_key == priv_key2.bn_key
+    assert pub_key1 == pub_key2
+
+    # A salt can be used too, but of course it affects the derived key
+    salt = b"optional, randomly generated salt"
+    priv_key3 = keys.UmbralPrivateKey.derive_key_from_label(master_secret, label, salt=salt)
+    assert priv_key3.bn_key != priv_key1.bn_key
+
+    # Different labels on the same master secret create different keys
+    label = b"my_tax_information"
+    priv_key4 = keys.UmbralPrivateKey.derive_key_from_label(master_secret, label)
+    pub_key4 = priv_key4.get_pubkey()
+    assert priv_key1.bn_key != priv_key4.bn_key
 
 def test_private_key_serialization(random_ec_bignum1):
     priv_key = random_ec_bignum1

--- a/tests/test_keys/test_umbral_keys.py
+++ b/tests/test_keys/test_umbral_keys.py
@@ -21,26 +21,26 @@ def test_derive_key_from_label():
 
     label = b"my_healthcare_information"
 
-    priv_key1 = umbral_keying_material.derive_private_key_from_label(label)
+    priv_key1 = umbral_keying_material.derive_privkey_by_label(label)
     assert type(priv_key1) == keys.UmbralPrivateKey
 
     pub_key1 = priv_key1.get_pubkey()
     assert type(pub_key1) == keys.UmbralPublicKey
 
     # Check that key derivation is reproducible
-    priv_key2 = umbral_keying_material.derive_private_key_from_label(label)
+    priv_key2 = umbral_keying_material.derive_privkey_by_label(label)
     pub_key2 = priv_key2.get_pubkey()
     assert priv_key1.bn_key == priv_key2.bn_key
     assert pub_key1 == pub_key2
 
     # A salt can be used too, but of course it affects the derived key
     salt = b"optional, randomly generated salt"
-    priv_key3 = umbral_keying_material.derive_private_key_from_label(label, salt=salt)
+    priv_key3 = umbral_keying_material.derive_privkey_by_label(label, salt=salt)
     assert priv_key3.bn_key != priv_key1.bn_key
 
     # Different labels on the same master secret create different keys
     label = b"my_tax_information"
-    priv_key4 = umbral_keying_material.derive_private_key_from_label(label)
+    priv_key4 = umbral_keying_material.derive_privkey_by_label(label)
     pub_key4 = priv_key4.get_pubkey()
     assert priv_key1.bn_key != priv_key4.bn_key
 

--- a/tests/test_keys/test_umbral_keys.py
+++ b/tests/test_keys/test_umbral_keys.py
@@ -10,29 +10,31 @@ def test_gen_key():
     assert type(umbral_pub_key) == keys.UmbralPublicKey
 
 def test_derive_key_from_label():
-    master_secret = b"random master secret"
+    
+    umbral_keying_material = keys.UmbralKeyingMaterial()
+
     label = b"my_healthcare_information"
 
-    priv_key1 = keys.UmbralPrivateKey.derive_key_from_label(master_secret, label)
+    priv_key1 = umbral_keying_material.derive_private_key_from_label(label)
     assert type(priv_key1) == keys.UmbralPrivateKey
 
     pub_key1 = priv_key1.get_pubkey()
     assert type(pub_key1) == keys.UmbralPublicKey
 
-
-    priv_key2 = keys.UmbralPrivateKey.derive_key_from_label(master_secret, label)
+    # Check that key derivation is reproducible
+    priv_key2 = umbral_keying_material.derive_private_key_from_label(label)
     pub_key2 = priv_key2.get_pubkey()
     assert priv_key1.bn_key == priv_key2.bn_key
     assert pub_key1 == pub_key2
 
     # A salt can be used too, but of course it affects the derived key
     salt = b"optional, randomly generated salt"
-    priv_key3 = keys.UmbralPrivateKey.derive_key_from_label(master_secret, label, salt=salt)
+    priv_key3 = umbral_keying_material.derive_private_key_from_label(label, salt=salt)
     assert priv_key3.bn_key != priv_key1.bn_key
 
     # Different labels on the same master secret create different keys
     label = b"my_tax_information"
-    priv_key4 = keys.UmbralPrivateKey.derive_key_from_label(master_secret, label)
+    priv_key4 = umbral_keying_material.derive_private_key_from_label(label)
     pub_key4 = priv_key4.get_pubkey()
     assert priv_key1.bn_key != priv_key4.bn_key
 

--- a/umbral/bignum.py
+++ b/umbral/bignum.py
@@ -6,6 +6,7 @@ from cryptography.hazmat.primitives import hashes
 
 from umbral.config import default_curve
 from umbral.utils import get_curve_keysize_bytes
+import umbral.point
 
 
 class BigNum(object):
@@ -253,11 +254,16 @@ class BigNum(object):
 
 
 def hash_to_bn(crypto_items, params):
+    if not isinstance(crypto_items, list):
+        crypto_items = [crypto_items]
+
+    valid_instance_types = (BigNum, umbral.point.Point)
+
     blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
     for item in crypto_items:
-        try:
+        if isinstance(item, valid_instance_types):
             data_bytes = item.to_bytes()
-        except AttributeError:
+        else:
             data_bytes = item
         blake2b.update(data_bytes)
 

--- a/umbral/bignum.py
+++ b/umbral/bignum.py
@@ -6,7 +6,6 @@ from cryptography.hazmat.primitives import hashes
 
 from umbral.config import default_curve
 from umbral.utils import get_curve_keysize_bytes
-import umbral.point
 
 
 class BigNum(object):
@@ -252,18 +251,12 @@ class BigNum(object):
     def __hash__(self):
         return hash(int(self))
 
-
 def hash_to_bn(crypto_items, params):
-    if not isinstance(crypto_items, list):
-        crypto_items = [crypto_items]
-
-    valid_instance_types = (BigNum, umbral.point.Point)
-
     blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
     for item in crypto_items:
-        if isinstance(item, valid_instance_types):
+        try:
             data_bytes = item.to_bytes()
-        else:
+        except AttributeError:
             data_bytes = item
         blake2b.update(data_bytes)
 

--- a/umbral/bignum.py
+++ b/umbral/bignum.py
@@ -85,17 +85,16 @@ class BigNum(object):
     def hash_to_bn(cls, *crypto_items, params=None):
         params = params if params is not None else default_params()
 
+        # TODO: Clean this in an upcoming cleanup of pyUmbral
         blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
         for item in crypto_items:
             try:
-                data_bytes = item.to_bytes()
+                item_bytes = item.to_bytes()
             except AttributeError:
-                if isinstance(item, bytes):
-                    data_bytes = item
-                else:
-                    raise TypeError("{} is not bytes, got {} instead.".format(item, type(item)))
-            else:
-                blake2b.update(data_bytes)
+                if not isinstance(item, bytes):
+                    raise TypeError("{} is not acceptable type, received {}".format(item, type(item)))
+                item_bytes = item
+            blake2b.update(item_bytes)
 
         i = 0
         h = 0
@@ -108,7 +107,6 @@ class BigNum(object):
 
         hash_bn = h % int(params.order)
         res = cls.from_int(hash_bn, params.curve)
-
         return res
 
     @classmethod

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -1,6 +1,6 @@
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from umbral.bignum import BigNum, hash_to_bn
+from umbral.bignum import BigNum
 from umbral.config import default_curve, default_params
 from umbral.point import Point
 from umbral.utils import get_curve_keysize_bytes
@@ -66,7 +66,7 @@ class KFrag(object):
 
         # We check the Schnorr signature over the kfrag components
         g_y = (z2 * params.g) + (z1 * pub_a)
-        check_kfrag_2 = z1 == hash_to_bn([g_y, self.bn_id, pub_a, pub_b, u1, x], params)
+        check_kfrag_2 = z1 == BigNum.hash_to_bn(g_y, self.bn_id, pub_a, pub_b, u1, x, params=params)
         
 
         return check_kfrag_1 & check_kfrag_2

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -276,7 +276,7 @@ class UmbralKeyingMaterial():
                 raise ValueError("UmbralKeyingMaterial must have size at least 32 bytes.")
             self.keying_material = keying_material
         else:
-            self.keying_material = os.urandom(32)
+            self.keying_material = os.urandom(64)
 
     def derive_privkey_by_label(self, label: bytes, salt: bytes=None, 
                                 params: UmbralParameters=None):

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -59,7 +59,6 @@ class UmbralPrivateKey(object):
                     backend=default_backend()
                     )
 
-        #import pdb; pdb.set_trace()
         bn_key = hash_to_bn(hkdf.derive(master_secret), params)
         return cls(bn_key, params)
 

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from umbral.config import default_params
 from umbral.point import Point
-from umbral.bignum import BigNum, hash_to_bn
+from umbral.bignum import BigNum
 from umbral.params import UmbralParameters
 
     
@@ -285,17 +285,17 @@ class UmbralKeyingMaterial(object):
         Derives an UmbralPrivateKey using a KDF from this instance of 
         UmbralKeyingMaterial, a label, and an optional salt.
         """
-        if params is None:
-            params = default_params()
+        params = params if params is not None else default_params()
 
-        hkdf = HKDF(algorithm=hashes.BLAKE2b(64),
-                    length=64,
-                    salt=salt,
-                    info=b"NuCypherKMS/KeyDerivation/"+label,
-                    backend=default_backend()
-                    )
+        key_material = HKDF(
+            algorithm=hashes.BLAKE2b(64),
+            length=64,
+            salt=salt,
+            info=b"NuCypherKMS/KeyDerivation/"+label,
+            backend=default_backend()
+        ).derive(self.keying_material)
 
-        bn_key = hash_to_bn([hkdf.derive(self.keying_material)], params)
+        bn_key = BigNum.hash_to_bn(key_material, params=params)
         return UmbralPrivateKey(bn_key, params)
 
     @classmethod

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -264,6 +264,12 @@ class UmbralPublicKey(object):
 
 
 class UmbralKeyingMaterial(AbstractUmbralKeyingMaterial):
+    """
+    This class handles keying material for Umbral, by allowing deterministic
+    derivation of UmbralPrivateKeys based on labels. 
+    Don't use this key material directly as a key.
+    
+    """
 
     def __init__(self, keying_material: bytes=None):
         """

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -57,6 +57,28 @@ class AbstractUmbralKeyingMaterial(ABC):
 
         encoded_key = base64.urlsafe_b64encode(umbral_keying_material)
         return encoded_key
+
+    @classmethod
+    def _key_bytes(cls, key_data: bytes, password: bytes=None, _scrypt_cost: int=20):
+        key_bytes = base64.urlsafe_b64decode(key_data)
+
+        if password:
+            salt = key_bytes[-16:]
+            key_bytes = key_bytes[:-16]
+
+            key = Scrypt(
+                salt=salt,
+                length=SecretBox.KEY_SIZE,
+                n=2**_scrypt_cost,
+                r=8,
+                p=1,
+                backend=default_backend()
+            ).derive(password)
+
+            key_bytes = SecretBox(key).decrypt(key_bytes)
+
+        return key_bytes
+
     
 class UmbralPrivateKey(AbstractUmbralKeyingMaterial):
     def __init__(self, bn_key: BigNum, params: UmbralParameters=None):
@@ -116,59 +138,13 @@ class UmbralPrivateKey(AbstractUmbralKeyingMaterial):
         if params is None:
             params = default_params()
 
-        key_bytes = base64.urlsafe_b64decode(key_data)
-
-        if password:
-            salt = key_bytes[-16:]
-            key_bytes = key_bytes[:-16]
-
-            key = Scrypt(
-                salt=salt,
-                length=SecretBox.KEY_SIZE,
-                n=2**_scrypt_cost,
-                r=8,
-                p=1,
-                backend=default_backend()
-            ).derive(password)
-
-            key_bytes = SecretBox(key).decrypt(key_bytes)
+        key_bytes = cls._key_bytes(key_data, password, _scrypt_cost)
 
         bn_key = BigNum.from_bytes(key_bytes, params.curve)
         return cls(bn_key, params)
 
     def _keying_material(self):
         return self.bn_key.to_bytes()
-
-    # def to_bytes(self, password: bytes=None, _scrypt_cost: int=20):
-    #     """
-    #     Returns an Umbral private key as a urlsafe base64 encoded string with
-    #     optional symmetric encryption via nacl's Salsa20-Poly1305 and Scrypt
-    #     key derivation. If a password is provided, the user must encode it to
-    #     bytes.
-
-    #     WARNING: RFC7914 recommends that you use a 2^20 cost value for sensitive
-    #     files. It is NOT recommended to change the `_scrypt_cost` value unless
-    #     you know what you are doing.
-    #     """
-    #     umbral_priv_key = self.bn_key.to_bytes()
-
-    #     if password:
-    #         salt = os.urandom(16)
-
-    #         key = Scrypt(
-    #             salt=salt,
-    #             length=SecretBox.KEY_SIZE,
-    #             n=2**_scrypt_cost,
-    #             r=8,
-    #             p=1,
-    #             backend=default_backend()
-    #         ).derive(password)
-
-    #         umbral_priv_key = SecretBox(key).encrypt(umbral_priv_key)
-    #         umbral_priv_key += salt
-
-    #     encoded_key = base64.urlsafe_b64encode(umbral_priv_key)
-    #     return encoded_key
 
     def get_pubkey(self):
         """
@@ -306,80 +282,80 @@ class UmbralPublicKey(object):
         return is_eq
 
 
-class UmbralKeyingMaterial(object):
-    def __init__(self, bn_key: BigNum, params: UmbralParameters=None):
-        """
-        Initializes an Umbral private key.
-        """
-        if params is None:
-            params = default_params()
+# class UmbralKeyingMaterial(object):
+#     def __init__(self, bn_key: BigNum, params: UmbralParameters=None):
+#         """
+#         Initializes an Umbral private key.
+#         """
+#         if params is None:
+#             params = default_params()
 
-        self.params = params
-        self.bn_key = bn_key
+#         self.params = params
+#         self.bn_key = bn_key
 
-    @classmethod
-    def gen_key(cls, params: UmbralParameters=None):
-        """
-        Generates a private key and returns it.
-        """
-        if params is None:
-            params = default_params()
+#     @classmethod
+#     def gen_key(cls, params: UmbralParameters=None):
+#         """
+#         Generates a private key and returns it.
+#         """
+#         if params is None:
+#             params = default_params()
 
-        bn_key = BigNum.gen_rand(params.curve)
-        return cls(bn_key, params)
+#         bn_key = BigNum.gen_rand(params.curve)
+#         return cls(bn_key, params)
 
-    @classmethod
-    def derive_key_from_label(cls, master_secret: bytes, label: bytes, 
-            salt: bytes=None, params: UmbralParameters=None):
-        """
-        Derives a private key using the KDF from a master secret, 
-        a label, and an optional salt.
-        """
-        if params is None:
-            params = default_params()
+#     @classmethod
+#     def derive_key_from_label(cls, master_secret: bytes, label: bytes, 
+#             salt: bytes=None, params: UmbralParameters=None):
+#         """
+#         Derives a private key using the KDF from a master secret, 
+#         a label, and an optional salt.
+#         """
+#         if params is None:
+#             params = default_params()
 
-        hkdf = HKDF(algorithm=hashes.BLAKE2b(64),
-                    length=64,
-                    salt=salt,
-                    info=b"NuCypherKMS/KeyDerivation/"+label,
-                    backend=default_backend()
-                    )
+#         hkdf = HKDF(algorithm=hashes.BLAKE2b(64),
+#                     length=64,
+#                     salt=salt,
+#                     info=b"NuCypherKMS/KeyDerivation/"+label,
+#                     backend=default_backend()
+#                     )
 
-        bn_key = hash_to_bn(hkdf.derive(master_secret), params)
-        return cls(bn_key, params)
+#         bn_key = hash_to_bn(hkdf.derive(master_secret), params)
+#         return cls(bn_key, params)
 
-    @classmethod
-    def from_bytes(cls, key_data: bytes, params: UmbralParameters=None,
-                 password: bytes=None, _scrypt_cost: int=20):
-        """
-        Loads an Umbral private key from a urlsafe base64 encoded string.
-        Optionally, if a password is provided it will decrypt the key using
-        nacl's Salsa20-Poly1305 and Scrypt key derivation.
+#     @classmethod
+#     def from_bytes(cls, key_data: bytes, params: UmbralParameters=None,
+#                  password: bytes=None, _scrypt_cost: int=20):
+#         """
+#         Loads an Umbral private key from a urlsafe base64 encoded string.
+#         Optionally, if a password is provided it will decrypt the key using
+#         nacl's Salsa20-Poly1305 and Scrypt key derivation.
 
-        WARNING: RFC7914 recommends that you use a 2^20 cost value for sensitive
-        files. Unless you changed this when you called `to_bytes`, you should
-        not change it here. It is NOT recommended to change the `_scrypt_cost`
-        value unless you know what you're doing.
-        """
-        if params is None:
-            params = default_params()
+#         WARNING: RFC7914 recommends that you use a 2^20 cost value for sensitive
+#         files. Unless you changed this when you called `to_bytes`, you should
+#         not change it here. It is NOT recommended to change the `_scrypt_cost`
+#         value unless you know what you're doing.
+#         """
+#         if params is None:
+#             params = default_params()
 
-        key_bytes = base64.urlsafe_b64decode(key_data)
+#         key_bytes = base64.urlsafe_b64decode(key_data)
 
-        if password:
-            salt = key_bytes[-16:]
-            key_bytes = key_bytes[:-16]
+#         if password:
+#             salt = key_bytes[-16:]
+#             key_bytes = key_bytes[:-16]
 
-            key = Scrypt(
-                salt=salt,
-                length=SecretBox.KEY_SIZE,
-                n=2**_scrypt_cost,
-                r=8,
-                p=1,
-                backend=default_backend()
-            ).derive(password)
+#             key = Scrypt(
+#                 salt=salt,
+#                 length=SecretBox.KEY_SIZE,
+#                 n=2**_scrypt_cost,
+#                 r=8,
+#                 p=1,
+#                 backend=default_backend()
+#             ).derive(password)
 
-            key_bytes = SecretBox(key).decrypt(key_bytes)
+#             key_bytes = SecretBox(key).decrypt(key_bytes)
 
-        bn_key = BigNum.from_bytes(key_bytes, params.curve)
-        return cls(bn_key, params)
+#         bn_key = BigNum.from_bytes(key_bytes, params.curve)
+#         return cls(bn_key, params)

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -347,7 +347,7 @@ class UmbralKeyingMaterial(AbstractUmbralKeyingMaterial):
                     backend=default_backend()
                     )
 
-        bn_key = hash_to_bn(hkdf.derive(self.keying_material), params)
+        bn_key = hash_to_bn([hkdf.derive(self.keying_material)], params)
         return UmbralPrivateKey(bn_key, params)
 
     @classmethod

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -331,8 +331,8 @@ class UmbralKeyingMaterial(AbstractUmbralKeyingMaterial):
     def _get_keying_material(self):
         return self.keying_material
 
-    def derive_private_key_from_label(self, label: bytes, 
-                                    salt: bytes=None, params: UmbralParameters=None):
+    def derive_privkey_by_label(self, label: bytes, salt: bytes=None, 
+                                params: UmbralParameters=None):
         """
         Derives an UmbralPrivateKey using a KDF from this instance of 
         UmbralKeyingMaterial, a label, and an optional salt.

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -19,7 +19,7 @@ from umbral.bignum import BigNum, hash_to_bn
 from umbral.params import UmbralParameters
 
     
-class UmbralPrivateKey():
+class UmbralPrivateKey(object):
     def __init__(self, bn_key: BigNum, params: UmbralParameters=None):
         """
         Initializes an Umbral private key.
@@ -259,7 +259,8 @@ class UmbralPublicKey(object):
     def __hash__(self):
         return int.from_bytes(self, byteorder="big")
 
-class UmbralKeyingMaterial():
+
+class UmbralKeyingMaterial(object):
     """
     This class handles keying material for Umbral, by allowing deterministic
     derivation of UmbralPrivateKeys based on labels. 

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -400,7 +400,7 @@ def _check_challenge(capsule: Capsule, cfrag: CapsuleFrag,
     if challenge_metadata is not None:
         hash_input.append(challenge_metadata)
     
-    h = BigNum.hash_to_bn(hash_input, params=params)
+    h = BigNum.hash_to_bn(*hash_input, params=params)
 
     check31 = z1 == BigNum.hash_to_bn(g_y, kfrag_id, pub_a, pub_b, u1, xcomp, params=params)
     check32 = z3 * e == e2 + (h * e1)

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -6,7 +6,7 @@ from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import hashes
 
-from umbral.bignum import BigNum, hash_to_bn
+from umbral.bignum import BigNum
 from umbral.config import default_params, default_curve
 from umbral.dem import UmbralDEM
 from umbral.fragments import KFrag, CapsuleFrag
@@ -107,7 +107,7 @@ class Capsule(object):
         e = self._point_eph_e
         v = self._point_eph_v
         s = self._bn_sig
-        h = hash_to_bn([e, v], params)
+        h = BigNum.hash_to_bn(e, v, params=params)
 
         return s * params.g == v + (h * e)
 
@@ -145,16 +145,16 @@ class Capsule(object):
 
         id_cfrag_pairs = list(self._attached_cfrags.items())
         id_0, cfrag_0 = id_cfrag_pairs[0]
-        x_0 = hash_to_bn([id_0, hashed_dh_tuple], params)
+        x_0 = BigNum.hash_to_bn(id_0, hashed_dh_tuple, params=params)
         if len(id_cfrag_pairs) > 1:
-            xs = [hash_to_bn([_id, hashed_dh_tuple], params) 
+            xs = [BigNum.hash_to_bn(_id, hashed_dh_tuple, params=params)
                     for _id in self._attached_cfrags.keys()]
             lambda_0 = lambda_coeff(x_0, xs)
             e = lambda_0 * cfrag_0.point_eph_e1
             v = lambda_0 * cfrag_0.point_eph_v1
 
             for id_i, cfrag in id_cfrag_pairs[1:]:
-                x_i = hash_to_bn([id_i, hashed_dh_tuple], params)
+                x_i = BigNum.hash_to_bn(id_i, hashed_dh_tuple, params=params)
                 lambda_i = lambda_coeff(x_i, xs)
                 e = e + (lambda_i * cfrag.point_eph_e1)
                 v = v + (lambda_i * cfrag.point_eph_v1)
@@ -280,7 +280,7 @@ def split_rekey(priv_a: Union[UmbralPrivateKey, BigNum],
 
     x = BigNum.gen_rand(params.curve)
     xcomp = x * g
-    d = hash_to_bn([xcomp, pub_b, pub_b * x], params)
+    d = BigNum.hash_to_bn(xcomp, pub_b, pub_b * x, params=params)
 
     coeffs = [priv_a * (~d)]
     coeffs += [BigNum.gen_rand(params.curve) for _ in range(threshold - 1)]
@@ -299,14 +299,14 @@ def split_rekey(priv_a: Union[UmbralPrivateKey, BigNum],
     for _ in range(N):
         id_kfrag = BigNum.gen_rand(params.curve)
 
-        share_x = hash_to_bn([id_kfrag, hashed_dh_tuple], params)
+        share_x = BigNum.hash_to_bn(id_kfrag, hashed_dh_tuple, params=params)
 
         rk = poly_eval(coeffs, share_x)
 
         u1 = rk * u
         y = BigNum.gen_rand(params.curve)
 
-        z1 = hash_to_bn([y * g, id_kfrag, pub_a, pub_b, u1, xcomp], params)
+        z1 = BigNum.hash_to_bn(y * g, id_kfrag, pub_a, pub_b, u1, xcomp, params=params)
         z2 = y - priv_a * z1
 
         kfrag = KFrag(id_=id_kfrag, key=rk, x=xcomp, u1=u1, z1=z1, z2=z2)
@@ -351,8 +351,8 @@ def _challenge(kfrag: KFrag, capsule: Capsule,
     hash_input = [e, e1, e2, v, v1, v2, u, u1, u2]
     if challenge_metadata is not None:
         hash_input.append(challenge_metadata)
-    
-    h = hash_to_bn(hash_input, params)
+
+    h = BigNum.hash_to_bn(*hash_input, params=params)
 
     z3 = t + h * kfrag.bn_key
 
@@ -400,9 +400,9 @@ def _check_challenge(capsule: Capsule, cfrag: CapsuleFrag,
     if challenge_metadata is not None:
         hash_input.append(challenge_metadata)
     
-    h = hash_to_bn(hash_input, params)
+    h = BigNum.hash_to_bn(hash_input, params=params)
 
-    check31 = z1 == hash_to_bn([g_y, kfrag_id, pub_a, pub_b, u1, xcomp], params)
+    check31 = z1 == BigNum.hash_to_bn(g_y, kfrag_id, pub_a, pub_b, u1, xcomp, params=params)
     check32 = z3 * e == e2 + (h * e1)
     check33 = z3 * u == u2 + (h * u1)
     check34 = z3 * v == v2 + (h * v1)
@@ -423,7 +423,7 @@ def _encapsulate(alice_pub_key: Point, key_length=32,
     priv_u = BigNum.gen_rand(params.curve)
     pub_u = priv_u * g
 
-    h = hash_to_bn([pub_r, pub_u], params)
+    h = BigNum.hash_to_bn(pub_r, pub_u, params=params)
     s = priv_u + (priv_r * h)
 
     shared_key = (priv_r + priv_u) * alice_pub_key
@@ -457,7 +457,7 @@ def _decapsulate_reencrypted(pub_key: Point, priv_key: BigNum,
     params = params if params is not None else default_params()
 
     xcomp = capsule._point_noninteractive
-    d = hash_to_bn([xcomp, pub_key, priv_key * xcomp], params)
+    d = BigNum.hash_to_bn(xcomp, pub_key, priv_key * xcomp, params=params)
 
     e_prime = capsule._point_eph_e_prime
     v_prime = capsule._point_eph_v_prime
@@ -469,7 +469,7 @@ def _decapsulate_reencrypted(pub_key: Point, priv_key: BigNum,
     e = capsule._point_eph_e
     v = capsule._point_eph_v
     s = capsule._bn_sig
-    h = hash_to_bn([e, v], params)
+    h = BigNum.hash_to_bn(e, v, params=params)
     inv_d = ~d
 
     if not (s*inv_d) * orig_pub_key == (h*e_prime) + v_prime:


### PR DESCRIPTION
### What this does:
1. Implements arg packing in `BigNum.hash_to_bn`
2. Moves `hash_to_bn` to be a class method on `BigNum`.
3. Raise `TypeError` in `hash_to_bn` when something can't be serialized to bytes, or isn't bytes already.