### PR TITLE
Make unsafe_hash_to_point a little bit safer

### DIFF
--- a/umbral/params.py
+++ b/umbral/params.py
@@ -19,11 +19,8 @@ class UmbralParameters(object):
 
     def __eq__(self, other: 'UmbralParameters') -> bool:
 
-        self_curve_nid = self.curve.curve_nid
-        other_curve_nid = other.curve.curve_nid
-
         # TODO: This is not comparing the order, which currently is an OpenSSL pointer
-        self_attributes = self_curve_nid, self.g, self.CURVE_KEY_SIZE_BYTES, self.u
-        others_attributes = other_curve_nid, other.g, other.CURVE_KEY_SIZE_BYTES, other.u
+        self_attributes = self.curve, self.g, self.CURVE_KEY_SIZE_BYTES, self.u
+        others_attributes = other.curve, other.g, other.CURVE_KEY_SIZE_BYTES, other.u
 
         return self_attributes == others_attributes

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -5,7 +5,7 @@ from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives import hashes
 
 from umbral import openssl
-from umbral.config import default_curve
+from umbral.config import default_curve, default_params
 from umbral.curve import Curve
 from umbral.curvebn import CurveBN
 from umbral.params import UmbralParameters
@@ -218,7 +218,9 @@ class Point(object):
         return self.to_bytes()
 
 
-def unsafe_hash_to_point(data, params: UmbralParameters, label=None) -> 'Point':
+def unsafe_hash_to_point(data : bytes = b'', 
+                         params: UmbralParameters = None, 
+                         label : bytes = b'') -> 'Point':
     """
     Hashes arbitrary data into a valid EC point of the specified curve,
     using the try-and-increment method.
@@ -231,8 +233,8 @@ def unsafe_hash_to_point(data, params: UmbralParameters, label=None) -> 'Point':
     TODO: Check how to uniformly generate ycoords. Currently, it only outputs points
     where ycoord is even (i.e., starting with 0x02 in compressed notation)
     """
-    if label is None:
-        label = []
+
+    params = params if params is not None else default_params()
 
     # We use a 32-bit counter as additional input
     i = 1

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -233,12 +233,17 @@ def unsafe_hash_to_point(data : bytes = b'',
 
     params = params if params is not None else default_params()
 
-    # We use a 32-bit counter as additional input
-    i = 1
+    len_data = len(data).to_bytes(4, byteorder='big')
+    len_label = len(label).to_bytes(4, byteorder='big')
+
+    label_data = len_label + label + len_data + data
+
+    # We use an internal 32-bit counter as additional input
+    i = 0
     while i < 2**32:
         ibytes = i.to_bytes(4, byteorder='big')
         blake2b = hashes.Hash(hashes.BLAKE2b(64), backend=backend)
-        blake2b.update(label + ibytes + data)
+        blake2b.update(label_data + ibytes)
         hash_digest = blake2b.finalize()[:1 + params.CURVE_KEY_SIZE_BYTES]
 
         sign = b'\x02' if hash_digest[0] & 1 == 0 else b'\x03' 


### PR DESCRIPTION
## What this does ##
- Removes potential collision attacks: previous implementation allowed to find collisions relatively easy, when either `label` or `data` were empty. Now the length of both parameters is encoded in the hash input, which eliminates this type of attacks. The length is fixed to fit in 4 bytes, which means that both `label` and `data` are limited to 4.29 GB. 
- Extends the output domain to reach also negative points (i.e., points whose compressed representation starts by `0x03`).
- Fixes bug when `label is None`. Now all arguments have default values, as well as type annotations.
- Small, unrelated change in `UmbralParameters.__eq__` to use the fact that `curve` objects provide their own `__eq__` method (#178 ). 

NOTE: wait until #198 is merged so we can build and test the PR.