### PR TITLE
Simplified API

### DIFF
--- a/tests/test_capsule/test_capsule_correctness_checks.py
+++ b/tests/test_capsule/test_capsule_correctness_checks.py
@@ -9,6 +9,7 @@ from umbral.keys import UmbralPrivateKey
 from umbral.point import Point
 from umbral.pre import Capsule
 from umbral.signing import Signer
+from umbral.config import default_params
 
 
 def test_cannot_attach_cfrag_without_keys():
@@ -16,7 +17,11 @@ def test_cannot_attach_cfrag_without_keys():
     We need the proper keys to verify the correctness of CFrags
     in order to attach them to a Capsule.
     """
-    capsule = Capsule(point_e=Point.gen_rand(),
+
+    params = default_params()
+
+    capsule = Capsule(params,
+                      point_e=Point.gen_rand(),
                       point_v=Point.gen_rand(),
                       bn_sig=CurveBN.gen_rand())
 
@@ -59,7 +64,10 @@ def test_cannot_attach_cfrag_without_proof():
     However, even when properly attaching keys, we can't attach the CFrag
     if it is unproven.
     """
-    capsule = Capsule(point_e=Point.gen_rand(),
+    params = default_params()
+
+    capsule = Capsule(params,
+                      point_e=Point.gen_rand(),
                       point_v=Point.gen_rand(),
                       bn_sig=CurveBN.gen_rand())
 
@@ -86,7 +94,10 @@ def test_cannot_set_different_keys():
     """
     Once a key is set on a Capsule, it can't be changed to a different key.
     """
-    capsule = Capsule(point_e=Point.gen_rand(),
+    params = default_params()
+
+    capsule = Capsule(params,
+                      point_e=Point.gen_rand(),
                       point_v=Point.gen_rand(),
                       bn_sig=CurveBN.gen_rand())
 

--- a/tests/test_capsule/test_capsule_operations.py
+++ b/tests/test_capsule/test_capsule_operations.py
@@ -62,11 +62,11 @@ def test_decapsulation_by_alice(alices_keys):
 
     delegating_privkey, _signing_privkey = alices_keys
 
-    sym_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key, params)
+    sym_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey())
     assert len(sym_key) == 32
 
     # The symmetric key sym_key is perhaps used for block cipher here in a real-world scenario.
-    sym_key_2 = pre._decapsulate_original(delegating_privkey.bn_key, capsule)
+    sym_key_2 = pre._decapsulate_original(delegating_privkey, capsule)
     assert sym_key_2 == sym_key
 
 
@@ -115,8 +115,7 @@ def test_capsule_as_dict_key(alices_keys, bobs_keys):
     capsule.attach_cfrag(cfrag)
 
     # Even if we activate the capsule, it still serves as the same key.
-    cleartext = pre.decrypt(ciphertext, capsule, receiving_privkey,
-                            delegating_pubkey, signing_pubkey)
+    cleartext = pre.decrypt(ciphertext, capsule, receiving_privkey)
     assert some_dict[capsule] == "Thing that Bob wants to try per-Capsule"
     assert cleartext == plain_data
 
@@ -132,13 +131,13 @@ def test_capsule_length(alices_keys, bobs_keys):
 
     priv_key_bob, pub_key_bob = bobs_keys
 
-    sym_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key)
+    sym_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey())
+
+    kfrags = pre.split_rekey(delegating_privkey, signer, pub_key_bob, 10, 15)
 
     capsule.set_correctness_keys(delegating=delegating_privkey.get_pubkey(),
                                  receiving=pub_key_bob,
                                  verifying=signing_privkey.get_pubkey())
-
-    kfrags = pre.split_rekey(delegating_privkey, signer, pub_key_bob, 10, 15)
 
     for counter, kfrag in enumerate(kfrags):
         assert len(capsule) == counter

--- a/tests/test_capsule/test_capsule_operations.py
+++ b/tests/test_capsule/test_capsule_operations.py
@@ -6,14 +6,21 @@ from umbral.point import Point
 from umbral.pre import Capsule
 from umbral.signing import Signer
 from umbral.keys import UmbralPrivateKey
+from umbral.config import default_params
 
 
 def test_capsule_creation(alices_keys):
+
+    params = default_params()
+
     with pytest.raises(TypeError):
-        rare_capsule = Capsule()  # Alice cannot make a capsule this way.
+        rare_capsule = Capsule(params)  # Alice cannot make a capsule this way.
+
+
 
     # Some users may create capsules their own way.
-    custom_capsule = Capsule(point_e=Point.gen_rand(),
+    custom_capsule = Capsule(params,
+                             point_e=Point.gen_rand(),
                              point_v=Point.gen_rand(),
                              bn_sig=CurveBN.gen_rand())
 
@@ -28,17 +35,22 @@ def test_capsule_creation(alices_keys):
 
 
 def test_capsule_equality():
-    one_capsule = Capsule(point_e=Point.gen_rand(),
+    params = default_params()
+
+    one_capsule = Capsule(params,
+                          point_e=Point.gen_rand(),
                           point_v=Point.gen_rand(),
                           bn_sig=CurveBN.gen_rand())
 
-    another_capsule = Capsule(point_e=Point.gen_rand(),
+    another_capsule = Capsule(params,
+                              point_e=Point.gen_rand(),
                               point_v=Point.gen_rand(),
                               bn_sig=CurveBN.gen_rand())
 
     assert one_capsule != another_capsule
 
-    activated_capsule = Capsule(point_e_prime=Point.gen_rand(),
+    activated_capsule = Capsule(params,
+                                point_e_prime=Point.gen_rand(),
                                 point_v_prime=Point.gen_rand(),
                                 point_noninteractive=Point.gen_rand())
 
@@ -46,9 +58,11 @@ def test_capsule_equality():
 
 
 def test_decapsulation_by_alice(alices_keys):
+    params = default_params()
+
     delegating_privkey, _signing_privkey = alices_keys
 
-    sym_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key)
+    sym_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key, params)
     assert len(sym_key) == 32
 
     # The symmetric key sym_key is perhaps used for block cipher here in a real-world scenario.
@@ -57,6 +71,7 @@ def test_decapsulation_by_alice(alices_keys):
 
 
 def test_bad_capsule_fails_reencryption(alices_keys, bobs_keys):
+    params = default_params()
     delegating_privkey, _signing_privkey = alices_keys
     signer_alice = Signer(_signing_privkey)
 
@@ -64,7 +79,8 @@ def test_bad_capsule_fails_reencryption(alices_keys, bobs_keys):
 
     kfrags = pre.split_rekey(delegating_privkey, signer_alice, receiving_pubkey, 1, 2)
 
-    bollocks_capsule = Capsule(point_e=Point.gen_rand(),
+    bollocks_capsule = Capsule(params,
+                               point_e=Point.gen_rand(),
                                point_v=Point.gen_rand(),
                                bn_sig=CurveBN.gen_rand())
 

--- a/tests/test_capsule/test_capsule_serializers.py
+++ b/tests/test_capsule/test_capsule_serializers.py
@@ -11,7 +11,7 @@ def test_capsule_serialization(alices_keys):
     delegating_privkey, _signing_privkey = alices_keys
     params = delegating_privkey.params
 
-    _symmetric_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key, params)
+    _symmetric_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey())
     capsule_bytes = capsule.to_bytes()
     capsule_bytes_casted = bytes(capsule)
     assert capsule_bytes == capsule_bytes_casted
@@ -44,16 +44,17 @@ def test_activated_capsule_serialization(alices_keys, bobs_keys):
 
     receiving_privkey, receiving_pubkey = bobs_keys
 
-    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key, params)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey)
 
-    capsule.set_correctness_keys(delegating=delegating_pubkey,
-                                 receiving=receiving_pubkey,
-                                 verifying=signing_privkey.get_pubkey())
-
+    
     kfrags = pre.split_rekey(delegating_privkey, signer_alice, receiving_pubkey, 1, 2)
 
     cfrag = pre.reencrypt(kfrags[0], capsule)
 
+    capsule.set_correctness_keys(delegating=delegating_pubkey,
+                                 receiving=receiving_pubkey,
+                                 verifying=signing_privkey.get_pubkey())
+    
     capsule.attach_cfrag(cfrag)
 
     capsule._reconstruct_shamirs_secret(receiving_privkey)

--- a/tests/test_capsule/test_capsule_serializers.py
+++ b/tests/test_capsule/test_capsule_serializers.py
@@ -3,14 +3,15 @@ import pytest
 from umbral import pre, keys
 from umbral.curvebn import CurveBN
 from umbral.point import Point
-from umbral.config import default_curve
+from umbral.config import default_curve, default_params
 from umbral.signing import Signer
 
 
 def test_capsule_serialization(alices_keys):
     delegating_privkey, _signing_privkey = alices_keys
+    params = delegating_privkey.params
 
-    _symmetric_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key)
+    _symmetric_key, capsule = pre._encapsulate(delegating_privkey.get_pubkey().point_key, params)
     capsule_bytes = capsule.to_bytes()
     capsule_bytes_casted = bytes(capsule)
     assert capsule_bytes == capsule_bytes_casted
@@ -18,7 +19,7 @@ def test_capsule_serialization(alices_keys):
     # A Capsule can be represented as the 98 total bytes of two Points (33 each) and a CurveBN (32).
     assert len(capsule_bytes) == pre.Capsule.expected_bytes_length()
 
-    new_capsule = pre.Capsule.from_bytes(capsule_bytes)
+    new_capsule = pre.Capsule.from_bytes(capsule_bytes, params)
 
     # Three ways to think about equality.
     # First, the public approach for the Capsule.  Simply:
@@ -39,9 +40,11 @@ def test_activated_capsule_serialization(alices_keys, bobs_keys):
     delegating_pubkey = delegating_privkey.get_pubkey()
     signer_alice = Signer(signing_privkey)
 
+    params = delegating_privkey.params
+
     receiving_privkey, receiving_pubkey = bobs_keys
 
-    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key, params)
 
     capsule.set_correctness_keys(delegating=delegating_pubkey,
                                  receiving=receiving_pubkey,
@@ -58,7 +61,7 @@ def test_activated_capsule_serialization(alices_keys, bobs_keys):
 
     assert len(rec_capsule_bytes) == pre.Capsule.expected_bytes_length(activated=True)
 
-    new_rec_capsule = pre.Capsule.from_bytes(rec_capsule_bytes)
+    new_rec_capsule = pre.Capsule.from_bytes(rec_capsule_bytes, params)
 
     # Again, the same three perspectives on equality.
     assert new_rec_capsule == capsule
@@ -71,22 +74,28 @@ def test_activated_capsule_serialization(alices_keys, bobs_keys):
 
 
 def test_cannot_create_capsule_from_bogus_material(alices_keys):
+    params = alices_keys[0].params
+    
     with pytest.raises(TypeError):
-        capsule_of_questionable_parentage = pre.Capsule(point_e=Point.gen_rand(),
+        capsule_of_questionable_parentage = pre.Capsule(params,
+                                                        point_e=Point.gen_rand(),
                                                         point_v=42,
                                                         bn_sig=CurveBN.gen_rand())
 
     with pytest.raises(TypeError):
-        capsule_of_questionable_parentage = pre.Capsule(point_e=Point.gen_rand(),
+        capsule_of_questionable_parentage = pre.Capsule(params,
+                                                        point_e=Point.gen_rand(),
                                                         point_v=Point.gen_rand(),
                                                         bn_sig=42)
 
     with pytest.raises(TypeError):
-        capsule_of_questionable_parentage = pre.Capsule(point_e_prime=Point.gen_rand(),
+        capsule_of_questionable_parentage = pre.Capsule(params,
+                                                        point_e_prime=Point.gen_rand(),
                                                         point_v_prime=42,
                                                         point_noninteractive=Point.gen_rand())
 
     with pytest.raises(TypeError):
-        capsule_of_questionable_parentage = pre.Capsule(point_e_prime=Point.gen_rand(),
+        capsule_of_questionable_parentage = pre.Capsule(params,
+                                                        point_e_prime=Point.gen_rand(),
                                                         point_v_prime=Point.gen_rand(),
                                                         point_noninteractive=42)

--- a/tests/test_keys/test_key_fragments.py
+++ b/tests/test_keys/test_key_fragments.py
@@ -32,7 +32,7 @@ def test_cfrag_serialization_with_proof_and_metadata(alices_keys, bobs_keys):
     _receiving_privkey, receiving_pubkey = bobs_keys
 
 
-    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key, delegating_pubkey.params)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
                              receiving_pubkey, 1, 2)
 
@@ -70,7 +70,7 @@ def test_cfrag_serialization_with_proof_but_no_metadata(alices_keys, bobs_keys):
     _receiving_privkey, receiving_pubkey = bobs_keys
     signer_alice = Signer(signing_privkey)
 
-    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key, delegating_pubkey.params)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
                              receiving_pubkey, 1, 2)
 
@@ -108,7 +108,7 @@ def test_cfrag_serialization_no_proof_no_metadata(alices_keys, bobs_keys):
     _receiving_privkey, receiving_pubkey = bobs_keys
     signer_alice = Signer(signing_privkey)
 
-    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key, delegating_pubkey.params)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
                              receiving_pubkey, 1, 2)
 

--- a/tests/test_keys/test_key_fragments.py
+++ b/tests/test_keys/test_key_fragments.py
@@ -32,7 +32,7 @@ def test_cfrag_serialization_with_proof_and_metadata(alices_keys, bobs_keys):
     _receiving_privkey, receiving_pubkey = bobs_keys
 
 
-    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key, delegating_pubkey.params)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
                              receiving_pubkey, 1, 2)
 
@@ -70,7 +70,7 @@ def test_cfrag_serialization_with_proof_but_no_metadata(alices_keys, bobs_keys):
     _receiving_privkey, receiving_pubkey = bobs_keys
     signer_alice = Signer(signing_privkey)
 
-    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key, delegating_pubkey.params)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
                              receiving_pubkey, 1, 2)
 
@@ -108,7 +108,7 @@ def test_cfrag_serialization_no_proof_no_metadata(alices_keys, bobs_keys):
     _receiving_privkey, receiving_pubkey = bobs_keys
     signer_alice = Signer(signing_privkey)
 
-    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key)
+    _unused_key, capsule = pre._encapsulate(delegating_pubkey.point_key, delegating_pubkey.params)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
                              receiving_pubkey, 1, 2)
 

--- a/tests/test_keys/test_umbral_keys.py
+++ b/tests/test_keys/test_umbral_keys.py
@@ -46,7 +46,7 @@ def test_derive_key_from_label():
 
 def test_private_key_serialization(random_ec_curvebn1):
     priv_key = random_ec_curvebn1
-    umbral_key = keys.UmbralPrivateKey(priv_key)
+    umbral_key = keys.UmbralPrivateKey(priv_key, default_params())
 
     encoded_key = umbral_key.to_bytes()
 
@@ -56,7 +56,7 @@ def test_private_key_serialization(random_ec_curvebn1):
 
 def test_private_key_serialization_with_encryption(random_ec_curvebn1):
     priv_key = random_ec_curvebn1
-    umbral_key = keys.UmbralPrivateKey(priv_key)
+    umbral_key = keys.UmbralPrivateKey(priv_key, default_params())
 
     encoded_key = umbral_key.to_bytes(password=b'test')
 
@@ -70,7 +70,7 @@ def test_public_key_serialization(random_ec_curvebn1):
     params = default_params()
     pub_key = priv_key * params.g
 
-    umbral_key = keys.UmbralPublicKey(pub_key)
+    umbral_key = keys.UmbralPublicKey(pub_key, params)
 
     encoded_key = umbral_key.to_bytes()
 
@@ -84,7 +84,7 @@ def test_public_key_to_bytes(random_ec_curvebn1):
     params = default_params()
     pub_key = priv_key * params.g
 
-    umbral_key = keys.UmbralPublicKey(pub_key)
+    umbral_key = keys.UmbralPublicKey(pub_key, params)
     key_bytes = bytes(umbral_key)
 
     assert type(key_bytes) == bytes
@@ -92,7 +92,7 @@ def test_public_key_to_bytes(random_ec_curvebn1):
 
 def test_key_encoder_decoder(random_ec_curvebn1):
     priv_key = random_ec_curvebn1
-    umbral_key = keys.UmbralPrivateKey(priv_key)
+    umbral_key = keys.UmbralPrivateKey(priv_key, default_params())
 
     encoded_key = umbral_key.to_bytes(encoder=base64.urlsafe_b64encode)
 

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -31,24 +31,23 @@ def test_simple_api(N, M, curve=default_curve()):
     receiving_pubkey = receiving_privkey.get_pubkey()
 
     plain_data = b'peace at dawn'
-    ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data, params=params)
+    ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data)
 
-    cleartext = pre.decrypt(ciphertext, capsule, delegating_privkey, params=params)
+    cleartext = pre.decrypt(ciphertext, capsule, delegating_privkey)
     assert cleartext == plain_data
 
     capsule.set_correctness_keys(delegating=delegating_pubkey,
                                  receiving=receiving_pubkey,
                                  verifying=signing_pubkey)
 
-    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, M, N, params=params)
+    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, M, N)
 
     for kfrag in kfrags:
-        cfrag = pre.reencrypt(kfrag, capsule, params=params)
+        cfrag = pre.reencrypt(kfrag, capsule)
         capsule.attach_cfrag(cfrag)
 
     reenc_cleartext = pre.decrypt(ciphertext, capsule, receiving_privkey,
-                                  delegating_pubkey, signing_pubkey,
-                                  params=params)
+                                  delegating_pubkey, signing_pubkey)
     assert reenc_cleartext == plain_data
 
 

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -15,17 +15,20 @@ secp_curves = [
 
 
 @pytest.mark.parametrize("N, M", parameters)
-def test_simple_api(alices_keys, bobs_keys, N, M, curve=default_curve()):
+def test_simple_api(N, M, curve=default_curve()):
     """Manually injects umbralparameters for multi-curve testing."""
 
     params = UmbralParameters(curve=curve)
 
-    delegating_privkey, signing_privkey = alices_keys
+    delegating_privkey = keys.UmbralPrivateKey.gen_key(params=params)
     delegating_pubkey = delegating_privkey.get_pubkey()
-    signing_pubkey = signing_privkey.get_pubkey()
 
-    receiving_privkey, receiving_pubkey = bobs_keys
+    signing_privkey = keys.UmbralPrivateKey.gen_key(params=params)
+    signing_pubkey = signing_privkey.get_pubkey()
     signer = Signer(signing_privkey)
+
+    receiving_privkey = keys.UmbralPrivateKey.gen_key(params=params)
+    receiving_pubkey = receiving_privkey.get_pubkey()
 
     plain_data = b'peace at dawn'
     ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data, params=params)
@@ -52,17 +55,7 @@ def test_simple_api(alices_keys, bobs_keys, N, M, curve=default_curve()):
 @pytest.mark.parametrize("curve", secp_curves)
 @pytest.mark.parametrize("N, M", parameters)
 def test_simple_api_on_multiple_curves(N, M, curve):
-    params = UmbralParameters(curve=curve)
-
-    delegating_privkey = keys.UmbralPrivateKey.gen_key(params=params)
-    signing_privkey = keys.UmbralPrivateKey.gen_key(params=params)
-    alices_keys = delegating_privkey, signing_privkey
-
-    receiving_privkey = keys.UmbralPrivateKey.gen_key(params=params)
-    receiving_pubkey = receiving_privkey.get_pubkey()
-    bobs_keys = receiving_privkey, receiving_pubkey
-    
-    test_simple_api(alices_keys, bobs_keys, N, M, curve)
+    test_simple_api(N, M, curve)
 
 
 def test_public_key_encryption(alices_keys):

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -46,8 +46,7 @@ def test_simple_api(N, M, curve=default_curve()):
         cfrag = pre.reencrypt(kfrag, capsule)
         capsule.attach_cfrag(cfrag)
 
-    reenc_cleartext = pre.decrypt(ciphertext, capsule, receiving_privkey,
-                                  delegating_pubkey, signing_pubkey)
+    reenc_cleartext = pre.decrypt(ciphertext, capsule, receiving_privkey)
     assert reenc_cleartext == plain_data
 
 

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -7,10 +7,9 @@ from umbral.params import UmbralParameters
 def prove_cfrag_correctness(cfrag: "CapsuleFrag",
                             kfrag: "KFrag",
                             capsule: "Capsule",
-                            metadata: bytes = None,
-                            params: UmbralParameters = None
+                            metadata: bytes = None
                             ) -> "CorrectnessProof":
-    params = params if params is not None else default_params()
+    params = capsule._umbral_params
 
     rk = kfrag._bn_key
     t = CurveBN.gen_rand(params.curve)
@@ -50,9 +49,8 @@ def assess_cfrag_correctness(cfrag,
                              capsule: "Capsule",
                              delegating_point,
                              signing_pubkey,
-                             receiving_point,
-                             params: UmbralParameters = None):
-    params = params if params is not None else default_params()
+                             receiving_point):
+    params = capsule._umbral_params
 
     ####
     ## Here are the formulaic constituents shared with `prove_cfrag_correctness`.
@@ -107,9 +105,8 @@ def verify_kfrag(kfrag,
                  delegating_point,
                  signing_pubkey,
                  receiving_point,
-                 params: UmbralParameters = None
+                 params: UmbralParameters
                  ):
-    params = params if params is not None else default_params()
 
     u = params.u
 

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -111,13 +111,20 @@ def assess_cfrag_correctness(cfrag, capsule: "Capsule"):
 
 
 def verify_kfrag(kfrag,
-                 delegating_point,
+                 delegating_pubkey: UmbralPublicKey,
                  signing_pubkey,
-                 receiving_point,
-                 params: UmbralParameters
+                 receiving_pubkey: UmbralPublicKey
                  ):
 
+
+    params = delegating_pubkey.params
+    if not params == receiving_pubkey.params:
+        raise ValueError("The delegating and receiving keys must use the same UmbralParameters")
+
     u = params.u
+
+    delegating_point = delegating_pubkey.point_key
+    receiving_point = receiving_pubkey.point_key
 
     id = kfrag._id
     key = kfrag._bn_key

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -45,8 +45,7 @@ def prove_cfrag_correctness(cfrag: "CapsuleFrag",
         raise capsule.NotValid("Capsule verification failed.")
 
 
-def assess_cfrag_correctness(cfrag,
-                             capsule: "Capsule"):
+def assess_cfrag_correctness(cfrag, capsule: "Capsule"):
 
     correctness_keys = capsule.get_correctness_keys()
 

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -46,10 +46,20 @@ def prove_cfrag_correctness(cfrag: "CapsuleFrag",
 
 
 def assess_cfrag_correctness(cfrag,
-                             capsule: "Capsule",
-                             delegating_point,
-                             signing_pubkey,
-                             receiving_point):
+                             capsule: "Capsule"):
+
+    correctness_keys = capsule.get_correctness_keys()
+
+    delegating_pubkey = correctness_keys['delegating']
+    signing_pubkey = correctness_keys['verifying']
+    receiving_pubkey = correctness_keys['receiving']
+
+    if not all((delegating_pubkey, signing_pubkey, receiving_pubkey)):
+        raise TypeError("Need all three keys to verify correctness.")
+
+    delegating_point = delegating_pubkey.point_key
+    receiving_point = receiving_pubkey.point_key
+
     params = capsule._umbral_params
 
     ####

--- a/umbral/curvebn.py
+++ b/umbral/curvebn.py
@@ -7,6 +7,7 @@ from cryptography.hazmat.primitives import hashes
 from umbral import openssl
 from umbral.config import default_curve, default_params
 from umbral.utils import get_curve_keysize_bytes
+from umbral.params import UmbralParameters
 
 
 class CurveBN(object):
@@ -84,8 +85,7 @@ class CurveBN(object):
         return cls(conv_bn, curve_nid, group, order)
 
     @classmethod
-    def hash(cls, *crypto_items, params=None):
-        params = params if params is not None else default_params()
+    def hash(cls, *crypto_items, params: UmbralParameters):
 
         curve_nid = backend._elliptic_curve_to_nid(params.curve)
         order = openssl._get_ec_order_by_curve_nid(curve_nid)

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -72,13 +72,7 @@ class KFrag(object):
                delegating_pubkey: UmbralPublicKey,
                receiving_pubkey: UmbralPublicKey):
 
-        params = delegating_pubkey.params
-
-        return verify_kfrag(self,
-                            delegating_pubkey.point_key,
-                            signing_pubkey,
-                            receiving_pubkey.point_key,
-                            params)
+        return verify_kfrag(self, delegating_pubkey, signing_pubkey, receiving_pubkey)
 
     def __bytes__(self):
         return self.to_bytes()

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -68,10 +68,11 @@ class KFrag(object):
         return self._id + key + ni + commitment + xcoord + signature
 
     def verify(self,
-               signing_pubkey: UmbralPublicKey,
+               signing_pubkey,
                delegating_pubkey: UmbralPublicKey,
-               receiving_pubkey: UmbralPublicKey,
-               params: UmbralParameters = None):
+               receiving_pubkey: UmbralPublicKey):
+
+        params = delegating_pubkey.params
 
         return verify_kfrag(self,
                             delegating_pubkey.point_key,
@@ -148,7 +149,7 @@ class CorrectnessProof(object):
 
         return result
 
-    def _bn_keytes__(self):
+    def _bytes__(self):
         return self.to_bytes()
 
 
@@ -222,9 +223,8 @@ class CapsuleFrag(object):
     def verify_correctness(self,
                            capsule: "Capsule",
                            delegating_pubkey: UmbralPublicKey,
-                           signing_pubkey: UmbralPublicKey,
-                           receiving_pubkey: UmbralPublicKey,
-                           params: UmbralParameters = None):
+                           signing_pubkey,
+                           receiving_pubkey: UmbralPublicKey):
         if not all((delegating_pubkey, signing_pubkey, receiving_pubkey)):
             raise TypeError("Need all three keys to verify correctness.")
 
@@ -232,7 +232,7 @@ class CapsuleFrag(object):
         pubkey_b_point = receiving_pubkey.point_key
 
         return assess_cfrag_correctness(self, capsule, pubkey_a_point,
-                                        signing_pubkey, pubkey_b_point, params)
+                                        signing_pubkey, pubkey_b_point)
 
     def attach_proof(self, e2, v2, u1, u2, z3, kfrag_signature, metadata):
         self.proof = CorrectnessProof(point_e2=e2,

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -149,7 +149,7 @@ class CorrectnessProof(object):
 
         return result
 
-    def _bytes__(self):
+    def __bytes__(self):
         return self.to_bytes()
 
 

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -220,19 +220,8 @@ class CapsuleFrag(object):
 
         return serialized_cfrag
 
-    def verify_correctness(self,
-                           capsule: "Capsule",
-                           delegating_pubkey: UmbralPublicKey,
-                           signing_pubkey,
-                           receiving_pubkey: UmbralPublicKey):
-        if not all((delegating_pubkey, signing_pubkey, receiving_pubkey)):
-            raise TypeError("Need all three keys to verify correctness.")
-
-        pubkey_a_point = delegating_pubkey.point_key
-        pubkey_b_point = receiving_pubkey.point_key
-
-        return assess_cfrag_correctness(self, capsule, pubkey_a_point,
-                                        signing_pubkey, pubkey_b_point)
+    def verify_correctness(self, capsule: "Capsule"):
+        return assess_cfrag_correctness(self, capsule)
 
     def attach_proof(self, e2, v2, u1, u2, z3, kfrag_signature, metadata):
         self.proof = CorrectnessProof(point_e2=e2,

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -20,19 +20,16 @@ from umbral.params import UmbralParameters
 
     
 class UmbralPrivateKey(object):
-    def __init__(self, bn_key: CurveBN, params: UmbralParameters=None):
+    def __init__(self, bn_key: CurveBN, params: UmbralParameters):
         """
         Initializes an Umbral private key.
         """
-        if params is None:
-            params = default_params()
-
         self.params = params
         self.bn_key = bn_key
-        self.pubkey = UmbralPublicKey(self.bn_key * self.params.g, params=params)
+        self.pubkey = UmbralPublicKey(self.bn_key * params.g, params=params)
 
     @classmethod
-    def gen_key(cls, params: UmbralParameters=None):
+    def gen_key(cls, params: UmbralParameters = None):
         """
         Generates a private key and returns it.
         """
@@ -43,9 +40,9 @@ class UmbralPrivateKey(object):
         return cls(bn_key, params)
 
     @classmethod
-    def from_bytes(cls, key_bytes: bytes, params: UmbralParameters=None,
-                   password: bytes=None, _scrypt_cost: int=20,
-                   decoder: Callable=None):
+    def from_bytes(cls, key_bytes: bytes, params: UmbralParameters = None,
+                   password: bytes = None, _scrypt_cost: int = 20,
+                   decoder: Callable = None):
         """
         Loads an Umbral private key from bytes.
         Optionally, allows a decoder function to be passed as a param to decode
@@ -82,8 +79,8 @@ class UmbralPrivateKey(object):
         bn_key = CurveBN.from_bytes(key_bytes, params.curve)
         return cls(bn_key, params)
 
-    def to_bytes(self, password: bytes=None, _scrypt_cost: int=20,
-                 encoder: Callable=None):
+    def to_bytes(self, password: bytes = None, _scrypt_cost: int = 20,
+                 encoder: Callable = None):
         """
         Returns an Umbral private key as bytes optional symmetric encryption
         via nacl's Salsa20-Poly1305 and Scrypt key derivation. If a password
@@ -163,13 +160,10 @@ class UmbralPrivateKey(object):
 
 
 class UmbralPublicKey(object):
-    def __init__(self, point_key, params: UmbralParameters=None):
+    def __init__(self, point_key, params: UmbralParameters):
         """
         Initializes an Umbral public key.
         """
-        if params is None:
-            params = default_params()
-
         self.params = params
 
         if not isinstance(point_key, Point):
@@ -178,8 +172,8 @@ class UmbralPublicKey(object):
         self.point_key = point_key
 
     @classmethod
-    def from_bytes(cls, key_bytes: bytes, params: UmbralParameters=None,
-                   decoder: Callable=None):
+    def from_bytes(cls, key_bytes: bytes, params: UmbralParameters = None,
+                   decoder: Callable = None):
         """
         Loads an Umbral public key from bytes.
         Optionally, if an decoder function is provided it will be used to decode
@@ -194,7 +188,7 @@ class UmbralPublicKey(object):
         point_key = Point.from_bytes(key_bytes, params.curve)
         return cls(point_key, params)
 
-    def to_bytes(self, encoder: Callable=None):
+    def to_bytes(self, encoder: Callable = None):
         """
         Returns an Umbral public key as bytes.
         Optionally, if an encoder function is provided it will be used to encode
@@ -266,7 +260,7 @@ class UmbralKeyingMaterial(object):
     
     """
 
-    def __init__(self, keying_material: bytes=None):
+    def __init__(self, keying_material: bytes = None):
         """
         Initializes an UmbralKeyingMaterial.
         """
@@ -277,8 +271,8 @@ class UmbralKeyingMaterial(object):
         else:
             self.keying_material = os.urandom(64)
 
-    def derive_privkey_by_label(self, label: bytes, salt: bytes=None, 
-                                params: UmbralParameters=None):
+    def derive_privkey_by_label(self, label: bytes, salt: bytes = None, 
+                                params: UmbralParameters = None):
         """
         Derives an UmbralPrivateKey using a KDF from this instance of 
         UmbralKeyingMaterial, a label, and an optional salt.
@@ -326,7 +320,7 @@ class UmbralKeyingMaterial(object):
 
         return cls(key_bytes)
 
-    def to_bytes(self, password: bytes=None, _scrypt_cost: int=20):
+    def to_bytes(self, password: bytes = None, _scrypt_cost: int = 20):
         """
         Returns an UmbralKeyingMaterial as a urlsafe base64 encoded string with
         optional symmetric encryption via nacl's Salsa20-Poly1305 and Scrypt

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -21,3 +21,14 @@ class UmbralParameters(object):
 
         parameters_seed = b'NuCypherKMS/UmbralParameters/'
         self.u = unsafe_hash_to_point(g_bytes, self, parameters_seed + b'u')
+
+    def __eq__(self, other):
+
+        self_curve_nid = backend._elliptic_curve_to_nid(self.curve)
+        other_curve_nid = backend._elliptic_curve_to_nid(other.curve)
+
+        # TODO: This is not comparing the order, which currently is an OpenSSL pointer
+        self_attributes = self_curve_nid, self.g, self.CURVE_KEY_SIZE_BYTES, self.u
+        others_attributes = other_curve_nid, other.g, other.CURVE_KEY_SIZE_BYTES, other.u
+
+        return self_attributes == others_attributes

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -7,6 +7,7 @@ from cryptography.exceptions import InternalError
 from umbral import openssl
 from umbral.config import default_curve
 from umbral.utils import get_field_order_size_in_bytes
+from umbral.params import UmbralParameters
 
 
 class Point(object):
@@ -231,7 +232,7 @@ class Point(object):
         return self.to_bytes()
 
 
-def unsafe_hash_to_point(data, params, label=None):
+def unsafe_hash_to_point(data, params : UmbralParameters, label=None):
     """
     Hashes arbitrary data into a valid EC point of the specified curve,
     using the try-and-increment method.

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -177,15 +177,11 @@ class Capsule(object):
         return s * g == v + (h * e)
 
     def attach_cfrag(self, cfrag: CapsuleFrag) -> None:
-        self.verify_cfrag(cfrag)
-        self._attached_cfrags.append(cfrag)
-
-    def verify_cfrag(self, cfrag):
-        return cfrag.verify_correctness(self,
-                                        self._cfrag_correctness_keys["delegating"],
-                                        self._cfrag_correctness_keys["receiving"],
-                                        self._cfrag_correctness_keys["verifying"],
-                                        )
+        if cfrag.verify_correctness(self):
+            self._attached_cfrags.append(cfrag)
+        else:
+            error_msg = "CFrag is not correct and cannot be attached to the Capsule"
+            raise UmbralCorrectnessError(error_msg, [cfrag])
 
     def original_components(self) -> Tuple[Point, Point, CurveBN]:
         return self._point_e, self._point_v, self._bn_sig

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -39,7 +39,7 @@ class Capsule(object):
                  point_noninteractive=None,
                  delegating_pubkey: UmbralPublicKey = None,
                  receiving_pubkey: UmbralPublicKey = None,
-                 verifying_pubkey = None):
+                 verifying_pubkey=None):
 
         self._umbral_params = params
 
@@ -146,7 +146,7 @@ class Capsule(object):
     def set_correctness_keys(self,
                  delegating: UmbralPublicKey = None,
                  receiving: UmbralPublicKey = None,
-                 verifying: UmbralPublicKey = None
+                 verifying=None
                  ):
         delegating_key_details = self._set_cfrag_correctness_key("delegating", delegating)
         receiving_key_details = self._set_cfrag_correctness_key("receiving", receiving)
@@ -365,7 +365,7 @@ def reencrypt(kfrag: KFrag, capsule: Capsule, provide_proof = True,
 
 
 def _encapsulate(alice_pubkey: UmbralPublicKey, 
-                 key_length = DEM_KEYSIZE) -> Tuple[bytes, Capsule]:
+                 key_length=DEM_KEYSIZE) -> Tuple[bytes, Capsule]:
     """Generates a symmetric key and its associated KEM ciphertext"""
 
     params = alice_pubkey.params
@@ -389,7 +389,7 @@ def _encapsulate(alice_pubkey: UmbralPublicKey,
 
 
 def _decapsulate_original(priv_key: UmbralPrivateKey, capsule: Capsule, 
-                          key_length = DEM_KEYSIZE) -> bytes:
+                          key_length=DEM_KEYSIZE) -> bytes:
     """Derive the same symmetric key"""
 
     priv_key = priv_key.bn_key
@@ -406,7 +406,7 @@ def _decapsulate_original(priv_key: UmbralPrivateKey, capsule: Capsule,
 
 
 def _decapsulate_reencrypted(receiving_privkey: UmbralPrivateKey, capsule: Capsule,
-                             key_length = DEM_KEYSIZE) -> bytes:
+                             key_length=DEM_KEYSIZE) -> bytes:
     """Derive the same symmetric key"""
     params = capsule._umbral_params
 
@@ -452,8 +452,7 @@ def encrypt(alice_pubkey: UmbralPublicKey, plaintext: bytes) -> Tuple[bytes, Cap
     return ciphertext, capsule
 
 
-def _open_capsule(capsule: Capsule,
-                  receiving_privkey: UmbralPrivateKey,
+def _open_capsule(capsule: Capsule, receiving_privkey: UmbralPrivateKey,
                   check_proof=True) -> bytes:
     """
     Activates the Capsule from the attached CFrags,
@@ -480,9 +479,7 @@ def _open_capsule(capsule: Capsule,
     return key
 
 
-def decrypt(ciphertext: bytes,
-            capsule: Capsule,
-            decrypting_key: UmbralPrivateKey,
+def decrypt(ciphertext: bytes, capsule: Capsule, decrypting_key: UmbralPrivateKey,
             check_proof=True) -> bytes:
     """
     Opens the capsule and gets what's inside.

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -57,8 +57,8 @@ class Capsule(object):
                 "Passing both is also fine.")
 
         self._cfrag_correctness_keys = {"delegating": delegating_pubkey,
-                                     "receiving": receiving_pubkey,
-                                     "verifying": verifying_pubkey}
+                                        "receiving": receiving_pubkey,
+                                        "verifying": verifying_pubkey}
 
         self._point_e = point_e
         self._point_v = point_v
@@ -132,6 +132,8 @@ class Capsule(object):
         if current_key is None:
             if key is None:
                 raise TypeError("The {} key is not set and you didn't pass one.".format(key_type))
+            elif self._umbral_params != key.params:
+                raise TypeError("You are trying to set a key with different UmbralParameters.")
             else:
                 self._cfrag_correctness_keys[key_type] = key
                 return True


### PR DESCRIPTION
## What this does: ##
This PR provides a slightly simplified API for pyUmbral. In particular, removes all redundant arguments from public and private methods that could be obtained by other means (primarily, from a neighboring argument), such as `params` and correctness keys. The result is not only that the interface is simplified, but also that there is less surface for misuse. 

* Simplified public API for `umbral.pre` and `umbral.fragments`:
    * Methods now only take Umbral keys as arguments, rather than primitive types (Point, CurveBN).
    * Remove unnecessary arguments from public facing and internal methods when they can be extracted from a `Capsule`, `UmbralPublicKey` or `UmbralPrivateKey`.
    * Adapts the test suite to new simplified API
* Fixes a bug in `Capsule.attach_cfrag()` that allowed to attach incorrect `CFrag`
* Adds a getter in `Capsule` for correctness keys
* Removes `pre.CHACHA20_KEY_SIZE` constant and uses `dem.DEM_KEYSIZE` instead
* Add `__eq__` method to `UmbralParameters`

