### PR TITLE
Constant time `hash_to_bn` (and some minor cleaning)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@ from umbral.config import _CONFIG
 import pytest
 import importlib
 from cryptography.hazmat.primitives.asymmetric import ec
-from umbral.curvebn import CurveBN
 import warnings
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ from umbral.config import _CONFIG
 import pytest
 import importlib
 from cryptography.hazmat.primitives.asymmetric import ec
-from umbral.point import Point
+from umbral.curvebn import CurveBN
 import warnings
 
 
@@ -63,8 +63,6 @@ def test_cannot_set_default_curve_twice():
 
     # Our default curve has been set...
     assert config.default_curve() == ec.SECP256R1
-    # ...and used to set the order of our default parameters.
-    assert config.default_params().order == Point.get_order_from_curve(ec.SECP256R1)
 
     # ...but once set, you can't set the default curve again, even if you've found a better one.
     with pytest.raises(config._CONFIG.UmbralConfigurationError):

--- a/umbral/curvebn.py
+++ b/umbral/curvebn.py
@@ -16,6 +16,12 @@ class CurveBN(object):
     """
 
     def __init__(self, bignum, curve_nid, group, order):
+
+        if curve_nid:
+            on_curve = openssl._bn_is_on_curve(bignum, curve_nid)
+            if not on_curve:
+                raise ValueError("The provided BIGNUM is not on the provided curve.")
+
         self.bignum = bignum
         self.curve_nid = curve_nid
         self.group = group

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -81,7 +81,7 @@ class KFrag(object):
         g_y = (z2 * params.g) + (z1 * pub_a)
 
         kfrag_components = [g_y, self._bn_id, pub_a, pub_b, u1, x]
-        valid_kfrag_signature = z1 == CurveBN.hash_to_bn(*kfrag_components, params=params)
+        valid_kfrag_signature = z1 == CurveBN.hash(*kfrag_components, params=params)
 
         return correct_commitment & valid_kfrag_signature
 

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -293,7 +293,7 @@ class UmbralKeyingMaterial(object):
             backend=default_backend()
         ).derive(self.keying_material)
 
-        bn_key = CurveBN.hash_to_bn(key_material, params=params)
+        bn_key = CurveBN.hash(key_material, params=params)
         return UmbralPrivateKey(bn_key, params)
 
     @classmethod

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -13,7 +13,6 @@ class UmbralParameters(object):
 
         g_bytes = self.g.to_bytes(is_compressed=True)
 
-        self.CURVE_MINVAL_HASH_512 = (1 << 512) % int(self.order)
         self.CURVE_KEY_SIZE_BYTES = get_curve_keysize_bytes(self.curve)
 
         parameters_seed = b'NuCypherKMS/UmbralParameters/'

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -1,4 +1,6 @@
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.backends.openssl import backend
+from umbral import openssl
 
 
 class UmbralParameters(object):
@@ -7,9 +9,11 @@ class UmbralParameters(object):
         from umbral.utils import get_curve_keysize_bytes
 
         self.curve = curve
+        curve_nid = backend._elliptic_curve_to_nid(curve)
 
         self.g = Point.get_generator_from_curve(self.curve)
-        self.order = Point.get_order_from_curve(self.curve)
+
+        self.order = openssl._get_ec_order_by_curve_nid(curve_nid)
 
         g_bytes = self.g.to_bytes(is_compressed=True)
 

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -49,7 +49,7 @@ class Point(object):
             )
             backend.openssl_assert(res == 1)
 
-        return Point(rand_point, curve_nid, group)
+        return cls(rand_point, curve_nid, group)
 
     @classmethod
     def from_affine(cls, coords, curve: ec.EllipticCurve=None):
@@ -74,7 +74,7 @@ class Point(object):
         group = openssl._get_ec_group_by_curve_nid(curve_nid)
         ec_point = openssl._get_EC_POINT_via_affine(affine_x, affine_y, ec_group=group)
 
-        return Point(ec_point, curve_nid, group)
+        return cls(ec_point, curve_nid, group)
 
     def to_affine(self):
         """
@@ -120,7 +120,7 @@ class Point(object):
             affine_x = int.from_bytes(data[1:key_size+1], 'big')
             affine_y = int.from_bytes(data[1+key_size:], 'big')
 
-            return Point.from_affine((affine_x, affine_y), curve)
+            return cls.from_affine((affine_x, affine_y), curve)
         else:
             raise ValueError("Invalid point serialization.")
 

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -230,7 +230,7 @@ def unsafe_hash_to_point(data, params, label=None):
     Hashes arbitrary data into a valid EC point of the specified curve,
     using the try-and-increment method.
     It admits an optional label as an additional input to the hash function.
-    It uses SHA256 as the internal hash function.
+    It uses BLAKE2b (with a digest size of 64 bytes) as the internal hash function.
 
     WARNING: Do not use when the input data is secret, as this implementation is not
     in constant time, and hence, it is not safe with respect to timing attacks.
@@ -245,9 +245,9 @@ def unsafe_hash_to_point(data, params, label=None):
     i = 1
     while i < 2**32:
         ibytes = i.to_bytes(4, byteorder='big')
-        sha_512 = hashes.Hash(hashes.SHA512(), backend=backend)
-        sha_512.update(label + ibytes + data)
-        hash_digest = sha_512.finalize()[:params.CURVE_KEY_SIZE_BYTES]
+        blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
+        blake2b.update(label + ibytes + data)
+        hash_digest = blake2b.finalize()[:params.CURVE_KEY_SIZE_BYTES]
 
         compressed02 = b"\x02" + hash_digest
 

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -132,8 +132,8 @@ class Point(object):
         affine_x, affine_y = self.to_affine()
 
         # Get size of curve via order
-        order = Point.get_order_from_curve(self.curve_nid)
-        key_size = backend._lib.BN_num_bytes(order.bignum)
+        order = openssl._get_ec_order_by_curve_nid(self.curve_nid)
+        key_size = backend._lib.BN_num_bytes(order)
 
         if is_compressed:
             y_bit = (affine_y & 1) + 2
@@ -162,23 +162,6 @@ class Point(object):
         generator = openssl._get_ec_generator_by_curve_nid(curve_nid)
 
         return cls(generator, curve_nid, group)
-
-    @classmethod
-    def get_order_from_curve(cls, curve: ec.EllipticCurve=None):
-        """
-        Returns the order from the given curve as a CurveBN.
-        """
-        curve = curve if curve is not None else default_curve()
-        try:
-            curve_nid = backend._elliptic_curve_to_nid(curve)
-        except AttributeError:
-            # Presume that the user passed in the curve_nid
-            curve_nid = curve
-
-        group = openssl._get_ec_group_by_curve_nid(curve_nid)
-        order = openssl._get_ec_order_by_curve_nid(curve_nid)
-
-        return CurveBN(order, curve_nid, group, order)
 
     def __eq__(self, other):
         """

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -1,5 +1,3 @@
-import hmac
-
 from typing import Tuple, Union, List
 
 from cryptography.hazmat.backends.openssl import backend

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -110,7 +110,7 @@ class Capsule(object):
         e = self._point_e
         v = self._point_v
         s = self._bn_sig
-        h = CurveBN.hash_to_bn(e, v, params=params)
+        h = CurveBN.hash(e, v, params=params)
 
         return s * params.g == v + (h * e)
 
@@ -148,16 +148,16 @@ class Capsule(object):
 
         cfrag_0 = self._attached_cfrags[0]
         id_0 = cfrag_0._bn_kfrag_id
-        x_0 = CurveBN.hash_to_bn(id_0, hashed_dh_tuple, params=params)
+        x_0 = CurveBN.hash(id_0, hashed_dh_tuple, params=params)
         if len(self._attached_cfrags) > 1:
-            xs = [CurveBN.hash_to_bn(cfrag._bn_kfrag_id, hashed_dh_tuple, params=params)
+            xs = [CurveBN.hash(cfrag._bn_kfrag_id, hashed_dh_tuple, params=params)
                     for cfrag in self._attached_cfrags]
             lambda_0 = lambda_coeff(x_0, xs)
             e = lambda_0 * cfrag_0._point_e1
             v = lambda_0 * cfrag_0._point_v1
 
             for cfrag in self._attached_cfrags[1:]:
-                x_i = CurveBN.hash_to_bn(cfrag._bn_kfrag_id, hashed_dh_tuple, params=params)
+                x_i = CurveBN.hash(cfrag._bn_kfrag_id, hashed_dh_tuple, params=params)
                 lambda_i = lambda_coeff(x_i, xs)
                 e = e + (lambda_i * cfrag._point_e1)
                 v = v + (lambda_i * cfrag._point_v1)
@@ -226,7 +226,7 @@ def split_rekey(priv_a: Union[UmbralPrivateKey, CurveBN],
 
     x = CurveBN.gen_rand(params.curve)
     xcomp = x * g
-    d = CurveBN.hash_to_bn(xcomp, pub_b, pub_b * x, params=params)
+    d = CurveBN.hash(xcomp, pub_b, pub_b * x, params=params)
 
     coeffs = [priv_a * (~d)]
     coeffs += [CurveBN.gen_rand(params.curve) for _ in range(threshold - 1)]
@@ -245,14 +245,14 @@ def split_rekey(priv_a: Union[UmbralPrivateKey, CurveBN],
     for _ in range(N):
         id_kfrag = CurveBN.gen_rand(params.curve)
 
-        share_x = CurveBN.hash_to_bn(id_kfrag, hashed_dh_tuple, params=params)
+        share_x = CurveBN.hash(id_kfrag, hashed_dh_tuple, params=params)
 
         rk = poly_eval(coeffs, share_x)
 
         u1 = rk * u
         y = CurveBN.gen_rand(params.curve)
 
-        z1 = CurveBN.hash_to_bn(y * g, id_kfrag, pub_a, pub_b, u1, xcomp, params=params)
+        z1 = CurveBN.hash(y * g, id_kfrag, pub_a, pub_b, u1, xcomp, params=params)
         z2 = y - priv_a * z1
 
         kfrag = KFrag(bn_id=id_kfrag, bn_key=rk, 
@@ -309,7 +309,7 @@ def _prove_correctness(cfrag: CapsuleFrag, kfrag: KFrag, capsule: Capsule,
     if metadata is not None:
         hash_input.append(metadata)
 
-    h = CurveBN.hash_to_bn(*hash_input, params=params)
+    h = CurveBN.hash(*hash_input, params=params)
 
     z3 = t + h * rk
 
@@ -363,10 +363,10 @@ def _verify_correctness(capsule: Capsule, cfrag: CapsuleFrag,
     if proof.metadata is not None:
         hash_input.append(proof.metadata)
     
-    h = CurveBN.hash_to_bn(*hash_input, params=params)
+    h = CurveBN.hash(*hash_input, params=params)
 
     signature_input = [g_y, kfrag_id, pub_a, pub_b, u1, xcomp]
-    kfrag_signature1 = CurveBN.hash_to_bn(*signature_input, params=params)
+    kfrag_signature1 = CurveBN.hash(*signature_input, params=params)
     valid_kfrag_signature = z1 == kfrag_signature1
     
     correct_reencryption_of_e = z3 * e == e2 + (h * e1)
@@ -393,7 +393,7 @@ def _encapsulate(alice_pub_key: Point, key_length=32,
     priv_u = CurveBN.gen_rand(params.curve)
     pub_u = priv_u * g
 
-    h = CurveBN.hash_to_bn(pub_r, pub_u, params=params)
+    h = CurveBN.hash(pub_r, pub_u, params=params)
     s = priv_u + (priv_r * h)
 
     shared_key = (priv_r + priv_u) * alice_pub_key
@@ -427,7 +427,7 @@ def _decapsulate_reencrypted(pub_key: Point, priv_key: CurveBN,
     params = params if params is not None else default_params()
 
     xcomp = capsule._point_noninteractive
-    d = CurveBN.hash_to_bn(xcomp, pub_key, priv_key * xcomp, params=params)
+    d = CurveBN.hash(xcomp, pub_key, priv_key * xcomp, params=params)
 
     e_prime = capsule._point_e_prime
     v_prime = capsule._point_v_prime
@@ -439,7 +439,7 @@ def _decapsulate_reencrypted(pub_key: Point, priv_key: CurveBN,
     e = capsule._point_e
     v = capsule._point_v
     s = capsule._bn_sig
-    h = CurveBN.hash_to_bn(e, v, params=params)
+    h = CurveBN.hash(e, v, params=params)
     inv_d = ~d
 
     if not (s*inv_d) * orig_pub_key == (h*e_prime) + v_prime:


### PR DESCRIPTION
- Implements `CurveBN.hash_to_bn()` in constant-time (resolves #110). There is a negligible probability that it requires a second call, which occurs when the digest returns 0. Now, the `params.CURVE_MINVAL_HASH` constant is not needed anymore.
- Renames `CurveBN.hash_to_bn()` as  `CurveBN.hash()`. This is a temporary decision until we find a better place to put this functionality.
- Uses Blake2b instead of SHA256 in `unsafe_hash_to_point`
- Removes `Point.get_order_from_curve`. This function was returning an ill-formed `CurveBN`, since it wasn't being used as a BigNum modulo the order of the curve. 
- Removes some unused imports

### NOTE:
- Actual constant-time requires to set the flag `BN_FLG_CONSTTIME`, as supported by PR #130 (pending at the time of this writing). 