### PR TITLE
PEP 484 Type Hints for pyUmbral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,4 @@ pytest.ini
 /tests/metrics/.benchmarks/
 tests/metrics/histograms/
 .circleci/execute_build.sh
+/monkeytype.sqlite3

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,10 @@
 [mypy]
 python_version=3.6
-verbosity=1
+verbosity=0
+ignore_missing_imports=True
 [mypy-umbral.*]
 disallow_untyped_defs=True
-check_untyped_defs=False
-disallow_untyped_calls=True
+check_untyped_defs=True
+disallow_untyped_calls=False
 [mypy-umbral.openssl]
 disallow_untyped_defs=False

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,8 +3,8 @@ python_version=3.6
 verbosity=0
 ignore_missing_imports=True
 [mypy-umbral.*]
-disallow_untyped_defs=True
-check_untyped_defs=True
+disallow_untyped_defs=False
+check_untyped_defs=False
 disallow_untyped_calls=False
 [mypy-umbral.openssl]
 disallow_untyped_defs=False

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,62 @@
+from collections import namedtuple
+
+import pytest
+
+from umbral import keys
+from umbral.curvebn import CurveBN
+from umbral.point import Point
+
+MockKeyPair = namedtuple('TestKeyPair', 'priv pub')
+
+
+parameters = [
+    # (N, M)
+    (1, 1),
+    (6, 1),
+    (6, 4),
+    (6, 6),
+    (50, 30)
+]
+
+wrong_parameters = [
+    # (N, M)
+    (-1, -1),   (-1, 0),    (-1, 5),
+    (0, -1),    (0, 0),     (0, 5),
+    (1, -1),    (1, 0),     (1, 5),
+    (5, -1),    (5, 0),     (5, 10)
+]
+
+
+@pytest.fixture(scope='function')
+def alices_keys():
+    delegating_priv = keys.UmbralPrivateKey.gen_key()
+    signing_priv = keys.UmbralPrivateKey.gen_key()
+    return delegating_priv, signing_priv
+
+
+@pytest.fixture(scope='function')
+def bobs_keys():
+    priv = keys.UmbralPrivateKey.gen_key()
+    pub = priv.get_pubkey()
+    return MockKeyPair(priv, pub)
+
+
+@pytest.fixture()
+def random_ec_point1():
+    yield Point.gen_rand()
+
+
+@pytest.fixture()
+def random_ec_point2():
+    yield Point.gen_rand()
+
+
+@pytest.fixture()
+def random_ec_curvebn1():
+    yield CurveBN.gen_rand()
+
+
+@pytest.fixture()
+def random_ec_curvebn2():
+    yield CurveBN.gen_rand()
+

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -1,20 +1,21 @@
+from typing import Optional
+
 from umbral.curvebn import CurveBN
-from umbral.config import default_params
 from umbral.keys import UmbralPublicKey
-from umbral.params import UmbralParameters
 
 
-def prove_cfrag_correctness(cfrag: "CapsuleFrag",
-                            kfrag: "KFrag",
-                            capsule: "Capsule",
-                            metadata: bytes = None
-                            ) -> "CorrectnessProof":
+def prove_cfrag_correctness(cfrag: 'CapsuleFrag',
+                            kfrag: 'KFrag',
+                            capsule: 'Capsule',
+                            metadata: Optional[bytes] = None
+                            ) -> 'CorrectnessProof':
+
     params = capsule._umbral_params
 
     rk = kfrag._bn_key
     t = CurveBN.gen_rand(params.curve)
     ####
-    ## Here are the formulaic constituents shared with `assess_cfrag_correctness`.
+    # Here are the formulaic constituents shared with `assess_cfrag_correctness`.
     ####
     e = capsule._point_e
     v = capsule._point_v
@@ -45,7 +46,7 @@ def prove_cfrag_correctness(cfrag: "CapsuleFrag",
         raise capsule.NotValid("Capsule verification failed.")
 
 
-def assess_cfrag_correctness(cfrag, capsule: "Capsule"):
+def assess_cfrag_correctness(cfrag: 'CapsuleFrag', capsule: 'Capsule') -> bool:
 
     correctness_keys = capsule.get_correctness_keys()
 
@@ -62,7 +63,7 @@ def assess_cfrag_correctness(cfrag, capsule: "Capsule"):
     params = capsule._umbral_params
 
     ####
-    ## Here are the formulaic constituents shared with `prove_cfrag_correctness`.
+    # Here are the formulaic constituents shared with `prove_cfrag_correctness`.
     ####
     e = capsule._point_e
     v = capsule._point_v
@@ -110,11 +111,11 @@ def assess_cfrag_correctness(cfrag, capsule: "Capsule"):
            & correct_rk_commitment
 
 
-def verify_kfrag(kfrag,
+def verify_kfrag(kfrag: 'KFrag',
                  delegating_pubkey: UmbralPublicKey,
-                 signing_pubkey,
+                 signing_pubkey: UmbralPublicKey,
                  receiving_pubkey: UmbralPublicKey
-                 ):
+                 ) -> bool:
 
 
     params = delegating_pubkey.params

--- a/umbral/config.py
+++ b/umbral/config.py
@@ -1,6 +1,8 @@
+from typing import Optional, Type, Union
 from warnings import warn
 
 from umbral.curve import Curve, SECP256K1
+from umbral.params import UmbralParameters
 
 
 class _CONFIG:
@@ -18,19 +20,19 @@ class _CONFIG:
         cls.set_curve(cls.__CURVE_TO_USE_IF_NO_DEFAULT_IS_SET_BY_USER)
 
     @classmethod
-    def params(cls):
+    def params(cls) -> UmbralParameters:
         if not cls.__params:
             cls.__set_curve_by_default()
         return cls.__params
 
     @classmethod
-    def curve(cls):
+    def curve(cls) -> Union[Type[SECP256R1], Type[SECP256K1]]:
         if not cls.__curve:
             cls.__set_curve_by_default()
         return cls.__curve
 
     @classmethod
-    def set_curve(cls, curve: Curve=None):
+    def set_curve(cls, curve: Optional[Curve] = None) -> None:
         if cls.__curve:
             raise cls.UmbralConfigurationError(
                 "You can only set the default curve once.  Do it once and then leave it alone.")
@@ -42,13 +44,13 @@ class _CONFIG:
             cls.__params = UmbralParameters(curve)
 
 
-def set_default_curve(curve: Curve=None):
+def set_default_curve(curve: Optional[Curve] = None) -> None:
     return _CONFIG.set_curve(curve)
 
 
-def default_curve():
+def default_curve() -> Union[Type[SECP256R1], Type[SECP256K1]]:
     return _CONFIG.curve()
 
 
-def default_params():
+def default_params() -> UmbralParameters:
     return _CONFIG.params()

--- a/umbral/config.py
+++ b/umbral/config.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, Union
+from typing import Optional, Type
 from warnings import warn
 
 from umbral.curve import Curve, SECP256K1
@@ -26,7 +26,7 @@ class _CONFIG:
         return cls.__params
 
     @classmethod
-    def curve(cls) -> Union[Type[SECP256R1], Type[SECP256K1]]:
+    def curve(cls) -> Type[Curve]:
         if not cls.__curve:
             cls.__set_curve_by_default()
         return cls.__curve
@@ -48,7 +48,7 @@ def set_default_curve(curve: Optional[Curve] = None) -> None:
     return _CONFIG.set_curve(curve)
 
 
-def default_curve() -> Union[Type[SECP256R1], Type[SECP256K1]]:
+def default_curve() -> Type[Curve]:
     return _CONFIG.curve()
 
 

--- a/umbral/curvebn.py
+++ b/umbral/curvebn.py
@@ -1,13 +1,11 @@
-import os
-
 from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives import hashes
 
 from umbral import openssl
-from umbral.config import default_curve, default_params
+from umbral.config import default_curve
 from umbral.curve import Curve
-from umbral.utils import get_field_order_size_in_bytes
 from umbral.params import UmbralParameters
+from umbral.utils import get_field_order_size_in_bytes
 
 
 class CurveBN(object):
@@ -27,7 +25,7 @@ class CurveBN(object):
         self.curve = curve
 
     @classmethod
-    def expected_bytes_length(cls, curve: Curve=None):
+    def expected_bytes_length(cls, curve: Curve=None) -> int:
         """
         Returns the size (in bytes) of a CurveBN given the curve.
         If no curve is provided, it uses the default.
@@ -36,7 +34,7 @@ class CurveBN(object):
         return get_field_order_size_in_bytes(curve)
 
     @classmethod
-    def gen_rand(cls, curve: Curve=None):
+    def gen_rand(cls, curve: Curve=None) -> 'CurveBN':
         """
         Returns a CurveBN object with a cryptographically secure OpenSSL BIGNUM
         based on the given curve.
@@ -56,7 +54,7 @@ class CurveBN(object):
         return cls(new_rand_bn, curve)
 
     @classmethod
-    def from_int(cls, num, curve: Curve=None):
+    def from_int(cls, num: int, curve: Curve=None) -> 'CurveBN':
         """
         Returns a CurveBN object from a given integer on a curve.
         By default, the underlying OpenSSL BIGNUM has BN_FLG_CONSTTIME set for
@@ -67,7 +65,7 @@ class CurveBN(object):
         return cls(conv_bn, curve)
 
     @classmethod
-    def hash(cls, *crypto_items, params: UmbralParameters):
+    def hash(cls, *crypto_items, params: UmbralParameters) -> 'CurveBN':
         # TODO: Clean this in an upcoming cleanup of pyUmbral
         blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
         for item in crypto_items:
@@ -101,7 +99,7 @@ class CurveBN(object):
         return cls(bignum, params.curve)
 
     @classmethod
-    def from_bytes(cls, data, curve: Curve=None):
+    def from_bytes(cls, data: bytes, curve: Curve=None) -> 'CurveBN':
         """
         Returns a CurveBN object from the given byte data that's within the size
         of the provided curve's order.
@@ -112,20 +110,20 @@ class CurveBN(object):
         num = int.from_bytes(data, 'big')
         return cls.from_int(num, curve)
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         """
         Returns the CurveBN as bytes.
         """
         size = backend._lib.BN_num_bytes(self.curve.order)
         return int.to_bytes(int(self), size, 'big')
 
-    def __int__(self):
+    def __int__(self) -> int:
         """
         Converts the CurveBN to a Python int.
         """
         return backend._bn_to_int(self.bignum)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """
         Compares the two BIGNUMS or int.
         """
@@ -137,7 +135,7 @@ class CurveBN(object):
         # -1 less than, 0 is equal to, 1 is greater than
         return not bool(backend._lib.BN_cmp(self.bignum, other.bignum))
 
-    def __pow__(self, other):
+    def __pow__(self, other) -> 'CurveBN':
         """
         Performs a BN_mod_exp on two BIGNUMS.
 
@@ -157,7 +155,7 @@ class CurveBN(object):
 
         return CurveBN(power, self.curve)
 
-    def __mul__(self, other):
+    def __mul__(self, other) -> 'CurveBN':
         """
         Performs a BN_mod_mul between two BIGNUMS.
         """
@@ -173,7 +171,7 @@ class CurveBN(object):
 
         return CurveBN(product, self.curve)
 
-    def __truediv__(self, other):
+    def __truediv__(self, other) -> 'CurveBN':
         """
         Performs a BN_div on two BIGNUMs (modulo the order of the curve).
 
@@ -193,7 +191,7 @@ class CurveBN(object):
 
         return CurveBN(product, self.curve)
 
-    def __add__(self, other):
+    def __add__(self, other) -> 'CurveBN':
         """
         Performs a BN_mod_add on two BIGNUMs.
         """
@@ -206,7 +204,7 @@ class CurveBN(object):
 
         return CurveBN(op_sum, self.curve)
 
-    def __sub__(self, other):
+    def __sub__(self, other) -> 'CurveBN':
         """
         Performs a BN_mod_sub on two BIGNUMS.
         """
@@ -219,7 +217,7 @@ class CurveBN(object):
 
         return CurveBN(diff, self.curve)
 
-    def __invert__(self):
+    def __invert__(self) -> 'CurveBN':
         """
         Performs a BN_mod_inverse.
 
@@ -235,7 +233,7 @@ class CurveBN(object):
 
         return CurveBN(inv, self.curve)
 
-    def __mod__(self, other):
+    def __mod__(self, other) -> 'CurveBN':
         """
         Performs a BN_nnmod on two BIGNUMS.
         """

--- a/umbral/dem.py
+++ b/umbral/dem.py
@@ -1,4 +1,6 @@
 import os
+from typing import Optional
+
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
 
@@ -7,7 +9,7 @@ DEM_NONCE_SIZE = 12
 
 
 class UmbralDEM(object):
-    def __init__(self, symm_key: bytes):
+    def __init__(self, symm_key: bytes) -> None:
         """
         Initializes an UmbralDEM object. Requires a key to perform
         ChaCha20-Poly1305.
@@ -19,7 +21,7 @@ class UmbralDEM(object):
 
         self.cipher = ChaCha20Poly1305(symm_key)
 
-    def encrypt(self, data: bytes, authenticated_data: bytes=None):
+    def encrypt(self, data: bytes, authenticated_data: Optional[bytes] = None) -> bytes:
         """
         Encrypts data using ChaCha20-Poly1305 with optional authenticated data.
         """
@@ -28,7 +30,7 @@ class UmbralDEM(object):
         # Ciphertext will be a 12 byte nonce, the ciphertext, and a 16 byte tag.
         return nonce + enc_data
 
-    def decrypt(self, ciphertext: bytes, authenticated_data: bytes=None):
+    def decrypt(self, ciphertext: bytes, authenticated_data: Optional[bytes] = None) -> bytes:
         """
         Decrypts data using ChaCha20-Poly1305 and validates the provided
         authenticated data.

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -154,7 +154,8 @@ class CapsuleFrag(object):
                  point_v1: Point,
                  kfrag_id: bytes,
                  point_noninteractive: Point,
-                 point_xcoord: Point, proof: Optional[CorrectnessProof] = None) -> None:
+                 point_xcoord: Point,
+                 proof: Optional[CorrectnessProof] = None) -> None:
 
         self._point_e1 = point_e1
         self._point_v1 = point_v1
@@ -203,7 +204,7 @@ class CapsuleFrag(object):
 
         proof = components.pop(-1) or None
         proof = CorrectnessProof.from_bytes(proof, curve) if proof else None
-        return cls(*components, proof)
+        return cls(*components, proof=proof)
 
     def to_bytes(self) -> bytes:
         """

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -1,19 +1,19 @@
-from bytestring_splitter import BytestringSplitter
-from cryptography.hazmat.primitives.asymmetric import ec
+from typing import Optional
 
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
+
+from bytestring_splitter import BytestringSplitter
 from umbral._pre import assess_cfrag_correctness, verify_kfrag
-from umbral.config import default_curve, default_params
+from umbral.config import default_curve
 from umbral.curvebn import CurveBN
 from umbral.keys import UmbralPublicKey
-from umbral.params import UmbralParameters
 from umbral.point import Point
-
 from umbral.signing import Signature
 
 
 class KFrag(object):
-    def __init__(self, id, bn_key, point_noninteractive,
-                 point_commitment, point_xcoord, signature):
+    def __init__(self, id: bytes, bn_key: CurveBN, point_noninteractive: Point,
+                 point_commitment: Point, point_xcoord: Point, signature: Signature) -> None:
         self._id = id
         self._bn_key = bn_key
         self._point_noninteractive = point_noninteractive
@@ -22,7 +22,7 @@ class KFrag(object):
         self.signature = signature
 
     @classmethod
-    def expected_bytes_length(cls, curve: ec.EllipticCurve = None):
+    def expected_bytes_length(cls, curve: Optional[EllipticCurve] = None) -> int:
         """
         Returns the size (in bytes) of a KFrag given the curve.
         If no curve is provided, it will use the default curve.
@@ -34,7 +34,7 @@ class KFrag(object):
         return (bn_size * 4) + (point_size * 3)
 
     @classmethod
-    def from_bytes(cls, data: bytes, curve: ec.EllipticCurve = None):
+    def from_bytes(cls, data: bytes, curve: Optional[EllipticCurve] = None) -> 'KFrag':
         """
         Instantiate a KFrag object from the serialized data.
         """
@@ -56,7 +56,7 @@ class KFrag(object):
 
         return cls(*components)
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         """
         Serialize the KFrag into a bytestring.
         """
@@ -69,19 +69,19 @@ class KFrag(object):
         return self._id + key + ni + commitment + xcoord + signature
 
     def verify(self,
-               signing_pubkey,
+               signing_pubkey: UmbralPublicKey,
                delegating_pubkey: UmbralPublicKey,
-               receiving_pubkey: UmbralPublicKey):
+               receiving_pubkey: UmbralPublicKey) -> bool:
 
         return verify_kfrag(self, delegating_pubkey, signing_pubkey, receiving_pubkey)
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return self.to_bytes()
 
 
 class CorrectnessProof(object):
-    def __init__(self, point_e2, point_v2, point_kfrag_commitment,
-                 point_kfrag_pok, bn_sig, kfrag_signature: bytes, metadata: bytes = None):
+    def __init__(self, point_e2: Point, point_v2: Point, point_kfrag_commitment: Point,
+                 point_kfrag_pok: Point, bn_sig: CurveBN, kfrag_signature: bytes, metadata: Optional[bytes] = None) -> None:
         self._point_e2 = point_e2
         self._point_v2 = point_v2
         self._point_kfrag_commitment = point_kfrag_commitment
@@ -91,7 +91,7 @@ class CorrectnessProof(object):
         self.kfrag_signature = kfrag_signature
 
     @classmethod
-    def expected_bytes_length(cls, curve: ec.EllipticCurve = None):
+    def expected_bytes_length(cls, curve: Optional[EllipticCurve] = None):
         """
         Returns the size (in bytes) of a CorrectnessProof without the metadata.
         If no curve is given, it will use the default curve.
@@ -103,7 +103,7 @@ class CorrectnessProof(object):
         return (bn_size * 3) + (point_size * 4)
 
     @classmethod
-    def from_bytes(cls, data: bytes, curve: ec.EllipticCurve = None):
+    def from_bytes(cls, data: bytes, curve: Optional[EllipticCurve] = None) -> 'CorrectnessProof':
         """
         Instantiate CorrectnessProof from serialized data.
         """
@@ -149,8 +149,13 @@ class CorrectnessProof(object):
 
 
 class CapsuleFrag(object):
-    def __init__(self, point_e1, point_v1, kfrag_id, point_noninteractive,
-                 point_xcoord, proof: CorrectnessProof = None):
+    def __init__(self,
+                 point_e1: Point,
+                 point_v1: Point,
+                 kfrag_id: bytes,
+                 point_noninteractive: Point,
+                 point_xcoord: Point, proof: Optional[CorrectnessProof] = None) -> None:
+
         self._point_e1 = point_e1
         self._point_v1 = point_v1
         self._kfrag_id = kfrag_id
@@ -164,7 +169,7 @@ class CapsuleFrag(object):
         """
 
     @classmethod
-    def expected_bytes_length(cls, curve: ec.EllipticCurve = None):
+    def expected_bytes_length(cls, curve: Optional[EllipticCurve] = None) -> int:
         """
         Returns the size (in bytes) of a CapsuleFrag given the curve without
         the CorrectnessProof.
@@ -177,7 +182,7 @@ class CapsuleFrag(object):
         return (bn_size * 1) + (point_size * 4)
 
     @classmethod
-    def from_bytes(cls, data: bytes, curve: ec.EllipticCurve = None):
+    def from_bytes(cls, data: bytes, curve: Optional[EllipticCurve] = None) -> 'CapsuleFrag':
         """
         Instantiates a CapsuleFrag object from the serialized data.
         """
@@ -200,7 +205,7 @@ class CapsuleFrag(object):
         proof = CorrectnessProof.from_bytes(proof, curve) if proof else None
         return cls(*components, proof)
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         """
         Serialize the CapsuleFrag into a bytestring.
         """
@@ -216,10 +221,10 @@ class CapsuleFrag(object):
 
         return serialized_cfrag
 
-    def verify_correctness(self, capsule: "Capsule"):
+    def verify_correctness(self, capsule: 'Capsule') -> bool:
         return assess_cfrag_correctness(self, capsule)
 
-    def attach_proof(self, e2, v2, u1, u2, z3, kfrag_signature, metadata):
+    def attach_proof(self, e2: Point, v2: Point, u1: Point, u2: Point, z3: CurveBN, kfrag_signature: Signature, metadata: Optional[bytes]) -> None:
         self.proof = CorrectnessProof(point_e2=e2,
                                       point_v2=v2,
                                       point_kfrag_commitment=u1,
@@ -229,5 +234,5 @@ class CapsuleFrag(object):
                                       metadata=metadata,
                                       )
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return self.to_bytes()

--- a/umbral/openssl.py
+++ b/umbral/openssl.py
@@ -1,7 +1,9 @@
+import typing
 from contextlib import contextmanager
 from cryptography.hazmat.backends.openssl import backend
 
 
+@typing.no_type_check
 def _get_new_BN(set_consttime_flag=True):
     """
     Returns a new and initialized OpenSSL BIGNUM.
@@ -18,6 +20,7 @@ def _get_new_BN(set_consttime_flag=True):
     return new_bn
 
 
+@typing.no_type_check
 def _get_ec_group_by_curve_nid(curve_nid: int):
     """
     Returns the group of a given curve via its OpenSSL nid. This must be freed
@@ -29,6 +32,7 @@ def _get_ec_group_by_curve_nid(curve_nid: int):
     return group
 
 
+@typing.no_type_check
 def _get_ec_order_by_group(ec_group):
     """
     Returns the order of a given curve via its OpenSSL EC_GROUP.
@@ -40,6 +44,7 @@ def _get_ec_order_by_group(ec_group):
     return ec_order
 
 
+@typing.no_type_check
 def _get_ec_generator_by_group(ec_group):
     """
     Returns the generator point of a given curve via its OpenSSL EC_GROUP.
@@ -51,6 +56,7 @@ def _get_ec_generator_by_group(ec_group):
     return generator
 
 
+@typing.no_type_check
 def _get_ec_group_degree(ec_group):
     """
     Returns the number of bits needed to represent the order of the finite 
@@ -59,6 +65,7 @@ def _get_ec_group_degree(ec_group):
     return backend._lib.EC_GROUP_get_degree(ec_group) 
 
 
+@typing.no_type_check
 def _bn_is_on_curve(check_bn, curve: 'Curve'):
     """
     Checks if a given OpenSSL BIGNUM is within the provided curve's order.
@@ -73,6 +80,7 @@ def _bn_is_on_curve(check_bn, curve: 'Curve'):
     return check_sign == 1 and range_check == -1
 
 
+@typing.no_type_check
 def _int_to_bn(py_int: int, curve: 'Curve'=None, set_consttime_flag=True):
     """
     Converts the given Python int to an OpenSSL BIGNUM. If a curve is
@@ -95,6 +103,7 @@ def _int_to_bn(py_int: int, curve: 'Curve'=None, set_consttime_flag=True):
     return conv_bn
 
 
+@typing.no_type_check
 def _get_new_EC_POINT(curve: 'Curve'):
     """
     Returns a new and initialized OpenSSL EC_POINT given the group of a curve.
@@ -107,6 +116,7 @@ def _get_new_EC_POINT(curve: 'Curve'):
     return new_point
 
 
+@typing.no_type_check
 def _get_EC_POINT_via_affine(affine_x, affine_y, curve: 'Curve'):
     """
     Returns an EC_POINT given the group of a curve and the affine coordinates
@@ -121,6 +131,7 @@ def _get_EC_POINT_via_affine(affine_x, affine_y, curve: 'Curve'):
     return new_point
 
 
+@typing.no_type_check
 def _get_affine_coords_via_EC_POINT(ec_point, curve: 'Curve'):
     """
     Returns the affine coordinates of a given point on the provided ec_group.
@@ -136,6 +147,7 @@ def _get_affine_coords_via_EC_POINT(ec_point, curve: 'Curve'):
     return (affine_x, affine_y)
 
 
+@typing.no_type_check
 @contextmanager
 def _tmp_bn_mont_ctx(modulus):
     """

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -1,10 +1,11 @@
 from cryptography.hazmat.backends.openssl import backend
+
 from umbral import openssl
 from umbral.curve import Curve
 
 
 class UmbralParameters(object):
-    def __init__(self, curve: Curve):
+    def __init__(self, curve: Curve) -> None:
         from umbral.point import Point, unsafe_hash_to_point
         from umbral.utils import get_field_order_size_in_bytes
 
@@ -17,7 +18,7 @@ class UmbralParameters(object):
         parameters_seed = b'NuCypherKMS/UmbralParameters/'
         self.u = unsafe_hash_to_point(g_bytes, self, parameters_seed + b'u')
 
-    def __eq__(self, other):
+    def __eq__(self, other: 'UmbralParameters') -> bool:
 
         self_curve_nid = self.curve.curve_nid
         other_curve_nid = other.curve.curve_nid

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -1,13 +1,14 @@
-from typing import Tuple, Union, List
+import os
+from typing import Dict, List, Optional, Tuple, Union
+
+from cryptography.hazmat.backends.openssl import backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 
 from bytestring_splitter import BytestringSplitter
-from cryptography.hazmat.backends.openssl import backend
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives import hashes
-
-from umbral._pre import prove_cfrag_correctness, assess_cfrag_correctness
+from umbral._pre import prove_cfrag_correctness
+from umbral.config import default_curve
 from umbral.curvebn import CurveBN
-from umbral.config import default_params, default_curve
 from umbral.dem import UmbralDEM, DEM_KEYSIZE
 from umbral.fragments import KFrag, CapsuleFrag
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
@@ -15,7 +16,6 @@ from umbral.params import UmbralParameters
 from umbral.point import Point
 from umbral.signing import Signer
 from umbral.utils import poly_eval, lambda_coeff, kdf
-import os
 
 
 class GenericUmbralError(Exception):
@@ -23,7 +23,7 @@ class GenericUmbralError(Exception):
 
 
 class UmbralCorrectnessError(GenericUmbralError):
-    def __init__(self, message, offending_cfrags):
+    def __init__(self, message: str, offending_cfrags: List[CapsuleFrag]) -> None:
         super().__init__(message)
         self.offending_cfrags = offending_cfrags
 
@@ -31,15 +31,16 @@ class UmbralCorrectnessError(GenericUmbralError):
 class Capsule(object):
     def __init__(self,
                  params: UmbralParameters,
-                 point_e=None,
-                 point_v=None,
-                 bn_sig=None,
-                 point_e_prime=None,
-                 point_v_prime=None,
-                 point_noninteractive=None,
-                 delegating_pubkey: UmbralPublicKey = None,
-                 receiving_pubkey: UmbralPublicKey = None,
-                 verifying_pubkey=None):
+                 point_e: Optional[Point] = None,
+                 point_v: Optional[Union[int, Point]] = None,
+                 bn_sig: Optional[Union[int, CurveBN]] = None,
+                 point_e_prime: Optional[Point] = None,
+                 point_v_prime: Optional[Union[int, Point]] = None,
+                 point_noninteractive: Optional[Union[int, Point]] = None,
+                 delegating_pubkey: Optional[UmbralPublicKey] = None,
+                 receiving_pubkey: Optional[UmbralPublicKey] = None,
+                 verifying_pubkey: None = None
+                 ) -> None:
 
         self._umbral_params = params
 
@@ -69,7 +70,7 @@ class Capsule(object):
         self._attached_cfrags = list()
 
     @classmethod
-    def expected_bytes_length(cls, curve: ec.EllipticCurve = None, activated=False):
+    def expected_bytes_length(cls, curve: Optional[EllipticCurve] = None, activated: bool = False) -> int:
         """
         Returns the size (in bytes) of a Capsule given the curve.
         If no curve is provided, it will use the default curve.
@@ -89,7 +90,7 @@ class Capsule(object):
         """
 
     @classmethod
-    def from_bytes(cls, capsule_bytes: bytes, params: UmbralParameters):
+    def from_bytes(cls, capsule_bytes: bytes, params: UmbralParameters) -> 'Capsule':
         """
         Instantiates a Capsule object from the serialized data.
         """
@@ -123,7 +124,7 @@ class Capsule(object):
         components = splitter(capsule_bytes)
         return cls(params, *components)
 
-    def _set_cfrag_correctness_key(self, key_type, key: UmbralPublicKey):
+    def _set_cfrag_correctness_key(self, key_type: str, key: UmbralPublicKey) -> bool:
         if key_type not in ("delegating", "receiving", "verifying"): 
             raise ValueError("You can only set 'delegating', 'receiving' or 'verifying' keys.") 
 
@@ -142,15 +143,15 @@ class Capsule(object):
         else:
             raise ValueError("The {} key is already set; you can't set it again.".format(key_type))
 
-
-    def get_correctness_keys(self):
+    def get_correctness_keys(self) -> Dict[str, Union[UmbralPublicKey, None]]:
         return dict(self._cfrag_correctness_keys)
 
     def set_correctness_keys(self,
-                 delegating: UmbralPublicKey = None,
-                 receiving: UmbralPublicKey = None,
-                 verifying=None
-                 ):
+                             delegating: Optional[UmbralPublicKey] = None,
+                             receiving: Optional[UmbralPublicKey] = None,
+                             verifying: Optional[UmbralPublicKey] = None
+                             ) -> Tuple[bool, bool, bool]:
+
         delegating_key_details = self._set_cfrag_correctness_key("delegating", delegating)
         receiving_key_details = self._set_cfrag_correctness_key("receiving", receiving)
         verifying_key_details = self._set_cfrag_correctness_key("verifying", verifying)
@@ -236,10 +237,10 @@ class Capsule(object):
         self._point_v_prime = v
         self._point_noninteractive = ni
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return self.to_bytes()
 
-    def __eq__(self, other):
+    def __eq__(self, other: 'Capsule') -> bool:
         """
         If both Capsules are activated, we compare only the activated components.
         Otherwise, we compare only original components.
@@ -260,7 +261,7 @@ class Capsule(object):
             # Again, it's hard to imagine why.
             return False
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         # We only ever want to store in a hash table based on original components;
         # A Capsule that is part of a dict needs to continue to be lookup-able even
         # after activation.
@@ -268,7 +269,7 @@ class Capsule(object):
         component_bytes = tuple(component.to_bytes() for component in self.original_components())
         return hash(component_bytes)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._attached_cfrags)
 
 
@@ -349,8 +350,8 @@ def split_rekey(delegating_privkey: UmbralPrivateKey, signer: Signer,
     return kfrags
 
 
-def reencrypt(kfrag: KFrag, capsule: Capsule, provide_proof = True, 
-              metadata: bytes = None) -> CapsuleFrag:
+def reencrypt(kfrag: KFrag, capsule: Capsule, provide_proof: bool = True, 
+              metadata: Optional[bytes] = None) -> CapsuleFrag:
 
     if not capsule.verify():
         raise capsule.NotValid
@@ -371,7 +372,7 @@ def reencrypt(kfrag: KFrag, capsule: Capsule, provide_proof = True,
 
 
 def _encapsulate(alice_pubkey: UmbralPublicKey, 
-                 key_length=DEM_KEYSIZE) -> Tuple[bytes, Capsule]:
+                 key_length: int = DEM_KEYSIZE) -> Tuple[bytes, Capsule]:
     """Generates a symmetric key and its associated KEM ciphertext"""
 
     params = alice_pubkey.params
@@ -395,7 +396,7 @@ def _encapsulate(alice_pubkey: UmbralPublicKey,
 
 
 def _decapsulate_original(priv_key: UmbralPrivateKey, capsule: Capsule, 
-                          key_length=DEM_KEYSIZE) -> bytes:
+                          key_length: int = DEM_KEYSIZE) -> bytes:
     """Derive the same symmetric key"""
 
     priv_key = priv_key.bn_key
@@ -412,7 +413,7 @@ def _decapsulate_original(priv_key: UmbralPrivateKey, capsule: Capsule,
 
 
 def _decapsulate_reencrypted(receiving_privkey: UmbralPrivateKey, capsule: Capsule,
-                             key_length=DEM_KEYSIZE) -> bytes:
+                             key_length: int = DEM_KEYSIZE) -> bytes:
     """Derive the same symmetric key"""
     params = capsule._umbral_params
 
@@ -459,7 +460,7 @@ def encrypt(alice_pubkey: UmbralPublicKey, plaintext: bytes) -> Tuple[bytes, Cap
 
 
 def _open_capsule(capsule: Capsule, receiving_privkey: UmbralPrivateKey,
-                  check_proof=True) -> bytes:
+                  check_proof: bool = True) -> bytes:
     """
     Activates the Capsule from the attached CFrags,
     opens the Capsule and returns what is inside.
@@ -486,7 +487,7 @@ def _open_capsule(capsule: Capsule, receiving_privkey: UmbralPrivateKey,
 
 
 def decrypt(ciphertext: bytes, capsule: Capsule, decrypting_key: UmbralPrivateKey,
-            check_proof=True) -> bytes:
+            check_proof: bool = True) -> bytes:
     """
     Opens the capsule and gets what's inside.
 

--- a/umbral/signing.py
+++ b/umbral/signing.py
@@ -4,7 +4,6 @@ from typing import Optional
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.ec import ECDSA
-from cryptography.hazmat.primitives.asymmetric.ec import Curve
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
 
 from umbral.config import default_curve

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -1,13 +1,14 @@
-import math
+from typing import List 
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from cryptography.hazmat.primitives.asymmetric import ec
+
 from umbral import openssl
+from umbral.curve import Curve
 
 
-def lambda_coeff(id_i, selected_ids):
+def lambda_coeff(id_i: 'CurveBN', selected_ids: List['CurveBN']) -> 'CurveBN':
     ids = [x for x in selected_ids if x != id_i]
 
     if not ids:
@@ -22,7 +23,7 @@ def lambda_coeff(id_i, selected_ids):
     return result
 
 
-def poly_eval(coeff, x):
+def poly_eval(coeff: List['CurveBN'], x: 'CurveBN') -> 'CurveBN':
     result = coeff[-1]
     for i in range(-2, -len(coeff) - 1, -1):
         result = ((result * x) + coeff[i])
@@ -30,7 +31,7 @@ def poly_eval(coeff, x):
     return result
 
 
-def kdf(ecpoint, key_length):
+def kdf(ecpoint: 'Point', key_length: int) -> bytes:
     data = ecpoint.to_bytes(is_compressed=True)
 
     return HKDF(
@@ -42,7 +43,7 @@ def kdf(ecpoint, key_length):
     ).derive(data)
 
 
-def get_field_order_size_in_bytes(curve):
+def get_field_order_size_in_bytes(curve: Curve) -> int:
     backend = default_backend()
     size_in_bits = openssl._get_ec_group_degree(curve.ec_group)
     return (size_in_bits + 7) // 8


### PR DESCRIPTION
#### Goal
Passing mypy checks, PEP 484 compliance.

##### Adds type annotations to the following modules:
- [X] `_pre.py`
- [X] `config.py`
- [ ] `curvebn.py`
- [X] `dem.py`
- [x] `fragments.py`
- [X] `keys.py`
- [x] `opensll.py` - Skipped
- [X] `params.py`
- [ ] `point.py`
- [X] `pre.py`
- [X] `signing.py`
- [X] `utils.py`

See: #183 