### PR TITLE
Improved test coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,13 @@ parameters = [
     (50, 30)
 ]
 
+wrong_parameters = [
+    # (N, M)
+    (-1, -1),   (-1, 0),    (-1, 5),
+    (0, -1),    (0, 0),     (0, 5),
+    (1, -1),    (1, 0),     (1, 5),
+    (5, -1),    (5, 0),     (5, 10)
+]
 
 @pytest.fixture(scope='function')
 def alices_keys():

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -133,6 +133,7 @@ def test_cheating_ursula_sends_garbage(N, M, alices_keys):
         # Example of potential metadata to describe the re-encryption request
         metadata_i = "This is an example of metadata for re-encryption request #{}"
         metadata_i = metadata_i.format(i).encode()
+        metadata.append(metadata_i)
 
         cfrag = pre.reencrypt(kfrag, capsule_alice, metadata=metadata_i)
 

--- a/tests/test_primitives/test_point/test_point_arithmetic.py
+++ b/tests/test_primitives/test_point/test_point_arithmetic.py
@@ -7,6 +7,7 @@ def test_mocked_openssl_point_arithmetic(mock_openssl, random_ec_point1, random_
     operations_that_construct = (
         random_ec_point1 * random_ec_curvebn1,  # __mul__
         random_ec_point1 + random_ec_point2,   # __add__
+        random_ec_point1 - random_ec_point2,   # __sub__
         ~random_ec_point1                      # __invert__
     )
 

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -8,7 +8,7 @@ from umbral.config import default_curve
 from umbral.params import UmbralParameters
 from umbral.signing import Signer
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
-from .conftest import parameters
+from .conftest import parameters, wrong_parameters
 
 secp_curves = [
     ec.SECP384R1,
@@ -179,3 +179,8 @@ def test_public_key_encryption(alices_keys):
     ciphertext, capsule = pre.encrypt(delegating_privkey.get_pubkey(), plain_data)
     cleartext = pre.decrypt(ciphertext, capsule, delegating_privkey)
     assert cleartext == plain_data
+
+@pytest.mark.parametrize("N, M", wrong_parameters)
+def test_wrong_N_M_in_split_rekey(N, M):
+    with pytest.raises(ValueError):
+        test_simple_api(N, M)

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -283,6 +283,9 @@ def split_rekey(delegating_privkey: UmbralPrivateKey, signer: Signer,
     Returns a list of KFrags.
     """
 
+    if threshold <= 0 or threshold > N:
+        raise ValueError('Arguments threshold and N must satisfy 0 < threshold <= N')
+
     if delegating_privkey.params != receiving_pubkey.params:
         raise ValueError("Keys must have the same parameter set.")
 


### PR DESCRIPTION
## What this does: ##
- Includes the tests in the coverage report. There were some missing lines in the tests due to bugs in the definition of the tests. 
- Improves the coverage of the `umbral` module.
   - Test for reconstruction of activated capsule with consistent CFrags
   - Test for `Point.__sub__`
- Includes a check of `M` and `N` in `pre.split_rekey`.