### PR TITLE
[WIP] Improved Fragments

### DIFF
--- a/tests/test_capsule/test_capsule_serializers.py
+++ b/tests/test_capsule/test_capsule_serializers.py
@@ -3,6 +3,7 @@ import pytest
 from umbral import pre
 from umbral.curvebn import CurveBN
 from umbral.point import Point
+from umbral.config import default_curve
 
 
 def test_capsule_serialization(alices_keys):
@@ -43,13 +44,19 @@ def test_activated_capsule_serialization(alices_keys, bobs_keys):
 
     capsule.attach_cfrag(cfrag)
 
-    capsule._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)
+    capsule._reconstruct_shamirs_secret(priv_key_bob)
     rec_capsule_bytes = capsule.to_bytes()
 
     # An activated Capsule is:
     # three points, representable as 33 bytes each (the original), and
     # two points and a CurveBN (32 bytes) (the activated components), for 197 total.
-    assert len(rec_capsule_bytes) == (33 * 3) + (33 + 33 + 32)
+
+    curve = default_curve()
+    bn_size = CurveBN.get_size(curve)
+    point_size = Point.get_size(curve)
+
+    expected_length = (point_size * 3) + (point_size * 2 + bn_size)
+    assert len(rec_capsule_bytes) == expected_length
 
     new_rec_capsule = pre.Capsule.from_bytes(rec_capsule_bytes)
 

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -5,8 +5,6 @@ from umbral.point import Point
 from umbral.fragments import CorrectnessProof
 from .conftest import parameters
 
-import time
-
 
 def test_correctness_proof_serialization():
     priv_key_alice = keys.UmbralPrivateKey.gen_key()
@@ -58,7 +56,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
 
     cfrags, metadata = [], []
-    for i, kfrag in enumerate(kfrags):
+    for i, kfrag in enumerate(kfrags[:M]):
 
         # Example of potential metadata to describe the re-encryption request
         metadata_i = "This is an example of metadata for re-encryption request #{}"
@@ -75,7 +73,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
         cfrags.append(cfrag)
 
     # Let's activate the capsule
-    capsule_alice1._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    
+    capsule_alice1._reconstruct_shamirs_secret(priv_key_bob)    
 
     with pytest.raises(pre.GenericUmbralError):
         sym_key = pre._decapsulate_reencrypted(pub_key_bob.point_key,
@@ -136,7 +134,7 @@ def test_cheating_ursula_sends_garbage(N, M):
     cfrags[0]._point_e1 = Point.gen_rand()
     cfrags[0]._point_v1 = Point.gen_rand()
 
-    capsule_alice._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    # activate capsule
+    capsule_alice._reconstruct_shamirs_secret(priv_key_bob)    # activate capsule
 
     with pytest.raises(pre.GenericUmbralError):
         _unused_key = pre._decapsulate_reencrypted(pub_key_bob.point_key,

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -1,5 +1,5 @@
 import pytest
-
+import random
 from umbral import pre, keys
 from umbral.point import Point
 from umbral.fragments import CorrectnessProof
@@ -15,6 +15,7 @@ def test_correctness_proof_serialization():
 
     _unused_key, capsule = pre._encapsulate(pub_key_alice.point_key)
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, 1, 2)
+    random.shuffle(kfrags)
 
     # Example of potential metadata to describe the re-encryption request
     metadata = b"This is an example of metadata for re-encryption request"
@@ -54,6 +55,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
     sym_key_alice2, capsule_alice2 = pre._encapsulate(pub_key_alice.point_key)
 
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
+    random.shuffle(kfrags)
 
     cfrags, metadata = [], []
     for i, kfrag in enumerate(kfrags[:M]):
@@ -117,6 +119,7 @@ def test_cheating_ursula_sends_garbage(N, M):
 
     sym_key, capsule_alice = pre._encapsulate(pub_key_alice.point_key)
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
+    random.shuffle(kfrags)
 
     cfrags, metadata = [], []
     for i, kfrag in enumerate(kfrags[:M]):
@@ -177,6 +180,8 @@ def test_decryption_fails_when_it_expects_a_proof_and_there_isnt(N, M, alices_ke
     ciphertext, capsule = pre.encrypt(pub_key_alice, plain_data)
 
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
+    random.shuffle(kfrags)
+
     for kfrag in kfrags:
         cfrag = pre.reencrypt(kfrag, capsule, provide_proof=False)
         capsule.attach_cfrag(cfrag)
@@ -193,6 +198,7 @@ def test_m_of_n(N, M, alices_keys, bobs_keys):
 
     sym_key, capsule = pre._encapsulate(pub_key_alice.point_key)
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
+    random.shuffle(kfrags)
 
     for kfrag in kfrags:
         assert kfrag.verify(pub_key_alice.point_key, pub_key_bob.point_key)

--- a/tests/test_keys/test_key_fragments.py
+++ b/tests/test_keys/test_key_fragments.py
@@ -12,7 +12,7 @@ def test_kfrag_serialization(alices_keys):
     assert len(kfrag_bytes) == 33 + 33 + (32 * 4) == 194
 
     new_frag = pre.KFrag.from_bytes(kfrag_bytes)
-    assert new_frag._bn_id == kfrags[0]._bn_id
+    assert new_frag._id == kfrags[0]._id
     assert new_frag._bn_key == kfrags[0]._bn_key
     assert new_frag._point_noninteractive == kfrags[0]._point_noninteractive
     assert new_frag._point_commitment == kfrags[0]._point_commitment
@@ -47,7 +47,7 @@ def test_cfrag_serialization_with_proof_and_metadata(alices_keys):
     new_cfrag = pre.CapsuleFrag.from_bytes(cfrag_bytes)
     assert new_cfrag._point_e1 == cfrag._point_e1
     assert new_cfrag._point_v1 == cfrag._point_v1
-    assert new_cfrag._bn_kfrag_id == cfrag._bn_kfrag_id
+    assert new_cfrag._kfrag_id == cfrag._kfrag_id
     assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
 
     new_proof = new_cfrag.proof
@@ -83,7 +83,7 @@ def test_cfrag_serialization_with_proof_but_no_metadata(alices_keys):
     new_cfrag = pre.CapsuleFrag.from_bytes(cfrag_bytes)
     assert new_cfrag._point_e1 == cfrag._point_e1
     assert new_cfrag._point_v1 == cfrag._point_v1
-    assert new_cfrag._bn_kfrag_id == cfrag._bn_kfrag_id
+    assert new_cfrag._kfrag_id == cfrag._kfrag_id
     assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
 
     new_proof = new_cfrag.proof
@@ -115,7 +115,7 @@ def test_cfrag_serialization_no_proof_no_metadata(alices_keys):
     new_cfrag = pre.CapsuleFrag.from_bytes(cfrag_bytes)
     assert new_cfrag._point_e1 == cfrag._point_e1
     assert new_cfrag._point_v1 == cfrag._point_v1
-    assert new_cfrag._bn_kfrag_id == cfrag._bn_kfrag_id
+    assert new_cfrag._kfrag_id == cfrag._kfrag_id
     assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
 
     new_proof = new_cfrag.proof

--- a/tests/test_keys/test_key_fragments.py
+++ b/tests/test_keys/test_key_fragments.py
@@ -27,11 +27,7 @@ def test_cfrag_serialization_with_proof_and_metadata(alices_keys):
     kfrags = pre.split_rekey(priv_key_alice, pub_key_alice, 1, 2)
 
     # Example of potential metadata to describe the re-encryption request
-    metadata = { 'ursula_id' : 42, 
-                 'timestamp' : time.time(), 
-                 'capsule' : bytes(capsule), 
-               }
-    metadata = str(metadata).encode()
+    metadata = b"This is an example of metadata for re-encryption request"
 
     cfrag = pre.reencrypt(kfrags[0], capsule, provide_proof=True, metadata=metadata)
     cfrag_bytes = cfrag.to_bytes()

--- a/tests/test_keys/test_key_fragments.py
+++ b/tests/test_keys/test_key_fragments.py
@@ -1,5 +1,6 @@
 from umbral import pre
-import time
+from umbral.config import default_curve
+from umbral.fragments import KFrag, CapsuleFrag
 
 
 def test_kfrag_serialization(alices_keys):
@@ -8,14 +9,15 @@ def test_kfrag_serialization(alices_keys):
     kfrags = pre.split_rekey(priv_key_alice, pub_key_alice, 1, 2)
     kfrag_bytes = kfrags[0].to_bytes()
 
-    # A KFrag can be represented as the 194 total bytes of two Points (33 each) and four CurveBNs (32 each).
-    assert len(kfrag_bytes) == 33 + 33 + (32 * 4) == 194
+    curve = default_curve()
+    assert len(kfrag_bytes) == KFrag.get_size(curve)
 
     new_frag = pre.KFrag.from_bytes(kfrag_bytes)
     assert new_frag._id == kfrags[0]._id
     assert new_frag._bn_key == kfrags[0]._bn_key
     assert new_frag._point_noninteractive == kfrags[0]._point_noninteractive
     assert new_frag._point_commitment == kfrags[0]._point_commitment
+    assert new_frag._point_seed_xcoord == kfrags[0]._point_seed_xcoord
     assert new_frag._bn_sig1 == kfrags[0]._bn_sig1
     assert new_frag._bn_sig2 == kfrags[0]._bn_sig2
 
@@ -105,8 +107,8 @@ def test_cfrag_serialization_no_proof_no_metadata(alices_keys):
     proof = cfrag.proof
     assert proof is None
 
-    # A CFrag can be represented as the 131 total bytes of three Points (33 each) and a CurveBN (32).
-    assert len(cfrag_bytes) == 33 + 33 + 33 + 32 == 131
+    curve = default_curve()
+    assert len(cfrag_bytes) == CapsuleFrag.get_size(curve)
 
     new_cfrag = pre.CapsuleFrag.from_bytes(cfrag_bytes)
     assert new_cfrag._point_e1 == cfrag._point_e1

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -9,11 +9,12 @@ from io import BytesIO
 
 class KFrag(object):
     def __init__(self, id, bn_key, point_noninteractive, 
-                 point_commitment, bn_sig1, bn_sig2):
+                 point_commitment, point_seed_xcoord, bn_sig1, bn_sig2):
         self._id = id
         self._bn_key = bn_key
         self._point_noninteractive = point_noninteractive
         self._point_commitment = point_commitment
+        self._point_seed_xcoord = point_seed_xcoord
         self._bn_sig1 = bn_sig1
         self._bn_sig2 = bn_sig2
 
@@ -27,7 +28,7 @@ class KFrag(object):
         bn_size = CurveBN.get_size(curve)
         point_size = Point.get_size(curve)
 
-        return (bn_size * 4) + (point_size * 2)
+        return (bn_size * 4) + (point_size * 3)
 
     @classmethod
     def from_bytes(cls, data: bytes, curve: ec.EllipticCurve = None):
@@ -45,10 +46,11 @@ class KFrag(object):
         key = CurveBN.from_bytes(data.read(bn_size), curve)
         ni = Point.from_bytes(data.read(point_size), curve)
         commitment = Point.from_bytes(data.read(point_size), curve)
+        seed_xcoord = Point.from_bytes(data.read(point_size), curve)
         sig1 = CurveBN.from_bytes(data.read(bn_size), curve)
         sig2 = CurveBN.from_bytes(data.read(bn_size), curve)
 
-        return cls(id, key, ni, commitment, sig1, sig2)
+        return cls(id, key, ni, commitment, seed_xcoord, sig1, sig2)
 
     def to_bytes(self):
         """
@@ -57,10 +59,11 @@ class KFrag(object):
         key = self._bn_key.to_bytes()
         ni = self._point_noninteractive.to_bytes()
         commitment = self._point_commitment.to_bytes()
+        seed_xcoord = self._point_seed_xcoord.to_bytes()
         sig1 = self._bn_sig1.to_bytes()
         sig2 = self._bn_sig2.to_bytes()
 
-        return self._id + key + ni + commitment + sig1 + sig2
+        return self._id + key + ni + commitment + seed_xcoord + sig1 + sig2
 
     def verify(self, pub_a, pub_b, params: "UmbralParameters"=None):
         params = params if params is not None else default_params()
@@ -71,6 +74,7 @@ class KFrag(object):
         z1 = self._bn_sig1
         z2 = self._bn_sig2
         x = self._point_noninteractive
+        seed_xcoord = self._point_seed_xcoord
         key = self._bn_key
 
         # We check that the commitment u1 is well-formed
@@ -79,7 +83,7 @@ class KFrag(object):
         # We check the Schnorr signature over the kfrag components
         g_y = (z2 * params.g) + (z1 * pub_a)
 
-        kfrag_components = [g_y, self._id, pub_a, pub_b, u1, x]
+        kfrag_components = [g_y, self._id, pub_a, pub_b, u1, x, seed_xcoord]
         valid_kfrag_signature = z1 == CurveBN.hash_to_bn(*kfrag_components, params=params)
 
         return correct_commitment & valid_kfrag_signature
@@ -167,12 +171,14 @@ class CorrectnessProof(object):
 
 
 class CapsuleFrag(object):
-    def __init__(self, point_e1, point_v1, kfrag_id, point_noninteractive, 
+    def __init__(self, point_e1, point_v1, kfrag_id, 
+                 point_noninteractive, point_seed_xcoord,
                  proof: CorrectnessProof=None):
         self._point_e1 = point_e1
         self._point_v1 = point_v1
         self._kfrag_id = kfrag_id
         self._point_noninteractive = point_noninteractive
+        self._point_seed_xcoord = point_seed_xcoord
         self.proof = proof
 
     @classmethod
@@ -186,7 +192,7 @@ class CapsuleFrag(object):
         bn_size = CurveBN.get_size(curve)
         point_size = Point.get_size(curve)
 
-        return (bn_size * 1) + (point_size * 3)
+        return (bn_size * 1) + (point_size * 4)
 
     @classmethod
     def from_bytes(cls, data: bytes, curve: ec.EllipticCurve = None):
@@ -202,11 +208,12 @@ class CapsuleFrag(object):
         v1 = Point.from_bytes(data.read(point_size), curve)
         kfrag_id = data.read(key_size)
         ni = Point.from_bytes(data.read(point_size), curve)
+        seed_xcoord = Point.from_bytes(data.read(point_size), curve)
 
         proof = data.read() or None
         proof = CorrectnessProof.from_bytes(proof, curve) if proof else None
 
-        return cls(e1, v1, kfrag_id, ni, proof)
+        return cls(e1, v1, kfrag_id, ni, seed_xcoord, proof)
 
     def to_bytes(self):
         """
@@ -215,8 +222,9 @@ class CapsuleFrag(object):
         e1 = self._point_e1.to_bytes()
         v1 = self._point_v1.to_bytes()
         ni = self._point_noninteractive.to_bytes()
+        seed_xcoord = self._point_seed_xcoord.to_bytes()
 
-        serialized_cfrag = e1 + v1 + self._kfrag_id + ni
+        serialized_cfrag = e1 + v1 + self._kfrag_id + ni + seed_xcoord
 
         if self.proof is not None:
             serialized_cfrag += self.proof.to_bytes()

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -3,7 +3,6 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from umbral.curvebn import CurveBN
 from umbral.config import default_curve, default_params
 from umbral.point import Point
-from umbral.utils import get_curve_keysize_bytes
 
 from io import BytesIO
 
@@ -36,17 +35,18 @@ class KFrag(object):
         Instantiate a KFrag object from the serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = get_curve_keysize_bytes(curve)
+        bn_size = CurveBN.get_size(curve)
+        point_size = Point.get_size(curve)
         data = BytesIO(data)
 
         # CurveBNs are the keysize in bytes, Points are compressed and the
         # keysize + 1 bytes long.
-        id = data.read(key_size)
-        key = CurveBN.from_bytes(data.read(key_size), curve)
-        ni = Point.from_bytes(data.read(key_size + 1), curve)
-        commitment = Point.from_bytes(data.read(key_size + 1), curve)
-        sig1 = CurveBN.from_bytes(data.read(key_size), curve)
-        sig2 = CurveBN.from_bytes(data.read(key_size), curve)
+        id = data.read(bn_size)
+        key = CurveBN.from_bytes(data.read(bn_size), curve)
+        ni = Point.from_bytes(data.read(point_size), curve)
+        commitment = Point.from_bytes(data.read(point_size), curve)
+        sig1 = CurveBN.from_bytes(data.read(bn_size), curve)
+        sig2 = CurveBN.from_bytes(data.read(bn_size), curve)
 
         return cls(id, key, ni, commitment, sig1, sig2)
 
@@ -119,18 +119,19 @@ class CorrectnessProof(object):
         Instantiate CorrectnessProof from serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = get_curve_keysize_bytes(curve)
+        bn_size = CurveBN.get_size(curve)
+        point_size = Point.get_size(curve)
         data = BytesIO(data)
 
         # CurveBNs are the keysize in bytes, Points are compressed and the
         # keysize + 1 bytes long.
-        e2 = Point.from_bytes(data.read(key_size + 1), curve)
-        v2 = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_commitment = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_pok = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_sig1 = CurveBN.from_bytes(data.read(key_size), curve)
-        kfrag_sig2 = CurveBN.from_bytes(data.read(key_size), curve)
-        sig = CurveBN.from_bytes(data.read(key_size), curve)
+        e2 = Point.from_bytes(data.read(point_size), curve)
+        v2 = Point.from_bytes(data.read(point_size), curve)
+        kfrag_commitment = Point.from_bytes(data.read(point_size), curve)
+        kfrag_pok = Point.from_bytes(data.read(point_size), curve)
+        kfrag_sig1 = CurveBN.from_bytes(data.read(bn_size), curve)
+        kfrag_sig2 = CurveBN.from_bytes(data.read(bn_size), curve)
+        sig = CurveBN.from_bytes(data.read(bn_size), curve)
 
         metadata = data.read() or None
 
@@ -193,15 +194,14 @@ class CapsuleFrag(object):
         Instantiates a CapsuleFrag object from the serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = get_curve_keysize_bytes(curve)
+        key_size = CurveBN.get_size(curve)
+        point_size = Point.get_size(curve)
         data = BytesIO(data)
 
-        # CurveBNs are the keysize in bytes, Points are compressed and the
-        # keysize + 1 bytes long.
-        e1 = Point.from_bytes(data.read(key_size + 1), curve)
-        v1 = Point.from_bytes(data.read(key_size + 1), curve)
+        e1 = Point.from_bytes(data.read(point_size), curve)
+        v1 = Point.from_bytes(data.read(point_size), curve)
         kfrag_id = data.read(key_size)
-        ni = Point.from_bytes(data.read(key_size + 1), curve)
+        ni = Point.from_bytes(data.read(point_size), curve)
 
         proof = data.read() or None
         proof = CorrectnessProof.from_bytes(proof, curve) if proof else None


### PR DESCRIPTION
Some improvements in `KFrag` and `CapsuleFrag`:
* Change `KFrag._bn_id` from a `CurveBN` type to a byte string (Solves #123), since it's not necessary anymore that this value be a `CurveBN`.
* New ephemeral public key in `KFrags` to use during reconstruction of activated capsule, instead of using Alice's public key. This new ephemeral pk is called `KFrag._point_seed_xcoord`. The motivation of this change is that if Alice's private key is disclosed, this prevents a potential reconstruction of the re-encryption key without using Bob's private key.
* Checks that all attached `cfrags` are consistent with respect to `point_noninteractive` and `point_seed_xcoord`
* Fixes corresponding tests