### PR TITLE
Improved Fragments

### DIFF
--- a/tests/test_capsule/test_capsule_serializers.py
+++ b/tests/test_capsule/test_capsule_serializers.py
@@ -3,6 +3,7 @@ import pytest
 from umbral import pre
 from umbral.curvebn import CurveBN
 from umbral.point import Point
+from umbral.config import default_curve
 
 
 def test_capsule_serialization(alices_keys):
@@ -43,13 +44,18 @@ def test_activated_capsule_serialization(alices_keys, bobs_keys):
 
     capsule.attach_cfrag(cfrag)
 
-    capsule._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)
+    capsule._reconstruct_shamirs_secret(priv_key_bob)
     rec_capsule_bytes = capsule.to_bytes()
 
     # An activated Capsule is:
     # three points, representable as 33 bytes each (the original), and
     # two points and a CurveBN (32 bytes) (the activated components), for 197 total.
-    assert len(rec_capsule_bytes) == (33 * 3) + (33 + 33 + 32)
+    curve = default_curve()
+    bn_size = CurveBN.get_size(curve)
+    point_size = Point.get_size(curve)
+
+    expected_length = (point_size * 3) + (point_size * 2 + bn_size)
+    assert len(rec_capsule_bytes) == expected_length
 
     new_rec_capsule = pre.Capsule.from_bytes(rec_capsule_bytes)
 

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -5,8 +5,6 @@ from umbral.point import Point
 from umbral.fragments import CorrectnessProof
 from .conftest import parameters
 
-import time
-
 
 def test_correctness_proof_serialization():
     priv_key_alice = keys.UmbralPrivateKey.gen_key()
@@ -58,7 +56,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
     kfrags = pre.split_rekey(priv_key_alice, pub_key_bob, M, N)
 
     cfrags, metadata = [], []
-    for i, kfrag in enumerate(kfrags):
+    for i, kfrag in enumerate(kfrags[:M]):
 
         # Example of potential metadata to describe the re-encryption request
         metadata_i = "This is an example of metadata for re-encryption request #{}"
@@ -75,7 +73,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M):
         cfrags.append(cfrag)
 
     # Let's activate the capsule
-    capsule_alice1._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    
+    capsule_alice1._reconstruct_shamirs_secret(priv_key_bob)    
 
     with pytest.raises(pre.GenericUmbralError):
         sym_key = pre._decapsulate_reencrypted(pub_key_bob.point_key,
@@ -134,7 +132,7 @@ def test_cheating_ursula_sends_garbage(N, M):
     cfrags[0]._point_e1 = Point.gen_rand()
     cfrags[0]._point_v1 = Point.gen_rand()
 
-    capsule_alice._reconstruct_shamirs_secret(pub_key_alice, priv_key_bob)    # activate capsule
+    capsule_alice._reconstruct_shamirs_secret(priv_key_bob)    # activate capsule
 
     with pytest.raises(pre.GenericUmbralError):
         _unused_key = pre._decapsulate_reencrypted(pub_key_bob.point_key,

--- a/tests/test_keys/test_key_fragments.py
+++ b/tests/test_keys/test_key_fragments.py
@@ -12,7 +12,7 @@ def test_kfrag_serialization(alices_keys):
     assert len(kfrag_bytes) == 33 + 33 + (32 * 4) == 194
 
     new_frag = pre.KFrag.from_bytes(kfrag_bytes)
-    assert new_frag._bn_id == kfrags[0]._bn_id
+    assert new_frag._id == kfrags[0]._id
     assert new_frag._bn_key == kfrags[0]._bn_key
     assert new_frag._point_noninteractive == kfrags[0]._point_noninteractive
     assert new_frag._point_commitment == kfrags[0]._point_commitment
@@ -47,7 +47,7 @@ def test_cfrag_serialization_with_proof_and_metadata(alices_keys):
     new_cfrag = pre.CapsuleFrag.from_bytes(cfrag_bytes)
     assert new_cfrag._point_e1 == cfrag._point_e1
     assert new_cfrag._point_v1 == cfrag._point_v1
-    assert new_cfrag._bn_kfrag_id == cfrag._bn_kfrag_id
+    assert new_cfrag._kfrag_id == cfrag._kfrag_id
     assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
 
     new_proof = new_cfrag.proof
@@ -83,7 +83,7 @@ def test_cfrag_serialization_with_proof_but_no_metadata(alices_keys):
     new_cfrag = pre.CapsuleFrag.from_bytes(cfrag_bytes)
     assert new_cfrag._point_e1 == cfrag._point_e1
     assert new_cfrag._point_v1 == cfrag._point_v1
-    assert new_cfrag._bn_kfrag_id == cfrag._bn_kfrag_id
+    assert new_cfrag._kfrag_id == cfrag._kfrag_id
     assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
 
     new_proof = new_cfrag.proof
@@ -115,7 +115,7 @@ def test_cfrag_serialization_no_proof_no_metadata(alices_keys):
     new_cfrag = pre.CapsuleFrag.from_bytes(cfrag_bytes)
     assert new_cfrag._point_e1 == cfrag._point_e1
     assert new_cfrag._point_v1 == cfrag._point_v1
-    assert new_cfrag._bn_kfrag_id == cfrag._bn_kfrag_id
+    assert new_cfrag._kfrag_id == cfrag._kfrag_id
     assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
 
     new_proof = new_cfrag.proof

--- a/tests/test_keys/test_key_fragments.py
+++ b/tests/test_keys/test_key_fragments.py
@@ -27,11 +27,7 @@ def test_cfrag_serialization_with_proof_and_metadata(alices_keys):
     kfrags = pre.split_rekey(priv_key_alice, pub_key_alice, 1, 2)
 
     # Example of potential metadata to describe the re-encryption request
-    metadata = { 'ursula_id' : 42, 
-                 'timestamp' : time.time(), 
-                 'capsule' : bytes(capsule), 
-               }
-    metadata = str(metadata).encode()
+    metadata = b'This is an example of metadata for re-encryption request' 
 
     cfrag = pre.reencrypt(kfrags[0], capsule, provide_proof=True, metadata=metadata)
     cfrag_bytes = cfrag.to_bytes()

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -29,9 +29,9 @@ def prove_cfrag_correctness(cfrag: "CapsuleFrag",
     v2 = t * v
     u2 = t * u
 
-    hash_input = [e, e1, e2, v, v1, v2, u, u1, u2]
+    hash_input = (e, e1, e2, v, v1, v2, u, u1, u2)
     if metadata is not None:
-        hash_input.append(metadata)
+        hash_input += (metadata,)
     h = CurveBN.hash(*hash_input, params=params)
 
     z1 = kfrag._bn_sig1
@@ -70,9 +70,9 @@ def assess_cfrag_correctness(cfrag,
     v2 = cfrag.proof._point_v2
     u2 = cfrag.proof._point_kfrag_pok
 
-    hash_input = [e, e1, e2, v, v1, v2, u, u1, u2]
+    hash_input = (e, e1, e2, v, v1, v2, u, u1, u2)
     if cfrag.proof.metadata is not None:
-        hash_input.append(cfrag.proof.metadata)
+        hash_input += (cfrag.proof.metadata,)
     h = CurveBN.hash(*hash_input, params=params)
 
     z1 = cfrag.proof._bn_kfrag_sig1
@@ -88,7 +88,7 @@ def assess_cfrag_correctness(cfrag,
 
     # TODO: change this Schnorr signature for Ed25519 or ECDSA (#97)
     g_y = (z2 * g) + (z1 * pubkey_a_point)
-    signature_input = [g_y, kfrag_id, pubkey_a_point, pubkey_b_point, u1, ni, xcoord]
+    signature_input = (g_y, kfrag_id, pubkey_a_point, pubkey_b_point, u1, ni, xcoord)
     kfrag_signature1 = CurveBN.hash(*signature_input, params=params)
     valid_kfrag_signature = z1 == kfrag_signature1
 
@@ -129,7 +129,7 @@ def verify_kfrag(kfrag,
     # We check the Schnorr signature over the kfrag components
     g_y = (z2 * params.g) + (z1 * pubkey_a_point)
 
-    signature_input = [g_y, id, pubkey_a_point, pubkey_b_point, u1, ni, xcoord]
+    signature_input = (g_y, id, pubkey_a_point, pubkey_b_point, u1, ni, xcoord)
     valid_kfrag_signature = z1 == CurveBN.hash(*signature_input, params=params)
 
     return correct_commitment & valid_kfrag_signature

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -80,13 +80,15 @@ def assess_cfrag_correctness(cfrag,
     z3 = cfrag.proof._bn_sig
     ########
 
-    xcomp = cfrag._point_noninteractive
+    ni = cfrag._point_noninteractive
+    xcoord = cfrag._point_xcoord
     kfrag_id = cfrag._kfrag_id
 
     g = params.g
 
+    # TODO: change this Schnorr signature for Ed25519 or ECDSA (#97)
     g_y = (z2 * g) + (z1 * pubkey_a_point)
-    signature_input = [g_y, kfrag_id, pubkey_a_point, pubkey_b_point, u1, xcomp]
+    signature_input = [g_y, kfrag_id, pubkey_a_point, pubkey_b_point, u1, ni, xcoord]
     kfrag_signature1 = CurveBN.hash(*signature_input, params=params)
     valid_kfrag_signature = z1 == kfrag_signature1
 
@@ -112,11 +114,14 @@ def verify_kfrag(kfrag,
 
     u = params.u
 
+    id = kfrag._id
+    key = kfrag._bn_key
     u1 = kfrag._point_commitment
     z1 = kfrag._bn_sig1
     z2 = kfrag._bn_sig2
-    x = kfrag._point_noninteractive
-    key = kfrag._bn_key
+    ni = kfrag._point_noninteractive
+    xcoord = kfrag._point_xcoord
+    
 
     #  We check that the commitment u1 is well-formed
     correct_commitment = u1 == key * u
@@ -124,7 +129,7 @@ def verify_kfrag(kfrag,
     # We check the Schnorr signature over the kfrag components
     g_y = (z2 * params.g) + (z1 * pubkey_a_point)
 
-    kfrag_components = [g_y, kfrag._id, pubkey_a_point, pubkey_b_point, u1, x]
-    valid_kfrag_signature = z1 == CurveBN.hash(*kfrag_components, params=params)
+    signature_input = [g_y, id, pubkey_a_point, pubkey_b_point, u1, ni, xcoord]
+    valid_kfrag_signature = z1 == CurveBN.hash(*signature_input, params=params)
 
     return correct_commitment & valid_kfrag_signature

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -81,7 +81,7 @@ def assess_cfrag_correctness(cfrag,
     ########
 
     xcomp = cfrag._point_noninteractive
-    kfrag_id = cfrag._bn_kfrag_id
+    kfrag_id = cfrag._kfrag_id
 
     g = params.g
 
@@ -124,7 +124,7 @@ def verify_kfrag(kfrag,
     # We check the Schnorr signature over the kfrag components
     g_y = (z2 * params.g) + (z1 * pubkey_a_point)
 
-    kfrag_components = [g_y, kfrag._bn_id, pubkey_a_point, pubkey_b_point, u1, x]
+    kfrag_components = [g_y, kfrag._id, pubkey_a_point, pubkey_b_point, u1, x]
     valid_kfrag_signature = z1 == CurveBN.hash(*kfrag_components, params=params)
 
     return correct_commitment & valid_kfrag_signature

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -5,7 +5,6 @@ from umbral.curvebn import CurveBN
 from umbral.config import default_curve, default_params
 from umbral.keys import UmbralPublicKey
 from umbral.point import Point
-from umbral.utils import get_curve_keysize_bytes
 from umbral.params import UmbralParameters
 
 from io import BytesIO
@@ -39,17 +38,18 @@ class KFrag(object):
         Instantiate a KFrag object from the serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = get_curve_keysize_bytes(curve)
+        bn_size = CurveBN.get_size(curve)
+        point_size = Point.get_size(curve)
         data = BytesIO(data)
 
         # CurveBNs are the keysize in bytes, Points are compressed and the
         # keysize + 1 bytes long.
-        id = data.read(key_size)
-        key = CurveBN.from_bytes(data.read(key_size), curve)
-        ni = Point.from_bytes(data.read(key_size + 1), curve)
-        commitment = Point.from_bytes(data.read(key_size + 1), curve)
-        sig1 = CurveBN.from_bytes(data.read(key_size), curve)
-        sig2 = CurveBN.from_bytes(data.read(key_size), curve)
+        id = data.read(bn_size)
+        key = CurveBN.from_bytes(data.read(bn_size), curve)
+        ni = Point.from_bytes(data.read(point_size), curve)
+        commitment = Point.from_bytes(data.read(point_size), curve)
+        sig1 = CurveBN.from_bytes(data.read(bn_size), curve)
+        sig2 = CurveBN.from_bytes(data.read(bn_size), curve)
 
         return cls(id, key, ni, commitment, sig1, sig2)
 
@@ -108,18 +108,19 @@ class CorrectnessProof(object):
         Instantiate CorrectnessProof from serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = get_curve_keysize_bytes(curve)
+        bn_size = CurveBN.get_size(curve)
+        point_size = Point.get_size(curve)
         data = BytesIO(data)
 
         # CurveBNs are the keysize in bytes, Points are compressed and the
         # keysize + 1 bytes long.
-        e2 = Point.from_bytes(data.read(key_size + 1), curve)
-        v2 = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_commitment = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_pok = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_sig1 = CurveBN.from_bytes(data.read(key_size), curve)
-        kfrag_sig2 = CurveBN.from_bytes(data.read(key_size), curve)
-        sig = CurveBN.from_bytes(data.read(key_size), curve)
+        e2 = Point.from_bytes(data.read(point_size), curve)
+        v2 = Point.from_bytes(data.read(point_size), curve)
+        kfrag_commitment = Point.from_bytes(data.read(point_size), curve)
+        kfrag_pok = Point.from_bytes(data.read(point_size), curve)
+        kfrag_sig1 = CurveBN.from_bytes(data.read(bn_size), curve)
+        kfrag_sig2 = CurveBN.from_bytes(data.read(bn_size), curve)
+        sig = CurveBN.from_bytes(data.read(bn_size), curve)
 
         metadata = data.read() or None
 
@@ -182,15 +183,16 @@ class CapsuleFrag(object):
         Instantiates a CapsuleFrag object from the serialized data.
         """
         curve = curve if curve is not None else default_curve()
-        key_size = get_curve_keysize_bytes(curve)
+        bn_size = CurveBN.get_size(curve=curve)
+        point_size = Point.get_size(curve=curve)
         data = BytesIO(data)
 
         # CurveBNs are the keysize in bytes, Points are compressed and the
         # keysize + 1 bytes long.
-        e1 = Point.from_bytes(data.read(key_size + 1), curve)
-        v1 = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_id = data.read(key_size)
-        ni = Point.from_bytes(data.read(key_size + 1), curve)
+        e1 = Point.from_bytes(data.read(point_size), curve)
+        v1 = Point.from_bytes(data.read(point_size), curve)
+        kfrag_id = data.read(bn_size)
+        ni = Point.from_bytes(data.read(point_size), curve)
 
         proof = data.read() or None
         proof = CorrectnessProof.from_bytes(proof, curve) if proof else None

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -12,9 +12,9 @@ from io import BytesIO
 
 
 class KFrag(object):
-    def __init__(self, bn_id, bn_key, point_noninteractive, 
+    def __init__(self, id, bn_key, point_noninteractive, 
                  point_commitment, bn_sig1, bn_sig2):
-        self._bn_id = bn_id
+        self._id = id
         self._bn_key = bn_key
         self._point_noninteractive = point_noninteractive
         self._point_commitment = point_commitment
@@ -44,7 +44,7 @@ class KFrag(object):
 
         # CurveBNs are the keysize in bytes, Points are compressed and the
         # keysize + 1 bytes long.
-        id = CurveBN.from_bytes(data.read(key_size), curve)
+        id = data.read(key_size)
         key = CurveBN.from_bytes(data.read(key_size), curve)
         ni = Point.from_bytes(data.read(key_size + 1), curve)
         commitment = Point.from_bytes(data.read(key_size + 1), curve)
@@ -57,14 +57,13 @@ class KFrag(object):
         """
         Serialize the KFrag into a bytestring.
         """
-        id = self._bn_id.to_bytes()
         key = self._bn_key.to_bytes()
         ni = self._point_noninteractive.to_bytes()
         commitment = self._point_commitment.to_bytes()
         sig1 = self._bn_sig1.to_bytes()
         sig2 = self._bn_sig2.to_bytes()
 
-        return id + key + ni + commitment + sig1 + sig2
+        return self._id + key + ni + commitment + sig1 + sig2
 
     def verify(self, pubkey_a: UmbralPublicKey,
                         pubkey_b: UmbralPublicKey,
@@ -156,11 +155,11 @@ class CorrectnessProof(object):
 
 
 class CapsuleFrag(object):
-    def __init__(self, point_e1, point_v1, bn_kfrag_id, point_noninteractive, 
+    def __init__(self, point_e1, point_v1, kfrag_id, point_noninteractive, 
                  proof: CorrectnessProof=None):
         self._point_e1 = point_e1
         self._point_v1 = point_v1
-        self._bn_kfrag_id = bn_kfrag_id
+        self._kfrag_id = kfrag_id
         self._point_noninteractive = point_noninteractive
         self.proof = proof
 
@@ -190,7 +189,7 @@ class CapsuleFrag(object):
         # keysize + 1 bytes long.
         e1 = Point.from_bytes(data.read(key_size + 1), curve)
         v1 = Point.from_bytes(data.read(key_size + 1), curve)
-        kfrag_id = CurveBN.from_bytes(data.read(key_size), curve)
+        kfrag_id = data.read(key_size)
         ni = Point.from_bytes(data.read(key_size + 1), curve)
 
         proof = data.read() or None
@@ -204,10 +203,9 @@ class CapsuleFrag(object):
         """
         e1 = self._point_e1.to_bytes()
         v1 = self._point_v1.to_bytes()
-        kfrag_id = self._bn_kfrag_id.to_bytes()
         ni = self._point_noninteractive.to_bytes()
 
-        serialized_cfrag = e1 + v1 + kfrag_id + ni
+        serialized_cfrag = e1 + v1 + self._kfrag_id + ni
 
         if self.proof is not None:
             serialized_cfrag += self.proof.to_bytes()

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -12,11 +12,12 @@ from io import BytesIO
 
 class KFrag(object):
     def __init__(self, id, bn_key, point_noninteractive, 
-                 point_commitment, bn_sig1, bn_sig2):
+                 point_commitment, point_xcoord, bn_sig1, bn_sig2):
         self._id = id
         self._bn_key = bn_key
         self._point_noninteractive = point_noninteractive
         self._point_commitment = point_commitment
+        self._point_xcoord = point_xcoord
         self._bn_sig1 = bn_sig1
         self._bn_sig2 = bn_sig2
 
@@ -30,7 +31,7 @@ class KFrag(object):
         bn_size = CurveBN.get_size(curve)
         point_size = Point.get_size(curve)
 
-        return (bn_size * 4) + (point_size * 2)
+        return (bn_size * 4) + (point_size * 3)
 
     @classmethod
     def from_bytes(cls, data: bytes, curve: ec.EllipticCurve = None):
@@ -48,10 +49,11 @@ class KFrag(object):
         key = CurveBN.from_bytes(data.read(bn_size), curve)
         ni = Point.from_bytes(data.read(point_size), curve)
         commitment = Point.from_bytes(data.read(point_size), curve)
+        xcoord = Point.from_bytes(data.read(point_size), curve)
         sig1 = CurveBN.from_bytes(data.read(bn_size), curve)
         sig2 = CurveBN.from_bytes(data.read(bn_size), curve)
 
-        return cls(id, key, ni, commitment, sig1, sig2)
+        return cls(id, key, ni, commitment, xcoord, sig1, sig2)
 
     def to_bytes(self):
         """
@@ -60,10 +62,11 @@ class KFrag(object):
         key = self._bn_key.to_bytes()
         ni = self._point_noninteractive.to_bytes()
         commitment = self._point_commitment.to_bytes()
+        xcoord = self._point_xcoord.to_bytes()
         sig1 = self._bn_sig1.to_bytes()
         sig2 = self._bn_sig2.to_bytes()
 
-        return self._id + key + ni + commitment + sig1 + sig2
+        return self._id + key + ni + commitment + xcoord + sig1 + sig2
 
     def verify(self, pubkey_a: UmbralPublicKey,
                         pubkey_b: UmbralPublicKey,
@@ -151,17 +154,18 @@ class CorrectnessProof(object):
 
         return result
 
-    def __bytes__(self):
+    def _bn_keytes__(self):
         return self.to_bytes()
 
 
 class CapsuleFrag(object):
     def __init__(self, point_e1, point_v1, kfrag_id, point_noninteractive, 
-                 proof: CorrectnessProof=None):
+                 point_xcoord, proof: CorrectnessProof=None):
         self._point_e1 = point_e1
         self._point_v1 = point_v1
         self._kfrag_id = kfrag_id
         self._point_noninteractive = point_noninteractive
+        self._point_xcoord = point_xcoord
         self.proof = proof
 
     @classmethod
@@ -175,7 +179,7 @@ class CapsuleFrag(object):
         bn_size = CurveBN.get_size(curve)
         point_size = Point.get_size(curve)
 
-        return (bn_size * 1) + (point_size * 3)
+        return (bn_size * 1) + (point_size * 4)
 
     @classmethod
     def from_bytes(cls, data: bytes, curve: ec.EllipticCurve = None):
@@ -193,11 +197,12 @@ class CapsuleFrag(object):
         v1 = Point.from_bytes(data.read(point_size), curve)
         kfrag_id = data.read(bn_size)
         ni = Point.from_bytes(data.read(point_size), curve)
+        xcoord = Point.from_bytes(data.read(point_size), curve)
 
         proof = data.read() or None
         proof = CorrectnessProof.from_bytes(proof, curve) if proof else None
 
-        return cls(e1, v1, kfrag_id, ni, proof)
+        return cls(e1, v1, kfrag_id, ni, xcoord, proof)
 
     def to_bytes(self):
         """
@@ -206,8 +211,9 @@ class CapsuleFrag(object):
         e1 = self._point_e1.to_bytes()
         v1 = self._point_v1.to_bytes()
         ni = self._point_noninteractive.to_bytes()
+        xcoord = self._point_xcoord.to_bytes()
 
-        serialized_cfrag = e1 + v1 + self._kfrag_id + ni
+        serialized_cfrag = e1 + v1 + self._kfrag_id + ni + xcoord
 
         if self.proof is not None:
             serialized_cfrag += self.proof.to_bytes()

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -277,7 +277,7 @@ def split_rekey(privkey_a_bn: Union[UmbralPrivateKey, CurveBN],
         # TODO: change this Schnorr signature for Ed25519 or ECDSA (#97)
         y = CurveBN.gen_rand(params.curve)
         g_y = y * g
-        signature_input = [g_y, id, pubkey_a_point, pubkey_b_point, u1, ni, xcoord]
+        signature_input = (g_y, id, pubkey_a_point, pubkey_b_point, u1, ni, xcoord)
         z1 = CurveBN.hash(*signature_input, params=params)
         z2 = y - privkey_a_bn * z1
 

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -127,39 +127,45 @@ class Capsule(object):
         return self._point_e_prime, self._point_v_prime, self._point_noninteractive
 
     def _reconstruct_shamirs_secret(self, 
-                                    pub_a: Union[UmbralPublicKey, Point], 
                                     priv_b: Union[UmbralPrivateKey, CurveBN],
                                     params: UmbralParameters=None) -> None:
 
         params = params if params is not None else default_params()
 
-        if isinstance(priv_b, UmbralPrivateKey):
-            priv_b = priv_b.bn_key
-
-        if isinstance(pub_a, UmbralPublicKey):
-            pub_a = pub_a.point_key
-
         g = params.g
-        pub_b = priv_b * g
-        g_ab = priv_b * pub_a
 
-        blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
-        blake2b.update(pub_a.to_bytes())
-        blake2b.update(pub_b.to_bytes())
-        blake2b.update(g_ab.to_bytes())
-        hashed_dh_tuple = blake2b.finalize()
+        if isinstance(priv_b, UmbralPrivateKey):
+            pub_b = priv_b.get_pubkey()
+            priv_b = priv_b.bn_key
+        else:
+            pub_b = priv_b * g
 
         cfrag_0 = self._attached_cfrags[0]
         id_0 = cfrag_0._kfrag_id
-        x_0 = CurveBN.hash(id_0, hashed_dh_tuple, params=params)
+        ni = cfrag_0._point_noninteractive
+        xcoord = cfrag_0._point_xcoord
+
+        dh_xcoord = priv_b * xcoord
+
+        blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
+        blake2b.update(xcoord.to_bytes())
+        blake2b.update(pub_b.to_bytes())
+        blake2b.update(dh_xcoord.to_bytes())
+        hashed_dh_tuple = blake2b.finalize()
+
+        
         if len(self._attached_cfrags) > 1:
             xs = [CurveBN.hash(cfrag._kfrag_id, hashed_dh_tuple, params=params)
                     for cfrag in self._attached_cfrags]
+            x_0 = CurveBN.hash(id_0, hashed_dh_tuple, params=params)
             lambda_0 = lambda_coeff(x_0, xs)
             e = lambda_0 * cfrag_0._point_e1
             v = lambda_0 * cfrag_0._point_v1
 
             for cfrag in self._attached_cfrags[1:]:
+                if (ni, xcoord) != (cfrag._point_noninteractive, cfrag._point_xcoord):
+                    raise ValueError("Attached CFrags are not pairwise consistent")
+
                 x_i = CurveBN.hash(cfrag._kfrag_id, hashed_dh_tuple, params=params)
                 lambda_i = lambda_coeff(x_i, xs)
                 e = e + (lambda_i * cfrag._point_e1)
@@ -170,7 +176,7 @@ class Capsule(object):
 
         self._point_e_prime = e
         self._point_v_prime = v
-        self._point_noninteractive = cfrag_0._point_noninteractive
+        self._point_noninteractive = ni
 
     def __bytes__(self):
         return self.to_bytes()
@@ -205,7 +211,7 @@ class Capsule(object):
         return hash(component_bytes)
 
 
-def split_rekey(priv_a: Union[UmbralPrivateKey, CurveBN],
+def split_rekey(privkey_a_bn: Union[UmbralPrivateKey, CurveBN],
                 pubkey_b_point: Union[UmbralPublicKey, Point],
                 threshold: int, N: int,
                 params: UmbralParameters=None) -> List[KFrag]:
@@ -218,30 +224,42 @@ def split_rekey(priv_a: Union[UmbralPrivateKey, CurveBN],
     """
     params = params if params is not None else default_params()
 
-    if isinstance(priv_a, UmbralPrivateKey):
-        priv_a = priv_a.bn_key
+    g = params.g
+
+    if isinstance(privkey_a_bn, UmbralPrivateKey):
+        pubkey_a_point = privkey_a_bn.get_pubkey().point_key
+        privkey_a_bn = privkey_a_bn.bn_key
+    else:
+        pubkey_a_point = privkey_a_bn * g 
 
     if isinstance(pubkey_b_point, UmbralPublicKey):
         pubkey_b_point = pubkey_b_point.point_key
 
-    g = params.g
-    pubkey_a_point = priv_a * g
+    # 'ni' stands for 'Non Interactive'.
+    # This point is used as an ephemeral public key in a DH key exchange,
+    # and the resulting shared secret 'd' allows to make Umbral non-interactive
+    priv_ni = CurveBN.gen_rand(params.curve)
+    ni = priv_ni * g
+    d = CurveBN.hash(ni, pubkey_b_point, pubkey_b_point * priv_ni, params=params)
 
-    x = CurveBN.gen_rand(params.curve)
-    xcomp = x * g
-    d = CurveBN.hash(xcomp, pubkey_b_point, pubkey_b_point * x, params=params)
-
-    coeffs = [priv_a * (~d)]
+    coeffs = [privkey_a_bn * (~d)]
     coeffs += [CurveBN.gen_rand(params.curve) for _ in range(threshold - 1)]
 
     u = params.u
 
-    g_ab = priv_a * pubkey_b_point
+    # 'xcoord' stands for 'X coordinate'.
+    # This point is used as an ephemeral public key in a DH key exchange,
+    # and the resulting shared secret 'dh_xcoord' contributes to prevent 
+    # reconstruction of the re-encryption key without Bob's intervention
+    priv_xcoord = CurveBN.gen_rand(params.curve)
+    xcoord = priv_xcoord * g
+
+    dh_xcoord = priv_xcoord * pubkey_b_point
 
     blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
-    blake2b.update(pubkey_a_point.to_bytes())
+    blake2b.update(xcoord.to_bytes())
     blake2b.update(pubkey_b_point.to_bytes())
-    blake2b.update(g_ab.to_bytes())
+    blake2b.update(dh_xcoord.to_bytes())
     hashed_dh_tuple = blake2b.finalize()
 
     bn_size = CurveBN.get_size(params.curve)
@@ -255,15 +273,17 @@ def split_rekey(priv_a: Union[UmbralPrivateKey, CurveBN],
         rk = poly_eval(coeffs, share_x)
 
         u1 = rk * u
-        y = CurveBN.gen_rand(params.curve)
 
-        signature_input = [y * g, id, pubkey_a_point, pubkey_b_point, u1, xcomp]
+        # TODO: change this Schnorr signature for Ed25519 or ECDSA (#97)
+        y = CurveBN.gen_rand(params.curve)
+        g_y = y * g
+        signature_input = [g_y, id, pubkey_a_point, pubkey_b_point, u1, ni, xcoord]
         z1 = CurveBN.hash(*signature_input, params=params)
-        z2 = y - priv_a * z1
+        z2 = y - privkey_a_bn * z1
 
         kfrag = KFrag(id=id, bn_key=rk, 
-                      point_noninteractive=xcomp, point_commitment=u1, 
-                      bn_sig1=z1, bn_sig2=z2)
+                      point_noninteractive=ni, point_commitment=u1, 
+                      point_xcoord=xcoord, bn_sig1=z1, bn_sig2=z2)
         kfrags.append(kfrag)
 
     return kfrags
@@ -277,11 +297,13 @@ def reencrypt(kfrag: KFrag, capsule: Capsule, params: UmbralParameters=None,
     if not capsule.verify(params):
         raise capsule.NotValid
 
-    e1 = kfrag._bn_key * capsule._point_e
-    v1 = kfrag._bn_key * capsule._point_v
+    rk = kfrag._bn_key
+    e1 = rk * capsule._point_e
+    v1 = rk * capsule._point_v
 
     cfrag = CapsuleFrag(point_e1=e1, point_v1=v1, kfrag_id=kfrag._id, 
-                        point_noninteractive=kfrag._point_noninteractive)
+                        point_noninteractive=kfrag._point_noninteractive,
+                        point_xcoord=kfrag._point_xcoord)
 
     if provide_proof:
         prove_cfrag_correctness(cfrag, kfrag, capsule, metadata, params)
@@ -335,8 +357,8 @@ def _decapsulate_reencrypted(pub_key: Point, priv_key: CurveBN,
     """Derive the same symmetric key"""
     params = params if params is not None else default_params()
 
-    xcomp = capsule._point_noninteractive
-    d = CurveBN.hash(xcomp, pub_key, priv_key * xcomp, params=params)
+    ni = capsule._point_noninteractive
+    d = CurveBN.hash(ni, pub_key, priv_key * ni, params=params)
 
     e_prime = capsule._point_e_prime
     v_prime = capsule._point_v_prime
@@ -402,7 +424,7 @@ def _open_capsule(capsule: Capsule, bob_privkey: UmbralPrivateKey,
             error_msg = "Decryption error: Some CFrags are not correct"
             raise UmbralCorrectnessError(error_msg, offending_cfrags)
 
-    capsule._reconstruct_shamirs_secret(alice_pubkey.point_key, priv_b, params=params)
+    capsule._reconstruct_shamirs_secret(priv_b, params=params)
 
     key = _decapsulate_reencrypted(bob_pubkey.point_key, priv_b, alice_pubkey.point_key, capsule, params=params)
     return key


### PR DESCRIPTION
Some improvements in `KFrag` and `CapsuleFrag`:
* Change `KFrag._bn_id` from a `CurveBN` type to a byte string (Solves #123), since it's not necessary anymore that this value be a `CurveBN`.
* New ephemeral public key in `KFrags` to use during reconstruction of activated capsule, instead of using Alice's public key. This new ephemeral pk is called `KFrag._point_xcoord`. The motivation of this change is that if Alice's private key is disclosed, this prevents a potential reconstruction of the re-encryption key without using Bob's private key.
* Checks that all attached `cfrags` are consistent with respect to `point_noninteractive` and `point_xcoord`
* Fixes corresponding tests
