### PR TITLE
Add BytestringSplitter to fragments and Capsule classes

### DIFF
--- a/tests/test_capsule/test_capsule_serializers.py
+++ b/tests/test_capsule/test_capsule_serializers.py
@@ -15,7 +15,7 @@ def test_capsule_serialization(alices_keys):
     assert capsule_bytes == capsule_bytes_casted
 
     # A Capsule can be represented as the 98 total bytes of two Points (33 each) and a CurveBN (32).
-    assert len(capsule_bytes) == 33 + 33 + 32 == 98
+    assert len(capsule_bytes) == pre.Capsule.get_size()
 
     new_capsule = pre.Capsule.from_bytes(capsule_bytes)
 
@@ -54,8 +54,7 @@ def test_activated_capsule_serialization(alices_keys, bobs_keys):
     bn_size = CurveBN.get_size(curve)
     point_size = Point.get_size(curve)
 
-    expected_length = (point_size * 3) + (point_size * 2 + bn_size)
-    assert len(rec_capsule_bytes) == expected_length
+    assert len(rec_capsule_bytes) == pre.Capsule.get_size(activated=True)
 
     new_rec_capsule = pre.Capsule.from_bytes(rec_capsule_bytes)
 

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -2,13 +2,11 @@ from bytestring_splitter import BytestringSplitter
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from umbral._pre import assess_cfrag_correctness, verify_kfrag
-from umbral.curvebn import CurveBN
 from umbral.config import default_curve, default_params
+from umbral.curvebn import CurveBN
 from umbral.keys import UmbralPublicKey
-from umbral.point import Point
 from umbral.params import UmbralParameters
-
-from io import BytesIO
+from umbral.point import Point
 
 
 class KFrag(object):
@@ -45,9 +43,13 @@ class KFrag(object):
         point_size = Point.get_size()
 
         splitter = BytestringSplitter(
-            bn_size, (CurveBN, bn_size), (Point, point_size),
-            (Point, point_size), (Point, point_size), (CurveBN, bn_size),
-            (CurveBN, bn_size)
+            bn_size,             # id
+            (CurveBN, bn_size),  # bn_key
+            (Point, point_size), # point_noninteractive
+            (Point, point_size), # point_commitment
+            (Point, point_size), # point_xcoord
+            (CurveBN, bn_size),  # bn_sig1
+            (CurveBN, bn_size)   # bn_sig2
         )
         components = splitter(data)
 
@@ -113,9 +115,13 @@ class CorrectnessProof(object):
         point_size = Point.get_size(curve)
 
         splitter = BytestringSplitter(
-            (Point, point_size), (Point, point_size), (Point, point_size),
-            (Point, point_size), (CurveBN, bn_size), (CurveBN, bn_size),
-            (CurveBN, bn_size)
+            (Point, point_size), # point_e2
+            (Point, point_size), # point_v2
+            (Point, point_size), # point_kfrag_commitment
+            (Point, point_size), # point_kfrag_pok
+            (CurveBN, bn_size),  # bn_kfrag_sig1
+            (CurveBN, bn_size),  # bn_kfrag_sig2
+            (CurveBN, bn_size)   # bn_sig
         )
         components = splitter(data, return_remainder=True)
         metadata = components.pop(-1) or None
@@ -184,8 +190,11 @@ class CapsuleFrag(object):
         point_size = Point.get_size(curve)
 
         splitter = BytestringSplitter(
-            (Point, point_size), (Point, bn_size), (CurveBN, bn_size),
-            (Point, point_size)
+            (Point, point_size), # point_e1
+            (Point, point_size), # point_v1
+            bn_size,             # kfrag_id
+            (Point, point_size), # point_noninteractive
+            (Point, point_size)  # point_xcoord
         )
         components = splitter(data, return_remainder=True)
 

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -63,7 +63,7 @@ class Capsule(object):
         self._attached_cfrags = list()
 
     @classmethod
-    def get_size(cls, curve: ec.EllipticCurve=None):
+    def get_size(cls, curve: ec.EllipticCurve=None, activated=False):
         """
         Returns the size (in bytes) of a Capsule given the curve.
         If no curve is provided, it will use the default curve.
@@ -72,7 +72,10 @@ class Capsule(object):
         bn_size = CurveBN.get_size(curve)
         point_size = Point.get_size(curve)
 
-        return (bn_size * 1) + (point_size * 2)
+        if not activated:
+            return (bn_size * 1) + (point_size * 2)
+        else:
+            return (bn_size * 1) + (point_size * 5)
 
     class NotValid(ValueError):
         """

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -62,6 +62,18 @@ class Capsule(object):
 
         self._attached_cfrags = list()
 
+    @classmethod
+    def get_size(cls, curve: ec.EllipticCurve=None):
+        """
+        Returns the size (in bytes) of a Capsule given the curve.
+        If no curve is provided, it will use the default curve.
+        """
+        curve = curve if curve is not None else default_curve()
+        bn_size = CurveBN.get_size(curve)
+        point_size = Point.get_size(curve)
+
+        return (bn_size * 1) + (point_size * 2)
+
     class NotValid(ValueError):
         """
         raised if the capsule does not pass verification.


### PR DESCRIPTION
# What this does:
1. Adds `BytestringSplitter` to `KFrag`, `CorrectnessProof`, `CapsuleFrag`, and `Capsule`.
2. Adds a `get_size` method to `Capsule` for both activated and unactivated capsules w/ unactivated as the default.
3. Uses `Capsule.get_size` in `test_capsule_serializers`.
4. Resolves #144.