### PR TITLE
Renaming keypairs

### DIFF
--- a/tests/test_capsule/test_capsule_correctness_checks.py
+++ b/tests/test_capsule/test_capsule_correctness_checks.py
@@ -74,9 +74,9 @@ def test_cannot_attach_cfrag_without_proof():
         UmbralPrivateKey.gen_key().get_pubkey(),
         UmbralPrivateKey.gen_key().get_pubkey())
 
-    delegating_details, encrypting_details, verifying_details = key_details
+    delegating_details, receiving_details, verifying_details = key_details
 
-    assert all((delegating_details, encrypting_details, verifying_details))
+    assert all((delegating_details, receiving_details, verifying_details))
 
     with pytest.raises(cfrag.NoProofProvided):
         capsule.attach_cfrag(cfrag)
@@ -91,14 +91,14 @@ def test_cannot_set_different_keys():
                       bn_sig=CurveBN.gen_rand())
 
     capsule.set_correctness_keys(delegating=UmbralPrivateKey.gen_key().get_pubkey(),
-                                 encrypting=UmbralPrivateKey.gen_key().get_pubkey(),
+                                 receiving=UmbralPrivateKey.gen_key().get_pubkey(),
                                  verifying=UmbralPrivateKey.gen_key().get_pubkey())
 
     with pytest.raises(ValueError):
         capsule.set_correctness_keys(delegating=UmbralPrivateKey.gen_key().get_pubkey())
 
     with pytest.raises(ValueError):
-        capsule.set_correctness_keys(encrypting=UmbralPrivateKey.gen_key().get_pubkey())
+        capsule.set_correctness_keys(receiving=UmbralPrivateKey.gen_key().get_pubkey())
 
     with pytest.raises(ValueError):
         capsule.set_correctness_keys(verifying=UmbralPrivateKey.gen_key().get_pubkey())

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -51,7 +51,7 @@ def test_cheating_ursula_replays_old_reencryption(N, M, alices_keys):
     sym_key_alice2, capsule_alice2 = pre._encapsulate(delegating_privkey.get_pubkey().point_key)
 
     capsule_alice1.set_correctness_keys(delegating=delegating_privkey.get_pubkey(),
-                                        encrypting=pub_key_bob,
+                                        receiving=pub_key_bob,
                                         verifying=signing_privkey.get_pubkey())
 
     kfrags = pre.split_rekey(delegating_privkey, signer, pub_key_bob, M, N)
@@ -128,7 +128,7 @@ def test_cheating_ursula_sends_garbage(N, M, alices_keys):
     sym_key, capsule_alice = pre._encapsulate(delegating_privkey.get_pubkey().point_key)
 
     capsule_alice.set_correctness_keys(delegating=delegating_privkey.get_pubkey(),
-                                       encrypting=pub_key_bob,
+                                       receiving=pub_key_bob,
                                        verifying=signing_privkey.get_pubkey())
 
     kfrags = pre.split_rekey(delegating_privkey, signer, pub_key_bob, M, N)
@@ -193,7 +193,7 @@ def test_decryption_fails_when_it_expects_a_proof_and_there_isnt(N, M, alices_ke
     ciphertext, capsule = pre.encrypt(delegating_privkey.get_pubkey(), plain_data)
 
     capsule.set_correctness_keys(delegating=delegating_privkey.get_pubkey(),
-                                 encrypting=pub_key_bob,
+                                 receiving=pub_key_bob,
                                  verifying=signing_privkey.get_pubkey())
 
     kfrags = pre.split_rekey(delegating_privkey, signer, pub_key_bob, M, N)
@@ -222,7 +222,7 @@ def test_m_of_n(N, M, alices_keys, bobs_keys):
     sym_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key)
 
     capsule.set_correctness_keys(delegating=delegating_privkey.get_pubkey(),
-                                 encrypting=pub_key_bob,
+                                 receiving=pub_key_bob,
                                  verifying=signing_privkey.get_pubkey())
 
     kfrags = pre.split_rekey(delegating_privkey, signer, pub_key_bob, M, N)

--- a/tests/test_keys/test_key_fragments.py
+++ b/tests/test_keys/test_key_fragments.py
@@ -4,13 +4,14 @@ from umbral.fragments import KFrag, CapsuleFrag
 from umbral.signing import Signer
 
 
-def test_kfrag_serialization(alices_keys):
+def test_kfrag_serialization(alices_keys, bobs_keys):
     delegating_privkey, signing_privkey = alices_keys
     signer_alice = Signer(signing_privkey)
+    _receiving_privkey, receiving_pubkey = bobs_keys
 
     kfrags = pre.split_rekey(delegating_privkey,
                              signer_alice,
-                             delegating_privkey.get_pubkey(), 1, 2)
+                             receiving_pubkey, 1, 2)
     kfrag_bytes = kfrags[0].to_bytes()
 
     curve = default_curve()
@@ -24,13 +25,16 @@ def test_kfrag_serialization(alices_keys):
     assert new_frag._point_xcoord == kfrags[0]._point_xcoord
 
 
-def test_cfrag_serialization_with_proof_and_metadata(alices_keys):
+def test_cfrag_serialization_with_proof_and_metadata(alices_keys, bobs_keys):
     delegating_privkey, signing_privkey = alices_keys
+    delegating_pubkey = delegating_privkey.get_pubkey()
     signer_alice = Signer(signing_privkey)
+    _receiving_privkey, receiving_pubkey = bobs_keys
 
-    _unused_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key)
+
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
-                             delegating_privkey.get_pubkey(), 1, 2)
+                             receiving_pubkey, 1, 2)
 
     # Example of potential metadata to describe the re-encryption request
     metadata = b'This is an example of metadata for re-encryption request'
@@ -59,13 +63,16 @@ def test_cfrag_serialization_with_proof_and_metadata(alices_keys):
     assert new_proof.metadata == proof.metadata
 
 
-def test_cfrag_serialization_with_proof_but_no_metadata(alices_keys):
+def test_cfrag_serialization_with_proof_but_no_metadata(alices_keys, bobs_keys):
     delegating_privkey, signing_privkey = alices_keys
+    delegating_pubkey = delegating_privkey.get_pubkey()
+
+    _receiving_privkey, receiving_pubkey = bobs_keys
     signer_alice = Signer(signing_privkey)
 
-    _unused_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
-                             delegating_privkey.get_pubkey(), 1, 2)
+                             receiving_pubkey, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule, provide_proof=True)
     cfrag_bytes = cfrag.to_bytes()
@@ -94,13 +101,16 @@ def test_cfrag_serialization_with_proof_but_no_metadata(alices_keys):
     assert new_proof.metadata is None
 
 
-def test_cfrag_serialization_no_proof_no_metadata(alices_keys):
+def test_cfrag_serialization_no_proof_no_metadata(alices_keys, bobs_keys):
     delegating_privkey, signing_privkey = alices_keys
+    delegating_pubkey = delegating_privkey.get_pubkey()
+
+    _receiving_privkey, receiving_pubkey = bobs_keys
     signer_alice = Signer(signing_privkey)
 
-    _unused_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
-                             delegating_privkey.get_pubkey(), 1, 2)
+                             receiving_pubkey, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule, provide_proof=False)
     cfrag_bytes = cfrag.to_bytes()

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -15,32 +15,36 @@ secp_curves = [
 
 
 @pytest.mark.parametrize("N, M", parameters)
-def test_simple_api(alices_keys, N, M, curve=default_curve()):
+def test_simple_api(alices_keys, bobs_keys, N, M, curve=default_curve()):
     """Manually injects umbralparameters for multi-curve testing."""
 
     params = UmbralParameters(curve=curve)
 
     delegating_privkey, signing_privkey = alices_keys
-    decrypting_key = keys.UmbralPrivateKey.gen_key(params=params)
+    delegating_pubkey = delegating_privkey.get_pubkey()
+    signing_pubkey = signing_privkey.get_pubkey()
+
+    receiving_privkey, receiving_pubkey = bobs_keys
     signer = Signer(signing_privkey)
 
     plain_data = b'peace at dawn'
-    ciphertext, capsule = pre.encrypt(delegating_privkey.get_pubkey(), plain_data, params=params)
-
-    capsule.set_correctness_keys(delegating=delegating_privkey.get_pubkey(),
-                     encrypting=decrypting_key.get_pubkey(),
-                     verifying=signing_privkey.get_pubkey())
+    ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data, params=params)
 
     cleartext = pre.decrypt(ciphertext, capsule, delegating_privkey, params=params)
     assert cleartext == plain_data
 
-    kfrags = pre.split_rekey(delegating_privkey, signer, decrypting_key.get_pubkey(), M, N, params=params)
+    capsule.set_correctness_keys(delegating=delegating_pubkey,
+                                 receiving=receiving_pubkey,
+                                 verifying=signing_pubkey)
+
+    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, M, N, params=params)
+
     for kfrag in kfrags:
         cfrag = pre.reencrypt(kfrag, capsule, params=params)
         capsule.attach_cfrag(cfrag)
 
-    reenc_cleartext = pre.decrypt(ciphertext, capsule, decrypting_key,
-                                  delegating_privkey.get_pubkey(), signing_privkey.get_pubkey(),
+    reenc_cleartext = pre.decrypt(ciphertext, capsule, receiving_privkey,
+                                  delegating_pubkey, signing_pubkey,
                                   params=params)
     assert reenc_cleartext == plain_data
 
@@ -49,8 +53,16 @@ def test_simple_api(alices_keys, N, M, curve=default_curve()):
 @pytest.mark.parametrize("N, M", parameters)
 def test_simple_api_on_multiple_curves(N, M, curve):
     params = UmbralParameters(curve=curve)
-    alices_keys = keys.UmbralPrivateKey.gen_key(params=params), keys.UmbralPrivateKey.gen_key(params=params)
-    test_simple_api(alices_keys, N, M, curve)
+
+    delegating_privkey = keys.UmbralPrivateKey.gen_key(params=params)
+    signing_privkey = keys.UmbralPrivateKey.gen_key(params=params)
+    alices_keys = delegating_privkey, signing_privkey
+
+    receiving_privkey = keys.UmbralPrivateKey.gen_key(params=params)
+    receiving_pubkey = receiving_privkey.get_pubkey()
+    bobs_keys = receiving_privkey, receiving_pubkey
+    
+    test_simple_api(alices_keys, bobs_keys, N, M, curve)
 
 
 def test_public_key_encryption(alices_keys):

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -50,7 +50,7 @@ def assess_cfrag_correctness(cfrag,
                              capsule: "Capsule",
                              delegating_point,
                              signing_pubkey,
-                             encrypting_point,
+                             receiving_point,
                              params: UmbralParameters = None):
     params = params if params is not None else default_params()
 
@@ -87,7 +87,7 @@ def assess_cfrag_correctness(cfrag,
     kfrag_id = cfrag._kfrag_id
 
     kfrag_validity_message = bytes().join(
-        bytes(material) for material in (kfrag_id, delegating_point, encrypting_point, u1, ni, xcoord))
+        bytes(material) for material in (kfrag_id, delegating_point, receiving_point, u1, ni, xcoord))
     valid_kfrag_signature = cfrag.proof.kfrag_signature.verify(kfrag_validity_message, signing_pubkey)
 
     z3 = cfrag.proof.bn_sig
@@ -106,7 +106,7 @@ def assess_cfrag_correctness(cfrag,
 def verify_kfrag(kfrag,
                  delegating_point,
                  signing_pubkey,
-                 encrypting_point,
+                 receiving_point,
                  params: UmbralParameters = None
                  ):
     params = params if params is not None else default_params()
@@ -123,7 +123,7 @@ def verify_kfrag(kfrag,
     correct_commitment = u1 == key * u
 
     kfrag_validity_message = bytes().join(
-        bytes(material) for material in (id, delegating_point, encrypting_point, u1, ni, xcoord))
+        bytes(material) for material in (id, delegating_point, receiving_point, u1, ni, xcoord))
     valid_kfrag_signature = kfrag.signature.verify(kfrag_validity_message, signing_pubkey)
 
     return correct_commitment & valid_kfrag_signature

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -70,13 +70,13 @@ class KFrag(object):
     def verify(self,
                signing_pubkey: UmbralPublicKey,
                delegating_pubkey: UmbralPublicKey,
-               encrypting_pubkey: UmbralPublicKey,
+               receiving_pubkey: UmbralPublicKey,
                params: UmbralParameters = None):
 
         return verify_kfrag(self,
                             delegating_pubkey.point_key,
                             signing_pubkey,
-                            encrypting_pubkey.point_key,
+                            receiving_pubkey.point_key,
                             params)
 
     def __bytes__(self):
@@ -223,13 +223,13 @@ class CapsuleFrag(object):
                            capsule: "Capsule",
                            delegating_pubkey: UmbralPublicKey,
                            signing_pubkey: UmbralPublicKey,
-                           encrypting_pubkey: UmbralPublicKey,
+                           receiving_pubkey: UmbralPublicKey,
                            params: UmbralParameters = None):
-        if not all((delegating_pubkey, signing_pubkey, encrypting_pubkey)):
+        if not all((delegating_pubkey, signing_pubkey, receiving_pubkey)):
             raise TypeError("Need all three keys to verify correctness.")
 
         pubkey_a_point = delegating_pubkey.point_key
-        pubkey_b_point = encrypting_pubkey.point_key
+        pubkey_b_point = receiving_pubkey.point_key
 
         return assess_cfrag_correctness(self, capsule, pubkey_a_point,
                                         signing_pubkey, pubkey_b_point, params)

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -29,7 +29,7 @@ class UmbralPrivateKey(object):
 
         self.params = params
         self.bn_key = bn_key
-        self.pubkey = UmbralPublicKey(self.bn_key * self.params.g)
+        self.pubkey = UmbralPublicKey(self.bn_key * self.params.g, params=params)
 
     @classmethod
     def gen_key(cls, params: UmbralParameters=None):

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -119,18 +119,21 @@ class Capsule(object):
         return cls(*components)
 
     def _set_cfrag_correctness_key(self, key_type, key: UmbralPublicKey):
+        if key_type not in ("delegating", "receiving", "verifying"): 
+            raise ValueError("You can only set 'delegating', 'receiving' or 'verifying' keys.") 
+
         current_key = self._cfrag_correctness_keys[key_type]
 
         if current_key is None:
             if key is None:
-                raise TypeError("The Delegating Key is not set and you didn't pass one.")
+                raise TypeError("The {} key is not set and you didn't pass one.".format(key_type))
             else:
                 self._cfrag_correctness_keys[key_type] = key
                 return True
-        elif key in (None, self._cfrag_correctness_keys[key_type]):
+        elif key in (None, current_key):
             return False
         else:
-            raise ValueError("The Delegating Key is already set; you can't set it again.")
+            raise ValueError("The {} key is already set; you can't set it again.".format(key_type))
 
     def set_correctness_keys(self,
                  delegating: UmbralPublicKey = None,


### PR DESCRIPTION
## What this does ##

- Renaming of keypairs and associated keys to follow the new standard (delegating, receiving, verifying)
- Fixes some weird test patterns, where `pre.split_rekey` is used from Alice to Alice.
- Inserts a check in `Capsule._set_cfrag_correctness_key` to allow only public keys associated to delegating, receiving, or verifying.
- Fixes a bug in `UmbralPrivateKey`, in the generation of the associated public key, which was created with the default params. This produced problems when used with curves other than default.
