### PR TITLE
Fixed incorrect Point operations 

### DIFF
--- a/tests/test_primitives/test_point/test_point_arithmetic.py
+++ b/tests/test_primitives/test_point/test_point_arithmetic.py
@@ -5,10 +5,10 @@ from umbral.point import Point
 def test_mocked_openssl_point_arithmetic(mock_openssl, random_ec_point1, random_ec_point2, random_ec_curvebn1):
 
     operations_that_construct = (
-        random_ec_point1 * random_ec_curvebn1,  # __mul__
+        random_ec_point1 * random_ec_curvebn1, # __mul__
         random_ec_point1 + random_ec_point2,   # __add__
         random_ec_point1 - random_ec_point2,   # __sub__
-        -random_ec_point1                      # __invert__
+        -random_ec_point1                      # __neg__
     )
 
     with mock_openssl():

--- a/tests/test_primitives/test_point/test_point_arithmetic.py
+++ b/tests/test_primitives/test_point/test_point_arithmetic.py
@@ -8,7 +8,7 @@ def test_mocked_openssl_point_arithmetic(mock_openssl, random_ec_point1, random_
         random_ec_point1 * random_ec_curvebn1,  # __mul__
         random_ec_point1 + random_ec_point2,   # __add__
         random_ec_point1 - random_ec_point2,   # __sub__
-        ~random_ec_point1                      # __invert__
+        -random_ec_point1                      # __invert__
     )
 
     with mock_openssl():

--- a/tests/test_primitives/test_point/test_point_serializers.py
+++ b/tests/test_primitives/test_point/test_point_serializers.py
@@ -131,3 +131,18 @@ def test_serialize_point_at_infinity():
     # We want to catch specific InternalExceptions:
     # - Point at infinity (code 107)
     assert e.value.err_code[0].reason == 106
+
+
+def test_some_interesting_points():
+
+    compressed = 0x02fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c
+    compressed = compressed.to_bytes(32+1, byteorder='big')
+
+    last_point = Point.from_bytes(compressed)
+
+    coords = (115792089237316195423570985008687907853269984665640564039457584007908834671660, 
+        109188863561374057667848968960504138135859662956057034999983532397866404169138)
+
+    assert last_point == Point.from_affine(coords)
+
+    # TODO: add point with x == 0 or y== 0

--- a/tests/test_primitives/test_point/test_point_serializers.py
+++ b/tests/test_primitives/test_point/test_point_serializers.py
@@ -129,20 +129,22 @@ def test_serialize_point_at_infinity():
         _bytes_point_at_infinity = point_at_infinity.to_bytes()
 
     # We want to catch specific InternalExceptions:
-    # - Point at infinity (code 107)
+    # - Point at infinity (code 106)
     assert e.value.err_code[0].reason == 106
 
 
-def test_some_interesting_points():
+def test_coords_with_special_characteristics():
 
+    # Testing that a point with the x coordinate greater than the curve order is still valid
     compressed = 0x02fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c
     compressed = compressed.to_bytes(32+1, byteorder='big')
 
     last_point = Point.from_bytes(compressed)
 
+    # The same point, but obtained through the from_affine method
     coords = (115792089237316195423570985008687907853269984665640564039457584007908834671660, 
         109188863561374057667848968960504138135859662956057034999983532397866404169138)
 
     assert last_point == Point.from_affine(coords)
 
-    # TODO: add point with x == 0 or y== 0
+    # TODO: add point with x == 0 or y == 0, if existing

--- a/tests/test_primitives/test_point/test_point_serializers.py
+++ b/tests/test_primitives/test_point/test_point_serializers.py
@@ -118,3 +118,16 @@ def test_point_not_on_curve():
     from cryptography.exceptions import InternalError
     with pytest.raises(InternalError):
         Point.from_bytes(point_on_koblitz256_but_not_P256.to_bytes(), curve=SECP256R1)
+
+
+def test_serialize_point_at_infinity():
+
+    p = Point.gen_rand()
+    point_at_infinity = p - p
+    
+    with pytest.raises(InternalError) as e:
+        _bytes_point_at_infinity = point_at_infinity.to_bytes()
+
+    # We want to catch specific InternalExceptions:
+    # - Point at infinity (code 107)
+    assert e.value.err_code[0].reason == 106

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -196,11 +196,12 @@ class Point(object):
         """
         Performs subtraction by adding the inverse of the `other` to the point.
         """
-        return (self + (~other))
+        return (self + (-other))
 
-    def __invert__(self) -> 'Point':
+    def __neg__(self) -> 'Point':
         """
-        Performs an EC_POINT_invert on itself.
+        Computes the additive inverse of a Point, by performing an 
+        EC_POINT_invert on itself.
         """
         inv = backend._lib.EC_POINT_dup(self.ec_point, self.curve.ec_group)
         backend.openssl_assert(inv != backend._ffi.NULL)

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -66,10 +66,10 @@ class Point(object):
 
         affine_x, affine_y = coords
         if type(affine_x) == int:
-            affine_x = openssl._int_to_bn(affine_x, curve=curve)
+            affine_x = openssl._int_to_bn(affine_x, curve=None)
 
         if type(affine_y) == int:
-            affine_y = openssl._int_to_bn(affine_y, curve=curve)
+            affine_y = openssl._int_to_bn(affine_y, curve=None)
 
         ec_point = openssl._get_EC_POINT_via_affine(affine_x, affine_y, curve)
         return cls(ec_point, curve)
@@ -96,13 +96,15 @@ class Point(object):
             if len(data) != compressed_size:
                 raise ValueError("X coordinate too large for curve.")
 
-            affine_x = CurveBN.from_bytes(data[1:], curve)
+            affine_x = int.from_bytes(data[1:], 'big')
+            affine_x = openssl._int_to_bn(affine_x, curve=None)
+
             type_y = data[0] - 2
 
             ec_point = openssl._get_new_EC_POINT(curve)
             with backend._tmp_bn_ctx() as bn_ctx:
                 res = backend._lib.EC_POINT_set_compressed_coordinates_GFp(
-                    curve.ec_group, ec_point, affine_x.bignum, type_y, bn_ctx
+                    curve.ec_group, ec_point, affine_x, type_y, bn_ctx
                 )
                 backend.openssl_assert(res == 1)
             return cls(ec_point, curve)


### PR DESCRIPTION
## What this does ##
- `Point` was only allowing deserialization of EC points whose affine coordinates where lower than the order of the curve, which is incorrect. Instead, coordinates must be lower than the order of the base field. This was affecting potentially more than 10<sup>38</sup> EC points, but the probability of hitting one of them by chance is in the order of 10<sup>-39</sup>, so this went unnoticed. The problem was affecting `Point.from_affine` and `Point.from_bytes`. Now is fixed.
- In pyUmbral we use the additive notation for EC operations, but the additive opposite of an EC point was implemented with `Point.__invert__` (which maps to the unary operator `~`) instead of the more correct `Point.__neg__` (which maps to the unary operator `-`, usually representing the additive opposite).