### PR TITLE
Remove loop in CurveBN.hash()

### DIFF
--- a/tests/test_primitives/test_bignum/test_bignum_methods.py
+++ b/tests/test_primitives/test_bignum/test_bignum_methods.py
@@ -1,4 +1,5 @@
 from umbral.curvebn import CurveBN
+import pytest
 
 
 def test_cast_curvebn_to_int():
@@ -11,3 +12,9 @@ def test_cast_curvebn_to_int():
 
     y = CurveBN.from_int(x)
     assert x == y
+
+
+def test_cant_hash_arbitrary_object_into_bignum():
+    whatever = object()
+    with pytest.raises(TypeError):
+        CurveBN.hash(whatever)

--- a/umbral/curvebn.py
+++ b/umbral/curvebn.py
@@ -91,9 +91,10 @@ class CurveBN(object):
             try:
                 item_bytes = item.to_bytes()
             except AttributeError:
-                if not isinstance(item, bytes):
+                if isinstance(item, bytes):
+                    item_bytes = item
+                else:
                     raise TypeError("{} is not acceptable type, received {}".format(item, type(item)))
-                item_bytes = item
             blake2b.update(item_bytes)
 
         hash_digest = blake2b.finalize()


### PR DESCRIPTION
Changes the try-and-increment method of the last stage of `CurveBN.hash()`, which converts a bytes digest into a valid `CurveBN`, to a direct method. Now, instead of computing `curvebn = digest % order` (which implies rejecting the case of `curvebn == 0` and trying again with an incremented input), we compute `curvebn = 1 + (digest % (order-1))`. This ensures that the result satisfies the condition `0 < curvebn < order`. With the change we get rid of the loop, the iteration counter, and handling exceptions. 

This is similar to the method described in Section B.2.1 of the [DSS Standard](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf) to produce per-message secrets in (EC)DSA.
