### PR TITLE
Add unfree'd OpenSSL structs to ffi garbage collector

### DIFF
--- a/umbral/openssl.py
+++ b/umbral/openssl.py
@@ -50,6 +50,7 @@ def _get_ec_generator_by_curve_nid(curve_nid: int):
 
     generator = backend._lib.EC_GROUP_get0_generator(ec_group)
     backend.openssl_assert(generator != backend._ffi.NULL)
+    generator = backend._ffi.gc(generator, backend._lib.EC_POINT_clear_free)
 
     return generator
 

--- a/umbral/openssl.py
+++ b/umbral/openssl.py
@@ -63,7 +63,10 @@ def _bn_is_on_curve(check_bn, curve_nid: int):
     """
     ec_order = _get_ec_order_by_curve_nid(curve_nid)
 
-    check_sign = backend._lib.BN_cmp(check_bn, backend._int_to_bn(0))
+    zero = backend._int_to_bn(0)
+    zero = backend._ffi.gc(zero, backend._lib.BN_clear_free)
+
+    check_sign = backend._lib.BN_cmp(check_bn, zero)
     range_check = backend._lib.BN_cmp(check_bn, ec_order)
     return check_sign == 1 and range_check == -1
 


### PR DESCRIPTION
### What this does:
1. Adds the `EC_POINT` returned in `openssl._get_ec_generator_by_curve_nid` to the ffi garbage collector with `EC_POINT_clear_free`.
2. Adds the `BIGNUM` used to compare a value to zero in `openssl._bn_is_on_curve` to the ffi garbage collector with `BN_clear_free`.