### PR TITLE
Improved Point deserialization

### DIFF
--- a/tests/test_primitives/test_point/test_point_serializers.py
+++ b/tests/test_primitives/test_point/test_point_serializers.py
@@ -34,8 +34,6 @@ def test_generate_random_points():
         assert isinstance(another_point, Point)
         assert point != another_point
 
-
-@pytest.mark.xfail(raises=AttributeError)
 @pytest.mark.parametrize("curve, nid, point_bytes", generate_test_points_bytes())
 def test_bytes_serializers(point_bytes, nid, curve):
 
@@ -47,13 +45,25 @@ def test_bytes_serializers(point_bytes, nid, curve):
 
     assert point_with_nid == point_with_curve
 
-    the_same_point_bytes = point_with_curve.to_bytes(is_compressed=False)
+    the_same_point_bytes = point_with_curve.to_bytes()
     assert point_bytes == the_same_point_bytes
 
-    malformed_point_bytes = point_bytes + b'0x'
-    with pytest.raises(ValueError):
-        _ = Point.from_bytes(malformed_point_bytes)
+    representations = (point_bytes, # Compressed representation
+                       point_with_curve.to_bytes(is_compressed=False)) # Uncompressed
 
+    for point_representation in representations:
+
+        malformed_point_bytes = point_bytes + b'0x'
+        with pytest.raises(ValueError):
+            _ = Point.from_bytes(malformed_point_bytes)
+
+        malformed_point_bytes = point_bytes[1:]
+        with pytest.raises(ValueError):
+            _ = Point.from_bytes(malformed_point_bytes)
+
+        malformed_point_bytes = point_bytes[:-1]
+        with pytest.raises(ValueError):
+            _ = Point.from_bytes(malformed_point_bytes)
 
 @pytest.mark.parametrize("curve, nid, point_affine", generate_test_points_affine())
 def test_affine(point_affine, nid, curve):

--- a/umbral/openssl.py
+++ b/umbral/openssl.py
@@ -53,6 +53,13 @@ def _get_ec_generator_by_curve_nid(curve_nid: int):
 
     return generator
 
+def _get_ec_group_degree(group):
+    """
+    Returns the number of bits needed to represent the order of the finite 
+    field upon the curve is based
+    """
+    return backend._lib.EC_GROUP_get_degree(group) 
+
 
 def _bn_is_on_curve(check_bn, curve_nid: int):
     """

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -6,7 +6,7 @@ from cryptography.exceptions import InternalError
 
 from umbral import openssl
 from umbral.config import default_curve
-from umbral.utils import get_curve_keysize_bytes
+from umbral.utils import get_field_order_size_in_bytes
 
 
 class Point(object):
@@ -26,7 +26,7 @@ class Point(object):
         If no curve is provided, it uses the default curve.
         """
         curve = curve if curve is not None else default_curve()
-        return get_curve_keysize_bytes(curve) + 1
+        return get_field_order_size_in_bytes(curve) + 1
 
     @classmethod
     def gen_rand(cls, curve: ec.EllipticCurve=None):
@@ -101,7 +101,7 @@ class Point(object):
         if data[0] in [2, 3]:
             type_y = data[0] - 2
 
-            if len(data[1:]) > get_curve_keysize_bytes(curve):
+            if len(data[1:]) != get_field_order_size_in_bytes(curve):
                 raise ValueError("X coordinate too large for curve.")
 
             affine_x = CurveBN.from_bytes(data[1:], curve)
@@ -116,9 +116,9 @@ class Point(object):
 
         # Handle uncompressed point
         elif data[0] == 4:
-            key_size = get_curve_keysize_bytes(curve)
-            affine_x = int.from_bytes(data[1:key_size+1], 'big')
-            affine_y = int.from_bytes(data[1+key_size:], 'big')
+            coord_size = get_field_order_size_in_bytes(curve)
+            affine_x = int.from_bytes(data[1:coord_size+1], 'big')
+            affine_y = int.from_bytes(data[1+coord_size:], 'big')
 
             return cls.from_affine((affine_x, affine_y), curve)
         else:

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -3,7 +3,8 @@ import math
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-
+from cryptography.hazmat.primitives.asymmetric import ec
+from umbral import openssl
 
 def lambda_coeff(id_i, selected_ids):
     ids = [x for x in selected_ids if x != id_i]
@@ -42,3 +43,10 @@ def kdf(ecpoint, key_length):
 
 def get_curve_keysize_bytes(curve):
     return (curve.key_size + 7) // 8
+
+def get_field_order_size_in_bytes(curve : ec.EllipticCurve):
+    backend = default_backend()
+    curve_nid = backend._elliptic_curve_to_nid(curve)
+    group = openssl._get_ec_group_by_curve_nid(curve_nid)
+    size_in_bits = openssl._get_ec_group_degree(group)
+    return (size_in_bits + 7) // 8

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -44,9 +44,15 @@ def kdf(ecpoint, key_length):
 def get_curve_keysize_bytes(curve):
     return (curve.key_size + 7) // 8
 
-def get_field_order_size_in_bytes(curve : ec.EllipticCurve):
+def get_field_order_size_in_bytes(curve):
+
     backend = default_backend()
-    curve_nid = backend._elliptic_curve_to_nid(curve)
+    try:
+        curve_nid = backend._elliptic_curve_to_nid(curve)
+    except AttributeError:
+        # Presume that the user passed in the curve_nid
+        curve_nid = curve
+
     group = openssl._get_ec_group_by_curve_nid(curve_nid)
     size_in_bits = openssl._get_ec_group_degree(group)
     return (size_in_bits + 7) // 8


### PR DESCRIPTION
- Introduces `get_ec_group_degree`, a new method in `umbral.openssl` to compute the expected size of serialized Points based on the size of the order of the underlying finite field. Previously we were using the size of the group order, which usually it's the same size, but not necessarily. 
- Improved checks in `Point.from_bytes`: now only bytestrings with the exact possible sizes are accepted.
- Tests for malformed input byte strings to `Point.from_bytes`.
- Fixes the problem in `test_point_serializers.py/test_bytes_serializers`. Previously it was marked as `xfail`. Now all tests in the codebase are a success (hooray! 🎉)