### PR TITLE
Refactor pyUmbral to use Curve object

### DIFF
--- a/docs/notebooks/pyUmbral Simple API.ipynb
+++ b/docs/notebooks/pyUmbral Simple API.ipynb
@@ -27,9 +27,9 @@
    "outputs": [],
    "source": [
     "from umbral.config import set_default_curve\n",
-    "from cryptography.hazmat.primitives.asymmetric import ec\n",
+    "from umbral.curve import SECP256K1\n",
     "\n",
-    "set_default_curve(ec.SECP256K1)\n"
+    "set_default_curve(SECP256K1)\n"
    ]
   },
   {

--- a/docs/source/choosing_and_using_curves.rst
+++ b/docs/source/choosing_and_using_curves.rst
@@ -22,8 +22,8 @@ Before you perform any ECC operations, you can set a default curve.
 
 .. code-block:: python
 
-    >>> from cryptography.hazmat.primitives.asymmetric import ec
-    >>> config.set_default_curve(ec.SECP256K1)
+    >>> from umbral.curve import SECP256K1
+    >>> config.set_default_curve(SECP256K1)
 
 If you don't set a default curve, then SECP256K1 will be set for you when you perform the first ECC
 operation.  This causes a small one-time performance penalty.

--- a/docs/source/using_pyumbral.rst
+++ b/docs/source/using_pyumbral.rst
@@ -33,8 +33,8 @@ The best way to start using pyUmbral is to decide on a elliptic curve to use and
 .. doctest:: capsule_story
 
     >>> from umbral import config
-    >>> from cryptography.hazmat.primitives.asymmetric import ec
-    >>> config.set_default_curve(ec.SECP256K1)
+    >>> from umbral.curve import SECP256K1
+    >>> config.set_default_curve(SECP256K1)
 
 For more information on curves, see :doc:`choosing_and_using_curves`.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 import pytest
 from collections import namedtuple
-from cryptography.hazmat.primitives.asymmetric import ec
 
 from umbral import keys
+from umbral.curve import SECP256K1
 from umbral.curvebn import CurveBN
 from umbral.config import set_default_curve
 from umbral.point import Point
 
-set_default_curve(ec.SECP256K1)
+set_default_curve(SECP256K1())
 
 
 MockKeyPair = namedtuple('TestKeyPair', 'priv pub')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from umbral.curvebn import CurveBN
 from umbral.config import set_default_curve
 from umbral.point import Point
 
-set_default_curve(SECP256K1())
+set_default_curve(SECP256K1)
 
 
 MockKeyPair = namedtuple('TestKeyPair', 'priv pub')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,9 @@
-from umbral.config import _CONFIG
-import pytest
 import importlib
-from cryptography.hazmat.primitives.asymmetric import ec
+import pytest
 import warnings
+
+from umbral.config import _CONFIG
+from umbral.curve import SECP256K1, SECP256R1
 
 
 def _copy_config_for_testing():
@@ -33,7 +34,7 @@ def test_try_to_use_curve_with_no_default_curve():
         assert caught_warnings[0].category == RuntimeWarning
 
     # Now, a default curve has been set.
-    assert config._CONFIG._CONFIG__curve == ec.SECP256K1
+    assert config._CONFIG._CONFIG__curve == SECP256K1()
 
 
 def test_try_to_use_default_params_with_no_default_curve():
@@ -51,18 +52,18 @@ def test_try_to_use_default_params_with_no_default_curve():
         assert caught_warnings[0].category == RuntimeWarning
 
     # Now, a default curve has been set.
-    assert config._CONFIG._CONFIG__curve == ec.SECP256K1
+    assert config._CONFIG._CONFIG__curve == SECP256K1()
 
 
 def test_cannot_set_default_curve_twice():
     config = _copy_config_for_testing()
 
-    # pyumbral even supports untrustworthy curves!
-    config.set_default_curve(ec.SECP256R1)
+    # pyumbral even supports NIST curves!
+    config.set_default_curve(SECP256R1())
 
     # Our default curve has been set...
-    assert config.default_curve() == ec.SECP256R1
+    assert config.default_curve() == SECP256R1()
 
     # ...but once set, you can't set the default curve again, even if you've found a better one.
     with pytest.raises(config._CONFIG.UmbralConfigurationError):
-        config.set_default_curve(ec.SECP256K1)
+        config.set_default_curve(SECP256K1())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ def test_try_to_use_curve_with_no_default_curve():
         assert caught_warnings[0].category == RuntimeWarning
 
     # Now, a default curve has been set.
-    assert config._CONFIG._CONFIG__curve == SECP256K1()
+    assert config._CONFIG._CONFIG__curve == SECP256K1
 
 
 def test_try_to_use_default_params_with_no_default_curve():
@@ -52,18 +52,18 @@ def test_try_to_use_default_params_with_no_default_curve():
         assert caught_warnings[0].category == RuntimeWarning
 
     # Now, a default curve has been set.
-    assert config._CONFIG._CONFIG__curve == SECP256K1()
+    assert config._CONFIG._CONFIG__curve == SECP256K1
 
 
 def test_cannot_set_default_curve_twice():
     config = _copy_config_for_testing()
 
     # pyumbral even supports NIST curves!
-    config.set_default_curve(SECP256R1())
+    config.set_default_curve(SECP256R1)
 
     # Our default curve has been set...
-    assert config.default_curve() == SECP256R1()
+    assert config.default_curve() == SECP256R1
 
     # ...but once set, you can't set the default curve again, even if you've found a better one.
     with pytest.raises(config._CONFIG.UmbralConfigurationError):
-        config.set_default_curve(SECP256K1())
+        config.set_default_curve(SECP256K1)

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -1,28 +1,29 @@
 import pytest
-from umbral.curve import Curve, SECP256R1, SECP256K1, SECP384R1
+from umbral.curve import Curve, SECP256R1, SECP256K1, SECP384R1, _AVAIL_CURVES
 
 
 def test_curve_whitelist():
     # Test the AVAIL_CURVES dict to have only these three curves:
-    assert len(Curve._Curve__AVAIL_CURVES) == 3
-    assert Curve._Curve__AVAIL_CURVES['secp256r1'] == 415
-    assert Curve._Curve__AVAIL_CURVES['secp256k1'] == 714
-    assert Curve._Curve__AVAIL_CURVES['secp384r1'] == 715
+    assert len(_AVAIL_CURVES) == 3
+    assert _AVAIL_CURVES['secp256r1'] == 415
+    assert _AVAIL_CURVES['secp256k1'] == 714
+    assert _AVAIL_CURVES['secp384r1'] == 715
 
     # Test that we can't instantiate other curves:
     with pytest.raises(ValueError):
         Curve(711)
 
     # Test the hardcoded curves are what they're supposed to be:
-    test_p256 = SECP256R1()
-    test_secp256k1 = SECP256K1()
-    test_p384 = SECP384R1()
-
-    # Test the supported curves property
-    assert test_p256.supported_curves\
-    == test_secp256k1.supported_curves\
-    == test_p384.supported_curves
+    test_p256 = SECP256R1
+    test_secp256k1 = SECP256K1
+    test_p384 = SECP384R1
 
     assert test_p256.curve_nid == 415
     assert test_secp256k1.curve_nid == 714
     assert test_p384.curve_nid == 715
+
+    # Test the supported curves property
+    assert test_p256.supported_curves == _AVAIL_CURVES
+    assert test_secp256k1.supported_curves == _AVAIL_CURVES
+    assert test_p384.supported_curves == _AVAIL_CURVES
+

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -1,5 +1,4 @@
 import pytest
-
 from umbral.curve import Curve, SECP256R1, SECP256K1, SECP384R1
 
 

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -1,0 +1,24 @@
+import pytest
+
+from umbral.curve import Curve, SECP256R1, SECP256K1, SECP384R1
+
+
+def test_curve_whitelist():
+    # Test the AVAIL_CURVES dict to have only these three curves:
+    assert len(Curve.AVAIL_CURVES) == 3
+    assert Curve.AVAIL_CURVES['secp256r1'] == 415
+    assert Curve.AVAIL_CURVES['secp256k1'] == 714
+    assert Curve.AVAIL_CURVES['secp384r1'] == 715
+
+    # Test that we can't instantiate other curves:
+    with pytest.raises(ValueError):
+        Curve(711)
+
+    # Test the hardcoded curves are what they're supposed to be:
+    test_p256 = SECP256R1()
+    test_secp256k1 = SECP256K1()
+    test_p384 = SECP384R1()
+
+    assert test_p256.curve_nid == 415
+    assert test_secp256k1.curve_nid == 714
+    assert test_p384.curve_nid == 715

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -5,10 +5,10 @@ from umbral.curve import Curve, SECP256R1, SECP256K1, SECP384R1
 
 def test_curve_whitelist():
     # Test the AVAIL_CURVES dict to have only these three curves:
-    assert len(Curve.AVAIL_CURVES) == 3
-    assert Curve.AVAIL_CURVES['secp256r1'] == 415
-    assert Curve.AVAIL_CURVES['secp256k1'] == 714
-    assert Curve.AVAIL_CURVES['secp384r1'] == 715
+    assert len(Curve._Curve__AVAIL_CURVES) == 3
+    assert Curve._Curve__AVAIL_CURVES['secp256r1'] == 415
+    assert Curve._Curve__AVAIL_CURVES['secp256k1'] == 714
+    assert Curve._Curve__AVAIL_CURVES['secp384r1'] == 715
 
     # Test that we can't instantiate other curves:
     with pytest.raises(ValueError):
@@ -18,6 +18,11 @@ def test_curve_whitelist():
     test_p256 = SECP256R1()
     test_secp256k1 = SECP256K1()
     test_p384 = SECP384R1()
+
+    # Test the supported curves property
+    assert test_p256.supported_curves\
+    == test_secp256k1.supported_curves\
+    == test_p384.supported_curves
 
     assert test_p256.curve_nid == 415
     assert test_secp256k1.curve_nid == 714

--- a/tests/test_primitives/conftest.py
+++ b/tests/test_primitives/conftest.py
@@ -48,7 +48,7 @@ def mock_openssl(mocker, random_ec_point1: Point, random_ec_curvebn1: CurveBN, r
             check_point_ctypes(ec_point, other_point)
             assert 'BN_CTX' in str(context)
             assert 'EC_GROUP' in str(group)
-            assert random_ec_point1.group == group
+            assert random_ec_point1.curve.ec_group == group
             assert not bool(actual_backend['EC_POINT_cmp'](group, random_ec_point1.ec_point, ec_point, context))
             result = actual_backend['EC_POINT_cmp'](group, random_ec_point1.ec_point, other_point, context)
             assert not bool(result)

--- a/tests/test_primitives/test_point/test_point_arithmetic.py
+++ b/tests/test_primitives/test_point/test_point_arithmetic.py
@@ -30,8 +30,7 @@ def test_point_curve_multiplication_regression():
     # Make sure we have instantiated a new, unequal point in the same curve and group
     assert isinstance(product_with_star_operator, Point), "Point.__mul__ did not return a point instance"
     assert k256_point != product_with_star_operator
-    assert k256_point.curve_nid == product_with_star_operator.curve_nid
-    assert k256_point.group == product_with_star_operator.group
+    assert k256_point.curve == product_with_star_operator.curve
 
     product_bytes = b'\x03\xc9\xda\xa2\x88\xe2\xa0+\xb1N\xb6\xe6\x1c\xa5(\xe6\xe0p\xf6\xf4\xa9\xfc\xb1\xfaUV\xd3\xb3\x0e4\x94\xbe\x12'
     product_point = Point.from_bytes(product_bytes)

--- a/tests/test_primitives/test_point/test_point_serializers.py
+++ b/tests/test_primitives/test_point/test_point_serializers.py
@@ -1,27 +1,27 @@
 import pytest
 from cryptography.exceptions import InternalError
-from cryptography.hazmat.primitives.asymmetric import ec
 
+from umbral.curve import SECP256K1
 from umbral.point import Point
 
 
 def generate_test_points_bytes(quantity=2):
     points_bytes = [
-        (ec.SECP256K1, 714, b'\x02x{DR\x94\x8f\x17\xb8\xa2\x14t\x11\xdb\xb1VK\xdb\xc2\xa0T\x97iCK\x8cz~\xea\xa3\xb7AJ'),
+        (SECP256K1(), 714, b'\x02x{DR\x94\x8f\x17\xb8\xa2\x14t\x11\xdb\xb1VK\xdb\xc2\xa0T\x97iCK\x8cz~\xea\xa3\xb7AJ'),
     ]
     for _ in range(quantity):
-        args = (ec.SECP256K1, 714, Point.gen_rand(curve=ec.SECP256K1).to_bytes())
+        args = (SECP256K1(), 714, Point.gen_rand(curve=SECP256K1()).to_bytes())
         points_bytes.append(args)
     return points_bytes
 
 
 def generate_test_points_affine(quantity=2):
     points_affine = [
-        (ec.SECP256K1, 714, (54495335564072000415434275044935054036617226655045445809732056033758606213450,
-                             26274482902044210718566767736429706729731617411738990314884135712590488065008)),
+        (SECP256K1(), 714, (54495335564072000415434275044935054036617226655045445809732056033758606213450,
+                            26274482902044210718566767736429706729731617411738990314884135712590488065008)),
     ]
     for _ in range(quantity):
-        args = (ec.SECP256K1, 714, Point.gen_rand(curve=ec.SECP256K1).to_affine())
+        args = (SECP256K1(), 714, Point.gen_rand(curve=SECP256K1()).to_affine())
         points_affine.append(args)
     return points_affine
 

--- a/tests/test_primitives/test_point/test_point_serializers.py
+++ b/tests/test_primitives/test_point/test_point_serializers.py
@@ -1,7 +1,7 @@
 import pytest
 from cryptography.exceptions import InternalError
 
-from umbral.curve import SECP256K1
+from umbral.curve import SECP256K1, SECP256R1
 from umbral.point import Point
 
 
@@ -121,8 +121,8 @@ def test_point_not_on_curve():
     https://www.openssl.org/docs/man1.1.0/crypto/EC_GFp_simple_method.html
     """
     point_on_koblitz256_but_not_P256 = Point.from_bytes(b'\x03%\x98Dk\x88\xe2\x97\xab?\xabZ\xef\xd4' \
-    b'\x9e\xaa\xc6\xb3\xa4\xa3\x89\xb2\xd7b.\x8f\x16Ci_&\xe0\x7f', curve=ec.SECP256K1)
+    b'\x9e\xaa\xc6\xb3\xa4\xa3\x89\xb2\xd7b.\x8f\x16Ci_&\xe0\x7f', curve=SECP256K1())
 
     from cryptography.exceptions import InternalError
     with pytest.raises(InternalError):
-        Point.from_bytes(point_on_koblitz256_but_not_P256.to_bytes(), curve=ec.SECP256R1)
+        Point.from_bytes(point_on_koblitz256_but_not_P256.to_bytes(), curve=SECP256R1())

--- a/tests/test_primitives/test_point/test_point_serializers.py
+++ b/tests/test_primitives/test_point/test_point_serializers.py
@@ -36,14 +36,8 @@ def test_generate_random_points():
 
 @pytest.mark.parametrize("curve, nid, point_bytes", generate_test_points_bytes())
 def test_bytes_serializers(point_bytes, nid, curve):
-
-    point_with_nid = Point.from_bytes(point_bytes, curve=nid)         # from nid
-    assert isinstance(point_with_nid, Point)
-
-    point_with_curve = Point.from_bytes(point_bytes, curve=curve)     # from curve
+    point_with_curve = Point.from_bytes(point_bytes, curve=curve) # from curve
     assert isinstance(point_with_curve, Point)
-
-    assert point_with_nid == point_with_curve
 
     the_same_point_bytes = point_with_curve.to_bytes()
     assert point_bytes == the_same_point_bytes
@@ -67,9 +61,7 @@ def test_bytes_serializers(point_bytes, nid, curve):
 
 @pytest.mark.parametrize("curve, nid, point_affine", generate_test_points_affine())
 def test_affine(point_affine, nid, curve):
-    point = Point.from_affine(point_affine, curve=nid)              # from nid
-    the_same_point = Point.from_affine(point_affine, curve=curve)   # from curve instance
-    assert point == the_same_point
+    point = Point.from_affine(point_affine, curve=curve)  # from curve
     assert isinstance(point, Point)
     point_affine2 = point.to_affine()
     assert point_affine == point_affine2

--- a/tests/test_primitives/test_point/test_point_serializers.py
+++ b/tests/test_primitives/test_point/test_point_serializers.py
@@ -7,21 +7,21 @@ from umbral.point import Point
 
 def generate_test_points_bytes(quantity=2):
     points_bytes = [
-        (SECP256K1(), 714, b'\x02x{DR\x94\x8f\x17\xb8\xa2\x14t\x11\xdb\xb1VK\xdb\xc2\xa0T\x97iCK\x8cz~\xea\xa3\xb7AJ'),
+        (SECP256K1, 714, b'\x02x{DR\x94\x8f\x17\xb8\xa2\x14t\x11\xdb\xb1VK\xdb\xc2\xa0T\x97iCK\x8cz~\xea\xa3\xb7AJ'),
     ]
     for _ in range(quantity):
-        args = (SECP256K1(), 714, Point.gen_rand(curve=SECP256K1()).to_bytes())
+        args = (SECP256K1, 714, Point.gen_rand(curve=SECP256K1).to_bytes())
         points_bytes.append(args)
     return points_bytes
 
 
 def generate_test_points_affine(quantity=2):
     points_affine = [
-        (SECP256K1(), 714, (54495335564072000415434275044935054036617226655045445809732056033758606213450,
+        (SECP256K1, 714, (54495335564072000415434275044935054036617226655045445809732056033758606213450,
                             26274482902044210718566767736429706729731617411738990314884135712590488065008)),
     ]
     for _ in range(quantity):
-        args = (SECP256K1(), 714, Point.gen_rand(curve=SECP256K1()).to_affine())
+        args = (SECP256K1, 714, Point.gen_rand(curve=SECP256K1).to_affine())
         points_affine.append(args)
     return points_affine
 
@@ -113,8 +113,8 @@ def test_point_not_on_curve():
     https://www.openssl.org/docs/man1.1.0/crypto/EC_GFp_simple_method.html
     """
     point_on_koblitz256_but_not_P256 = Point.from_bytes(b'\x03%\x98Dk\x88\xe2\x97\xab?\xabZ\xef\xd4' \
-    b'\x9e\xaa\xc6\xb3\xa4\xa3\x89\xb2\xd7b.\x8f\x16Ci_&\xe0\x7f', curve=SECP256K1())
+    b'\x9e\xaa\xc6\xb3\xa4\xa3\x89\xb2\xd7b.\x8f\x16Ci_&\xe0\x7f', curve=SECP256K1)
 
     from cryptography.exceptions import InternalError
     with pytest.raises(InternalError):
-        Point.from_bytes(point_on_koblitz256_but_not_P256.to_bytes(), curve=SECP256R1())
+        Point.from_bytes(point_on_koblitz256_but_not_P256.to_bytes(), curve=SECP256R1)

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -13,8 +13,8 @@ from .conftest import parameters, wrong_parameters
 
 
 secp_curves = [
-    SECP384R1(),
-    SECP256R1()
+    SECP384R1,
+    SECP256R1
 ]
 
 

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -4,22 +4,23 @@ from cryptography.hazmat.primitives.asymmetric import ec
 
 from umbral import pre
 from umbral.fragments import KFrag, CapsuleFrag
+from umbral.curve import SECP384R1, SECP256R1
 from umbral.config import default_curve
 from umbral.params import UmbralParameters
 from umbral.signing import Signer
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
 from .conftest import parameters, wrong_parameters
 
+
 secp_curves = [
-    ec.SECP384R1,
-    ec.SECP192R1
+    SECP384R1(),
+    SECP256R1()
 ]
 
 
 @pytest.mark.parametrize("N, M", parameters)
 def test_simple_api(N, M, curve=default_curve()):
     """Manually injects umbralparameters for multi-curve testing."""
-
     params = UmbralParameters(curve=curve)
 
     delegating_privkey = UmbralPrivateKey.gen_key(params=params)

--- a/umbral/config.py
+++ b/umbral/config.py
@@ -1,12 +1,12 @@
 from warnings import warn
 
-from cryptography.hazmat.primitives.asymmetric import ec
+from umbral.curve import Curve, SECP256K1
 
 
 class _CONFIG:
     __curve = None
     __params = None
-    __CURVE_TO_USE_IF_NO_DEFAULT_IS_SET_BY_USER = ec.SECP256K1
+    __CURVE_TO_USE_IF_NO_DEFAULT_IS_SET_BY_USER = SECP256K1()
     __WARNING_IF_NO_DEFAULT_SET = "No default curve has been set.  Using SECP256K1.  A slight performance penalty has been incurred for only this call.  Set a default curve with umbral.config.set_default_curve()."
 
     class UmbralConfigurationError(RuntimeError):
@@ -30,7 +30,7 @@ class _CONFIG:
         return cls.__curve
 
     @classmethod
-    def set_curve(cls, curve: ec.EllipticCurve=None):
+    def set_curve(cls, curve: Curve=None):
         if cls.__curve:
             raise cls.UmbralConfigurationError(
                 "You can only set the default curve once.  Do it once and then leave it alone.")
@@ -42,7 +42,7 @@ class _CONFIG:
             cls.__params = UmbralParameters(curve)
 
 
-def set_default_curve(curve: ec.EllipticCurve=None):
+def set_default_curve(curve: Curve=None):
     return _CONFIG.set_curve(curve)
 
 

--- a/umbral/config.py
+++ b/umbral/config.py
@@ -6,7 +6,7 @@ from umbral.curve import Curve, SECP256K1
 class _CONFIG:
     __curve = None
     __params = None
-    __CURVE_TO_USE_IF_NO_DEFAULT_IS_SET_BY_USER = SECP256K1()
+    __CURVE_TO_USE_IF_NO_DEFAULT_IS_SET_BY_USER = SECP256K1
     __WARNING_IF_NO_DEFAULT_SET = "No default curve has been set.  Using SECP256K1.  A slight performance penalty has been incurred for only this call.  Set a default curve with umbral.config.set_default_curve()."
 
     class UmbralConfigurationError(RuntimeError):

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -37,6 +37,9 @@ class Curve:
     def __eq__(self, other):
         return self.curve_nid == other.curve_nid
 
+    def __repr__(self):
+        return "<OpenSSL Curve w/ NID {}>".format(self.curve_nid)
+
 
 SECP256R1 = Curve(_AVAIL_CURVES['secp256r1'])
 SECP256K1 = Curve(_AVAIL_CURVES['secp256k1'])

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -1,6 +1,13 @@
 from umbral import openssl
 
 
+_AVAIL_CURVES = {
+    'secp256r1': 415,
+    'secp256k1': 714,
+    'secp384r1': 715,
+}
+
+
 class Curve:
     """
     Acts as a container to store constant variables such as the OpenSSL
@@ -8,23 +15,16 @@ class Curve:
     as a convenient whitelist to limit the curves used in pyUmbral.
     """
 
-    __AVAIL_CURVES = {
-        'secp256r1': 415,
-        'secp256k1': 714,
-        'secp384r1': 715,
-    }
-
     def __init__(self, curve_nid: int):
         """
         Instantiates an OpenSSL curve with the provided curve_nid and derives
         the proper EC_GROUP struct and order. You can _only_ instantiate curves
         with supported nids (see `Curve.supported_curves`).
         """
-        if curve_nid not in self.__AVAIL_CURVES.values():
+        if curve_nid not in _AVAIL_CURVES.values():
             raise ValueError(
                 "Curve NID passed ({}) is not supported.".format(curve_nid))
 
-        # TODO: Limit the creations of EC_GROUP structs in openssl.py
         self.curve_nid = curve_nid
         self.ec_group = openssl._get_ec_group_by_curve_nid(self.curve_nid)
         self.order = openssl._get_ec_order_by_group(self.ec_group)
@@ -32,32 +32,12 @@ class Curve:
 
     @property
     def supported_curves(self):
-        return self.__AVAIL_CURVES
+        return _AVAIL_CURVES
 
     def __eq__(self, other):
         return self.curve_nid == other.curve_nid
 
 
-class SECP256R1(Curve):
-    """
-    Instantiates a NIST secp256r1 (P-256) curve.
-    """
-    def __init__(self):
-        super().__init__(self.supported_curves['secp256r1'])
-
-
-class SECP256K1(Curve):
-    """
-    Instantiates a SECG secp256k1 curve.
-    This is the default curve currently used in NuCypher.
-    """
-    def __init__(self):
-        super().__init__(self.supported_curves['secp256k1'])
-
-
-class SECP384R1(Curve):
-    """
-    Instantiates a NIST secp384r1 (P-384) curve.
-    """
-    def __init__(self):
-        super().__init__(self.supported_curves['secp384r1'])
+SECP256R1 = Curve(_AVAIL_CURVES['secp256r1'])
+SECP256K1 = Curve(_AVAIL_CURVES['secp256k1'])
+SECP384R1 = Curve(_AVAIL_CURVES['secp384r1'])

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -33,6 +33,9 @@ class Curve:
     def supported_curves(self):
         return self.__AVAIL_CURVES
 
+    def __eq__(self, other):
+        return self.curve_nid == other.curve_nid
+
 
 class SECP256R1(Curve):
     """

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -28,6 +28,7 @@ class Curve:
         self.curve_nid = curve_nid
         self.ec_group = openssl._get_ec_group_by_curve_nid(self.curve_nid)
         self.order = openssl._get_ec_order_by_curve_nid(self.curve_nid)
+        self.generator = openssl._get_ec_generator_by_curve_nid(self.curve_nid)
 
     @property
     def supported_curves(self):

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -1,0 +1,21 @@
+from umbral import openssl
+
+
+CURVE_WHITELIST = {
+    'secp256r1': 415,
+    'secp256k1': 714,
+    'secp384r1': 715,
+}
+
+
+class Curve:
+    """
+    Acts as a container to store constant variables such as the OpenSSL
+    curve_nid, the EC_GROUP struct, and the order of the curve. This also acts
+    as a convenient interface to limit the curves used in pyUmbral.
+    """
+    def __init__(self, curve_nid: int):
+        # TODO: Limit the creations of EC_GROUP structs in openssl.py
+        self.curve_nid = curve_nid
+        self.ec_group = openssl._get_ec_group_by_curve_nid(self.curve_nid)
+        self.order = openssl._get_ec_order_by_curve_nid(self.curve_nid)

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -27,8 +27,8 @@ class Curve:
         # TODO: Limit the creations of EC_GROUP structs in openssl.py
         self.curve_nid = curve_nid
         self.ec_group = openssl._get_ec_group_by_curve_nid(self.curve_nid)
-        self.order = openssl._get_ec_order_by_curve_nid(self.curve_nid)
-        self.generator = openssl._get_ec_generator_by_curve_nid(self.curve_nid)
+        self.order = openssl._get_ec_order_by_group(self.ec_group)
+        self.generator = openssl._get_ec_generator_by_group(self.ec_group)
 
     @property
     def supported_curves(self):

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -19,3 +19,27 @@ class Curve:
         self.curve_nid = curve_nid
         self.ec_group = openssl._get_ec_group_by_curve_nid(self.curve_nid)
         self.order = openssl._get_ec_order_by_curve_nid(self.curve_nid)
+
+
+class SECP256R1(Curve):
+    """
+    Instantiates a NIST secp256r1 (P-256) curve.
+    """
+    def __init__(self):
+        super().__init__(CURVE_WHITELIST['secp256r1'])
+
+
+class SECP256K1(Curve):
+    """
+    Instantiates a SECG secp256k1 curve.
+    """
+    def __init__(self):
+        super().__init__(CURVE_WHITELIST['secp256k1'])
+
+
+class SECP384R1(Curve):
+    """
+    Instantiates a NIST secp384r1 (P-384) curve.
+    """
+    def __init__(self):
+        super().__init__(CURVE_WHITELIST['secp384r1'])

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -1,20 +1,24 @@
 from umbral import openssl
 
 
-CURVE_WHITELIST = {
-    'secp256r1': 415,
-    'secp256k1': 714,
-    'secp384r1': 715,
-}
-
-
 class Curve:
     """
     Acts as a container to store constant variables such as the OpenSSL
     curve_nid, the EC_GROUP struct, and the order of the curve. This also acts
-    as a convenient interface to limit the curves used in pyUmbral.
+    as a convenient whitelist to limit the curves used in pyUmbral.
     """
+
+    AVAIL_CURVES = {
+        'secp256r1': 415,
+        'secp256k1': 714,
+        'secp384r1': 715,
+    }
+
     def __init__(self, curve_nid: int):
+        if curve_nid not in self.AVAIL_CURVES.values():
+            raise ValueError(
+                "Curve NID passed ({}) is not supported.".format(curve_nid))
+
         # TODO: Limit the creations of EC_GROUP structs in openssl.py
         self.curve_nid = curve_nid
         self.ec_group = openssl._get_ec_group_by_curve_nid(self.curve_nid)
@@ -26,15 +30,16 @@ class SECP256R1(Curve):
     Instantiates a NIST secp256r1 (P-256) curve.
     """
     def __init__(self):
-        super().__init__(CURVE_WHITELIST['secp256r1'])
+        super().__init__(super().AVAIL_CURVES['secp256r1'])
 
 
 class SECP256K1(Curve):
     """
     Instantiates a SECG secp256k1 curve.
+    This is the default curve currently used in NuCypher.
     """
     def __init__(self):
-        super().__init__(CURVE_WHITELIST['secp256k1'])
+        super().__init__(super().AVAIL_CURVES['secp256k1'])
 
 
 class SECP384R1(Curve):
@@ -42,4 +47,4 @@ class SECP384R1(Curve):
     Instantiates a NIST secp384r1 (P-384) curve.
     """
     def __init__(self):
-        super().__init__(CURVE_WHITELIST['secp384r1'])
+        super().__init__(super().AVAIL_CURVES['secp384r1'])

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -8,14 +8,19 @@ class Curve:
     as a convenient whitelist to limit the curves used in pyUmbral.
     """
 
-    AVAIL_CURVES = {
+    __AVAIL_CURVES = {
         'secp256r1': 415,
         'secp256k1': 714,
         'secp384r1': 715,
     }
 
     def __init__(self, curve_nid: int):
-        if curve_nid not in self.AVAIL_CURVES.values():
+        """
+        Instantiates an OpenSSL curve with the provided curve_nid and derives
+        the proper EC_GROUP struct and order. You can _only_ instantiate curves
+        with supported nids (see `Curve.supported_curves`).
+        """
+        if curve_nid not in self.__AVAIL_CURVES.values():
             raise ValueError(
                 "Curve NID passed ({}) is not supported.".format(curve_nid))
 
@@ -24,13 +29,17 @@ class Curve:
         self.ec_group = openssl._get_ec_group_by_curve_nid(self.curve_nid)
         self.order = openssl._get_ec_order_by_curve_nid(self.curve_nid)
 
+    @property
+    def supported_curves(self):
+        return self.__AVAIL_CURVES
+
 
 class SECP256R1(Curve):
     """
     Instantiates a NIST secp256r1 (P-256) curve.
     """
     def __init__(self):
-        super().__init__(super().AVAIL_CURVES['secp256r1'])
+        super().__init__(self.supported_curves['secp256r1'])
 
 
 class SECP256K1(Curve):
@@ -39,7 +48,7 @@ class SECP256K1(Curve):
     This is the default curve currently used in NuCypher.
     """
     def __init__(self):
-        super().__init__(super().AVAIL_CURVES['secp256k1'])
+        super().__init__(self.supported_curves['secp256k1'])
 
 
 class SECP384R1(Curve):
@@ -47,4 +56,4 @@ class SECP384R1(Curve):
     Instantiates a NIST secp384r1 (P-384) curve.
     """
     def __init__(self):
-        super().__init__(super().AVAIL_CURVES['secp384r1'])
+        super().__init__(self.supported_curves['secp384r1'])

--- a/umbral/curvebn.py
+++ b/umbral/curvebn.py
@@ -241,7 +241,7 @@ class CurveBN(object):
         """
         if type(other) == int:
             other = openssl._int_to_bn(other)
-            other = CurveBN(other, None, None, None)
+            other = CurveBN(other, self.curve)
 
         rem = openssl._get_new_BN()
         with backend._tmp_bn_ctx() as bn_ctx:

--- a/umbral/curvebn.py
+++ b/umbral/curvebn.py
@@ -68,10 +68,6 @@ class CurveBN(object):
 
     @classmethod
     def hash(cls, *crypto_items, params: UmbralParameters):
-        curve_nid = backend._elliptic_curve_to_nid(params.curve)
-        order = openssl._get_ec_order_by_curve_nid(curve_nid)
-        group = openssl._get_ec_group_by_curve_nid(curve_nid)
-    
         # TODO: Clean this in an upcoming cleanup of pyUmbral
         blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
         for item in crypto_items:
@@ -91,7 +87,7 @@ class CurveBN(object):
         _1 = backend._lib.BN_value_one()
         
         order_minus_1 = openssl._get_new_BN()
-        res = backend._lib.BN_sub(order_minus_1, order, _1)
+        res = backend._lib.BN_sub(order_minus_1, params.curve.order, _1)
         backend.openssl_assert(res == 1)
 
         bignum = openssl._get_new_BN()
@@ -102,7 +98,7 @@ class CurveBN(object):
         res = backend._lib.BN_add(bignum, bignum, _1)
         backend.openssl_assert(res == 1)
         
-        return cls(bignum, curve_nid, group, order)
+        return cls(bignum, params.curve)
 
     @classmethod
     def from_bytes(cls, data, curve: Curve=None):

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -126,7 +126,7 @@ class UmbralPrivateKey(object):
         """
         backend = default_backend()
 
-        backend.openssl_assert(self.bn_key.group != backend._ffi.NULL)
+        backend.openssl_assert(self.bn_key.curve.ec_group != backend._ffi.NULL)
         backend.openssl_assert(self.bn_key.bignum != backend._ffi.NULL)
 
         ec_key = backend._lib.EC_KEY_new()
@@ -134,7 +134,7 @@ class UmbralPrivateKey(object):
         ec_key = backend._ffi.gc(ec_key, backend._lib.EC_KEY_free)
 
         set_group_result = backend._lib.EC_KEY_set_group(
-            ec_key, self.bn_key.group
+            ec_key, self.bn_key.curve.ec_group
         )
         backend.openssl_assert(set_group_result == 1)
 
@@ -144,11 +144,11 @@ class UmbralPrivateKey(object):
         backend.openssl_assert(set_privkey_result == 1)
 
         # Get public key
-        point = openssl._get_new_EC_POINT(ec_group=self.bn_key.group)
+        point = openssl._get_new_EC_POINT(ec_group=self.bn_key.curve.ec_group)
         with backend._tmp_bn_ctx() as bn_ctx:
             mult_result = backend._lib.EC_POINT_mul(
-                self.bn_key.group, point, self.bn_key.bignum, backend._ffi.NULL,
-                backend._ffi.NULL, bn_ctx
+                self.bn_key.curve.ec_group, point, self.bn_key.bignum,
+                backend._ffi.NULL, backend._ffi.NULL, bn_ctx
             )
             backend.openssl_assert(mult_result == 1)
 
@@ -210,7 +210,7 @@ class UmbralPublicKey(object):
         """
         backend = default_backend()
 
-        backend.openssl_assert(self.point_key.group != backend._ffi.NULL)
+        backend.openssl_assert(self.point_key.curve.ec_group != backend._ffi.NULL)
         backend.openssl_assert(self.point_key.ec_point != backend._ffi.NULL)
 
         ec_key = backend._lib.EC_KEY_new()
@@ -218,7 +218,7 @@ class UmbralPublicKey(object):
         ec_key = backend._ffi.gc(ec_key, backend._lib.EC_KEY_free)
 
         set_group_result = backend._lib.EC_KEY_set_group(
-            ec_key, self.point_key.group
+            ec_key, self.point_key.curve.ec_group
         )
         backend.openssl_assert(set_group_result == 1)
 

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -144,7 +144,7 @@ class UmbralPrivateKey(object):
         backend.openssl_assert(set_privkey_result == 1)
 
         # Get public key
-        point = openssl._get_new_EC_POINT(ec_group=self.bn_key.curve.ec_group)
+        point = openssl._get_new_EC_POINT(self.params.curve)
         with backend._tmp_bn_ctx() as bn_ctx:
             mult_result = backend._lib.EC_POINT_mul(
                 self.bn_key.curve.ec_group, point, self.bn_key.bignum,

--- a/umbral/openssl.py
+++ b/umbral/openssl.py
@@ -20,7 +20,8 @@ def _get_new_BN(set_consttime_flag=True):
 
 def _get_ec_group_by_curve_nid(curve_nid: int):
     """
-    Returns the group of a given curve via its OpenSSL nid.
+    Returns the group of a given curve via its OpenSSL nid. This must be freed
+    after each use otherwise it leaks memory.
     """
     group = backend._lib.EC_GROUP_new_by_curve_name(curve_nid)
     backend.openssl_assert(group != backend._ffi.NULL)

--- a/umbral/openssl.py
+++ b/umbral/openssl.py
@@ -80,9 +80,9 @@ def _bn_is_on_curve(check_bn, curve: Curve):
     return check_sign == 1 and range_check == -1
 
 
-def _int_to_bn(py_int: int, curve: Curve, set_consttime_flag=True):
+def _int_to_bn(py_int: int, curve: Curve=None, set_consttime_flag=True):
     """
-    Converts the given Python int to an OpenSSL BIGNUM. If a curve_nid is
+    Converts the given Python int to an OpenSSL BIGNUM. If a curve is
     provided, it will check if the Python integer is within the order of that
     curve. If it's not within the order, it will raise a ValueError.
 
@@ -92,9 +92,10 @@ def _int_to_bn(py_int: int, curve: Curve, set_consttime_flag=True):
     conv_bn = backend._int_to_bn(py_int)
     conv_bn = backend._ffi.gc(conv_bn, backend._lib.BN_clear_free)
     
-    on_curve = _bn_is_on_curve(conv_bn, curve)
-    if not on_curve:
-        raise ValueError("The Python integer given is not on the provided curve.")
+    if curve:
+        on_curve = _bn_is_on_curve(conv_bn, curve)
+        if not on_curve:
+            raise ValueError("The Python integer given is not on the provided curve.")
 
     if set_consttime_flag:
         backend._lib.BN_set_flags(conv_bn, backend._lib.BN_FLG_CONSTTIME)

--- a/umbral/openssl.py
+++ b/umbral/openssl.py
@@ -1,8 +1,6 @@
 from contextlib import contextmanager
 from cryptography.hazmat.backends.openssl import backend
 
-from umbral.curve import Curve
-
 
 def _get_new_BN(set_consttime_flag=True):
     """
@@ -61,7 +59,7 @@ def _get_ec_group_degree(ec_group):
     return backend._lib.EC_GROUP_get_degree(ec_group) 
 
 
-def _bn_is_on_curve(check_bn, curve: Curve):
+def _bn_is_on_curve(check_bn, curve: 'Curve'):
     """
     Checks if a given OpenSSL BIGNUM is within the provided curve's order.
     Returns True if the provided BN is on the curve, or False if the BN is zero
@@ -75,7 +73,7 @@ def _bn_is_on_curve(check_bn, curve: Curve):
     return check_sign == 1 and range_check == -1
 
 
-def _int_to_bn(py_int: int, curve: Curve=None, set_consttime_flag=True):
+def _int_to_bn(py_int: int, curve: 'Curve'=None, set_consttime_flag=True):
     """
     Converts the given Python int to an OpenSSL BIGNUM. If a curve is
     provided, it will check if the Python integer is within the order of that
@@ -97,7 +95,7 @@ def _int_to_bn(py_int: int, curve: Curve=None, set_consttime_flag=True):
     return conv_bn
 
 
-def _get_new_EC_POINT(curve: Curve):
+def _get_new_EC_POINT(curve: 'Curve'):
     """
     Returns a new and initialized OpenSSL EC_POINT given the group of a curve.
     If curve_nid is provided, it retrieves the group from the curve provided.
@@ -109,7 +107,7 @@ def _get_new_EC_POINT(curve: Curve):
     return new_point
 
 
-def _get_EC_POINT_via_affine(affine_x, affine_y, curve: Curve):
+def _get_EC_POINT_via_affine(affine_x, affine_y, curve: 'Curve'):
     """
     Returns an EC_POINT given the group of a curve and the affine coordinates
     provided.
@@ -123,7 +121,7 @@ def _get_EC_POINT_via_affine(affine_x, affine_y, curve: Curve):
     return new_point
 
 
-def _get_affine_coords_via_EC_POINT(ec_point, curve: Curve):
+def _get_affine_coords_via_EC_POINT(ec_point, curve: 'Curve'):
     """
     Returns the affine coordinates of a given point on the provided ec_group.
     """

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -19,8 +19,8 @@ class UmbralParameters(object):
 
     def __eq__(self, other):
 
-        self_curve_nid = backend._elliptic_curve_to_nid(self.curve)
-        other_curve_nid = backend._elliptic_curve_to_nid(other.curve)
+        self_curve_nid = self.curve.curve_nid
+        other_curve_nid = other.curve.curve_nid
 
         # TODO: This is not comparing the order, which currently is an OpenSSL pointer
         self_attributes = self_curve_nid, self.g, self.CURVE_KEY_SIZE_BYTES, self.u

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -1,23 +1,18 @@
-from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.backends.openssl import backend
 from umbral import openssl
+from umbral.curve import Curve
 
 
 class UmbralParameters(object):
-    def __init__(self, curve: ec.EllipticCurve):
+    def __init__(self, curve: Curve):
         from umbral.point import Point, unsafe_hash_to_point
-        from umbral.utils import get_curve_keysize_bytes
+        from umbral.utils import get_field_order_size_in_bytes
 
         self.curve = curve
-        curve_nid = backend._elliptic_curve_to_nid(curve)
+        self.CURVE_KEY_SIZE_BYTES = get_field_order_size_in_bytes(self.curve)
 
-        self.g = Point.get_generator_from_curve(self.curve)
-
-        self.order = openssl._get_ec_order_by_curve_nid(curve_nid)
-
-        g_bytes = self.g.to_bytes(is_compressed=True)
-
-        self.CURVE_KEY_SIZE_BYTES = get_curve_keysize_bytes(self.curve)
+        self.g = Point.get_generator_from_curve(curve=curve)
+        g_bytes = self.g.to_bytes()
 
         parameters_seed = b'NuCypherKMS/UmbralParameters/'
         self.u = unsafe_hash_to_point(g_bytes, self, parameters_seed + b'u')

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -67,9 +67,9 @@ class Point(object):
 
         group = openssl._get_ec_group_by_curve_nid(curve.curve_nid)
         ec_point = openssl._get_EC_POINT_via_affine(affine_x, affine_y,
-                                                    ec_group=self.curve.ec_group)
+                                                    ec_group=curve.ec_group)
 
-        return cls(ec_point, curve_nid, group)
+        return cls(ec_point, curve)
 
     def to_affine(self):
         """

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -1,11 +1,11 @@
 from umbral.curvebn import CurveBN 
 from cryptography.hazmat.backends.openssl import backend
-from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import hashes
 from cryptography.exceptions import InternalError
 
 from umbral import openssl
 from umbral.config import default_curve
+from umbral.curve import Curve
 from umbral.utils import get_field_order_size_in_bytes
 from umbral.params import UmbralParameters
 
@@ -15,13 +15,12 @@ class Point(object):
     Represents an OpenSSL EC_POINT except more Pythonic
     """
 
-    def __init__(self, ec_point, curve_nid, group):
+    def __init__(self, ec_point, curve: Curve):
         self.ec_point = ec_point
-        self.curve_nid = curve_nid
-        self.group = group
+        self.curve = curve
 
     @classmethod
-    def expected_bytes_length(cls, curve: ec.EllipticCurve=None):
+    def expected_bytes_length(cls, curve: Curve=None):
         """
         Returns the size (in bytes) of a compressed Point given a curve.
         If no curve is provided, it uses the default curve.
@@ -30,16 +29,15 @@ class Point(object):
         return get_field_order_size_in_bytes(curve) + 1
 
     @classmethod
-    def gen_rand(cls, curve: ec.EllipticCurve=None):
+    def gen_rand(cls, curve: Curve=None):
         """
         Returns a Point object with a cryptographically secure EC_POINT based
         on the provided curve.
         """
         curve = curve if curve is not None else default_curve()
-        curve_nid = backend._elliptic_curve_to_nid(curve)
 
-        group = openssl._get_ec_group_by_curve_nid(curve_nid)
-        generator = openssl._get_ec_generator_by_curve_nid(curve_nid)
+        group = openssl._get_ec_group_by_curve_nid(curve.curve_nid)
+        generator = openssl._get_ec_generator_by_curve_nid(curve.curve_nid)
 
         rand_point = openssl._get_new_EC_POINT(ec_group=group)
         rand_bn = CurveBN.gen_rand(curve).bignum
@@ -50,20 +48,15 @@ class Point(object):
             )
             backend.openssl_assert(res == 1)
 
-        return cls(rand_point, curve_nid, group)
+        return cls(rand_point, curve)
 
     @classmethod
-    def from_affine(cls, coords, curve: ec.EllipticCurve=None):
+    def from_affine(cls, coords, curve: Curve=None):
         """
         Returns a Point object from the given affine coordinates in a tuple in
         the format of (x, y) and a given curve.
         """
         curve = curve if curve is not None else default_curve()
-        try:
-            curve_nid = backend._elliptic_curve_to_nid(curve)
-        except AttributeError:
-            # Presume that the user passed in the curve_nid
-            curve_nid = curve
 
         affine_x, affine_y = coords
         if type(affine_x) == int:
@@ -72,8 +65,9 @@ class Point(object):
         if type(affine_y) == int:
             affine_y = openssl._int_to_bn(affine_y)
 
-        group = openssl._get_ec_group_by_curve_nid(curve_nid)
-        ec_point = openssl._get_EC_POINT_via_affine(affine_x, affine_y, ec_group=group)
+        group = openssl._get_ec_group_by_curve_nid(curve.curve_nid)
+        ec_point = openssl._get_EC_POINT_via_affine(affine_x, affine_y,
+                                                    ec_group=self.curve.ec_group)
 
         return cls(ec_point, curve_nid, group)
 
@@ -83,20 +77,15 @@ class Point(object):
         the point in the curve.
         """
         affine_x, affine_y = openssl._get_affine_coords_via_EC_POINT(
-                                self.ec_point, ec_group=self.group)
+                                self.ec_point, ec_group=self.curve.ec_group)
         return (backend._bn_to_int(affine_x), backend._bn_to_int(affine_y))
 
     @classmethod
-    def from_bytes(cls, data, curve: ec.EllipticCurve=None):
+    def from_bytes(cls, data, curve: Curve=None):
         """
         Returns a Point object from the given byte data on the curve provided.
         """
         curve = curve if curve is not None else default_curve()
-        try:
-            curve_nid = backend._elliptic_curve_to_nid(curve)
-        except AttributeError:
-            # Presume that the user passed in the curve_nid
-            curve_nid = curve
 
         compressed_size = cls.expected_bytes_length(curve)
         # Check if compressed
@@ -107,20 +96,21 @@ class Point(object):
             affine_x = CurveBN.from_bytes(data[1:], curve)
             type_y = data[0] - 2
 
-            ec_point = openssl._get_new_EC_POINT(ec_group=affine_x.group)
+            ec_point = openssl._get_new_EC_POINT(ec_group=curve.ec_group)
             with backend._tmp_bn_ctx() as bn_ctx:
                 res = backend._lib.EC_POINT_set_compressed_coordinates_GFp(
-                    affine_x.group, ec_point, affine_x.bignum, type_y, bn_ctx
+                    curve.ec_group, ec_point, affine_x.bignum, type_y, bn_ctx
                 )
                 backend.openssl_assert(res == 1)
-            return cls(ec_point, curve_nid, affine_x.group)
+            return cls(ec_point, curve)
 
         # Handle uncompressed point
+        # TODO: Give better error messages
         elif data[0] == 4:
             coord_size = compressed_size - 1
-            uncompressed_size = 1 + 2*coord_size
+            uncompressed_size = 1 + (2 * coord_size)
             if len(data) != uncompressed_size:
-                raise ValueError("uncompressed point does not have right size.")
+                raise ValueError("Uncompressed point does not have right size.")
             affine_x = int.from_bytes(data[1:coord_size+1], 'big')
             affine_y = int.from_bytes(data[1+coord_size:], 'big')
 
@@ -135,8 +125,8 @@ class Point(object):
         """
         affine_x, affine_y = self.to_affine()
 
-        # Get size of curve via order
-        order = openssl._get_ec_order_by_curve_nid(self.curve_nid)
+        # TODO: Get size of curve via OpenSSL
+        order = openssl._get_ec_order_by_curve_nid(self.curve.curve_nid)
         key_size = backend._lib.BN_num_bytes(order)
 
         if is_compressed:
@@ -151,21 +141,12 @@ class Point(object):
         return data
 
     @classmethod
-    def get_generator_from_curve(cls, curve: ec.EllipticCurve=None):
+    def get_generator_from_curve(cls, curve: Curve=None):
         """
         Returns the generator Point from the given curve as a Point object.
         """
         curve = curve if curve is not None else default_curve()
-        try:
-            curve_nid = backend._elliptic_curve_to_nid(curve)
-        except AttributeError:
-            # Presume that the user passed in the curve_nid
-            curve_nid = curve
-
-        group = openssl._get_ec_group_by_curve_nid(curve_nid)
-        generator = openssl._get_ec_generator_by_curve_nid(curve_nid)
-
-        return cls(generator, curve_nid, group)
+        return cls(curve.generator, curve)
 
     def __eq__(self, other):
         """
@@ -173,7 +154,7 @@ class Point(object):
         """
         with backend._tmp_bn_ctx() as bn_ctx:
             is_equal = backend._lib.EC_POINT_cmp(
-                self.group, self.ec_point, other.ec_point, bn_ctx
+                self.curve.ec_group, self.ec_point, other.ec_point, bn_ctx
             )
             backend.openssl_assert(is_equal != -1)
 
@@ -184,14 +165,16 @@ class Point(object):
         """
         Performs an EC_POINT_mul on an EC_POINT and a BIGNUM.
         """
-        prod = openssl._get_new_EC_POINT(ec_group=self.group)
+        # TODO: Check that both points use the same curve.
+        prod = openssl._get_new_EC_POINT(ec_group=self.curve.ec_group)
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_POINT_mul(
-                self.group, prod, backend._ffi.NULL, self.ec_point, other.bignum, bn_ctx
+                self.curve.ec_group, prod, backend._ffi.NULL,
+                self.ec_point, other.bignum, bn_ctx
             )
             backend.openssl_assert(res == 1)
 
-        return Point(prod, self.curve_nid, self.group)
+        return Point(prod, self.curve)
 
     __rmul__ = __mul__
 
@@ -199,13 +182,13 @@ class Point(object):
         """
         Performs an EC_POINT_add on two EC_POINTS.
         """
-        op_sum = openssl._get_new_EC_POINT(ec_group=self.group)
+        op_sum = openssl._get_new_EC_POINT(ec_group=self.curve.ec_group)
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_POINT_add(
-                self.group, op_sum, self.ec_point, other.ec_point, bn_ctx
+                self.curve.ec_group, op_sum, self.ec_point, other.ec_point, bn_ctx
             )
             backend.openssl_assert(res == 1)
-        return Point(op_sum, self.curve_nid, self.group)
+        return Point(op_sum, self.curve)
 
     def __sub__(self, other):
         """
@@ -217,16 +200,16 @@ class Point(object):
         """
         Performs an EC_POINT_invert on itself.
         """
-        inv = backend._lib.EC_POINT_dup(self.ec_point, self.group)
+        inv = backend._lib.EC_POINT_dup(self.ec_point, self.curve.ec_group)
         backend.openssl_assert(inv != backend._ffi.NULL)
         inv = backend._ffi.gc(inv, backend._lib.EC_POINT_clear_free)
 
         with backend._tmp_bn_ctx() as bn_ctx:
             res = backend._lib.EC_POINT_invert(
-                self.group, inv, bn_ctx
+                self.curve.ec_group, inv, bn_ctx
             )
             backend.openssl_assert(res == 1)
-        return Point(inv, self.curve_nid, self.group)
+        return Point(inv, self.curve)
 
     def __bytes__(self):
         return self.to_bytes()

--- a/umbral/signing.py
+++ b/umbral/signing.py
@@ -3,13 +3,13 @@ import hmac
 from cryptography.exceptions import InvalidSignature
 
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
-from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import hashes
 
 from umbral.config import default_curve
+from umbral.curve import Curve
 from umbral.keys import UmbralPublicKey, UmbralPrivateKey
 from umbral.curvebn import CurveBN
-from umbral.utils import get_curve_keysize_bytes
+from umbral.utils import get_field_order_size_in_bytes
 
 _BLAKE2B = hashes.BLAKE2b(64)
 
@@ -28,9 +28,9 @@ class Signature:
         return "ECDSA Signature: {}".format(bytes(self).hex()[:15])
 
     @classmethod
-    def expected_bytes_length(cls, curve: ec.EllipticCurve = None):
+    def expected_bytes_length(cls, curve: Curve = None):
         curve = curve if curve is not None else default_curve()
-        return get_curve_keysize_bytes(curve) * 2
+        return get_field_order_size_in_bytes(curve) * 2
 
     def verify(self, message: bytes, verifying_key: UmbralPublicKey) -> bool:
         """
@@ -54,7 +54,7 @@ class Signature:
         return True
 
     @classmethod
-    def from_bytes(cls, signature_as_bytes, der_encoded=False, curve: ec.EllipticCurve = None):
+    def from_bytes(cls, signature_as_bytes, der_encoded=False, curve: Curve = None):
         curve = curve if curve is not None else default_curve()
         if der_encoded:
             r, s = decode_dss_signature(signature_as_bytes)

--- a/umbral/signing.py
+++ b/umbral/signing.py
@@ -2,6 +2,7 @@ import hmac
 
 from cryptography.exceptions import InvalidSignature
 
+from cryptography.hazmat.primitives.asymmetric.ec import ECDSA
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
 from cryptography.hazmat.primitives import hashes
 
@@ -48,7 +49,7 @@ class Signature:
             cryptography_pub_key.verify(
                 self._der_encoded_bytes(),
                 message,
-                ec.ECDSA(_BLAKE2B)
+                ECDSA(_BLAKE2B)
             )
         except InvalidSignature:
             return False
@@ -104,5 +105,5 @@ class Signer:
          :param message: Message to hash and sign
          :return: signature
          """
-        signature_der_bytes = self.__cryptography_private_key.sign(message, ec.ECDSA(_BLAKE2B))
+        signature_der_bytes = self.__cryptography_private_key.sign(message, ECDSA(_BLAKE2B))
         return Signature.from_bytes(signature_der_bytes, der_encoded=True, curve=self._curve)

--- a/umbral/signing.py
+++ b/umbral/signing.py
@@ -43,6 +43,7 @@ class Signature:
         """
         cryptography_pub_key = verifying_key.to_cryptography_pubkey()
 
+        # TODO: Raise error instead of returning boolean
         try:
             cryptography_pub_key.verify(
                 self._der_encoded_bytes(),

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -6,6 +6,7 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.asymmetric import ec
 from umbral import openssl
 
+
 def lambda_coeff(id_i, selected_ids):
     ids = [x for x in selected_ids if x != id_i]
 
@@ -41,18 +42,7 @@ def kdf(ecpoint, key_length):
     ).derive(data)
 
 
-def get_curve_keysize_bytes(curve):
-    return (curve.key_size + 7) // 8
-
 def get_field_order_size_in_bytes(curve):
-
     backend = default_backend()
-    try:
-        curve_nid = backend._elliptic_curve_to_nid(curve)
-    except AttributeError:
-        # Presume that the user passed in the curve_nid
-        curve_nid = curve
-
-    group = openssl._get_ec_group_by_curve_nid(curve_nid)
-    size_in_bits = openssl._get_ec_group_degree(group)
+    size_in_bits = openssl._get_ec_group_degree(curve.ec_group)
     return (size_in_bits + 7) // 8


### PR DESCRIPTION
### What this does:
1. Creates a `Curve` object that uses a whitelist as to which curves can be instantiated.
   1. SECP256K1
   2. SECP256R1 (P-256)
   3. SECP384R1 (P-384)
2. Adds `SECP256K1`, `SECP256R1`, and `SECP384R1` curve objects.
3. Refactors the `openssl` module to use `curve` objects instead of `EC_GROUP` structs.
4. The `params` and `config` modules return an already instantiated `Curve` object. This prevents unnecessary creations of an `EC_GROUP` struct.
5. Items 3 & 4 _significantly_ reduce the memory consumption of pyUmbral. The memory leak is _no more_.
6. When creating `CurveBN` and `Point` objects, you no longer pass in a `group`, `order`, and `curve_nid`. Instead, you pass in an already instantiated `Curve` object.
7. Multi-curve support is now significantly cleaner.