### PR TITLE
Detect invalid KFrags before use

### DIFF
--- a/docs/notebooks/pyUmbral Simple API.ipynb
+++ b/docs/notebooks/pyUmbral Simple API.ipynb
@@ -203,7 +203,7 @@
    "source": [
     "\n",
     "## Ursulas Re-encrypt; Bob attaches fragments to capsule\n",
-    "Bob asks several Ursulas to re-encrypt the capsule so he can open it. Each Ursula performs re-encryption on the capsule using the `kfrag` provided by Alice, obtaining this way a \"capsule fragment\", or `cfrag`. Let's mock a network or transport layer by sampling `M` random `kfrags`, one for each required Ursula. Bob collects the resulting `cfrags` from several Ursulas. He must gather at least `M` `cfrags` in order to activate the capsule.\n"
+    "Bob asks several Ursulas to re-encrypt the capsule so he can open it. Each Ursula performs re-encryption on the capsule using the `kfrag` provided by Alice, obtaining this way a \"capsule fragment\", or `cfrag`. Let's mock a network or transport layer by sampling `M` random `kfrags`, one for each required Ursula. Note that each Ursula must prepare the received capsule before re-encryption by setting the proper correctness keys. Bob collects the resulting `cfrags` from several Ursulas. He must gather at least `M` `cfrags` in order to activate the capsule.\n"
    ]
   },
   {
@@ -215,6 +215,10 @@
     "import random\n",
     "kfrags = random.sample(kfrags,  # All kfrags from above\n",
     "                       10)      # M - Threshold\n",
+    "\n",
+    "bob_capsule.set_correctness_keys(delegating=alices_public_key,\n",
+    "                                 receiving=bobs_public_key,\n",
+    "                                 verifying=alices_verifying_key)\n",
     "\n",
     "cfrags = list()                 # Bob's cfrag collection\n",
     "for kfrag in kfrags:\n",
@@ -229,7 +233,7 @@
    "metadata": {},
    "source": [
     "## Bob activates and opens the capsule; Decrypts data from Alice.\n",
-    "Bob attaches at least `M` `cfrags` to the capsule. Then it can become *activated*. Finally, Bob activates and opens the capsule, then decrypts the re-encrypted ciphertext."
+    "Bob attaches at least `M` `cfrags` to the capsule, which has to be prepared in advance with the necessary correctness keys; only then it can become *activated*. Finally, Bob activates and opens the capsule, then decrypts the re-encrypted ciphertext."
    ]
   },
   {

--- a/docs/source/using_pyumbral.rst
+++ b/docs/source/using_pyumbral.rst
@@ -150,7 +150,8 @@ Bob asks several Ursulas to re-encrypt the capsule so he can open it.
 Each Ursula performs re-encryption on the capsule using the `kfrag` 
 provided by Alice, obtaining this way a "capsule fragment", or `cfrag`,
 Let's mock a network or transport layer by sampling `threshold` random `kfrags`,
-one for each required Ursula.
+one for each required Ursula. Note that each Ursula must prepare the received 
+capsule before re-encryption by setting the proper correctness keys.
 
 Bob collects the resulting `cfrags` from several Ursulas. 
 Bob must gather at least `threshold` `cfrags` in order to activate the capsule.
@@ -161,6 +162,11 @@ Bob must gather at least `threshold` `cfrags` in order to activate the capsule.
     >>> import random
     >>> kfrags = random.sample(kfrags,  # All kfrags from above
     ...                        10)      # M - Threshold
+
+    >>> capsule.set_correctness_keys(delegating=alices_public_key,
+    ...                              receiving=bobs_public_key,
+    ...                              verifying=alices_verifying_key)
+    (True, True, True)
 
     >>> cfrags = list()                 # Bob's cfrag collection
     >>> for kfrag in kfrags:
@@ -175,15 +181,16 @@ Bob must gather at least `threshold` `cfrags` in order to activate the capsule.
 
 Bob attaches cfrags to the capsule
 ----------------------------------
-Bob attaches at least `threshold` `cfrags` to the capsule;
-Then it can become *activated*.
+Bob attaches at least `threshold` `cfrags` to the capsule, 
+which has to be prepared in advance with the necessary correctness keys. 
+Only then it can become *activated*.
 
 .. doctest:: capsule_story
 
     >>> capsule.set_correctness_keys(delegating=alices_public_key,
     ...                              receiving=bobs_public_key,
     ...                              verifying=alices_verifying_key)
-    (True, True, True)
+    (False, False, False)
 
     >>> for cfrag in cfrags:
     ...     capsule.attach_cfrag(cfrag)

--- a/tests/metrics/reencryption_benchmark.py
+++ b/tests/metrics/reencryption_benchmark.py
@@ -67,6 +67,10 @@ def __standard_encryption_api() -> tuple:
     plain_data = os.urandom(32)
     ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data)
 
+    capsule.set_correctness_keys(delegating=delegating_pubkey,
+                                 receiving=receiving_pubkey,
+                                 verifying=signing_privkey.get_pubkey())
+
     return delegating_privkey, signer, receiving_pubkey, ciphertext, capsule
 
 

--- a/tests/metrics/reencryption_firehose.py
+++ b/tests/metrics/reencryption_firehose.py
@@ -51,6 +51,10 @@ def __produce_kfrags_and_capsule(m: int, n: int) -> Tuple[List[KFrag], Capsule]:
 
     kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, m, n)
 
+    capsule.set_correctness_keys(delegating=delegating_pubkey,
+                                 receiving=receiving_pubkey,
+                                 verifying=signing_privkey.get_pubkey())
+
     return kfrags, capsule
 
 

--- a/tests/test_capsule/test_capsule_serializers.py
+++ b/tests/test_capsule/test_capsule_serializers.py
@@ -65,14 +65,13 @@ def test_activated_capsule_serialization(alices_keys, bobs_keys):
 
     _unused_key, capsule = pre._encapsulate(delegating_pubkey)
 
-    
     kfrags = pre.split_rekey(delegating_privkey, signer_alice, receiving_pubkey, 1, 2)
-
-    cfrag = pre.reencrypt(kfrags[0], capsule)
 
     capsule.set_correctness_keys(delegating=delegating_pubkey,
                                  receiving=receiving_pubkey,
                                  verifying=signing_privkey.get_pubkey())
+
+    cfrag = pre.reencrypt(kfrags[0], capsule)
     
     capsule.attach_cfrag(cfrag)
 

--- a/tests/test_keys/test_key_fragments.py
+++ b/tests/test_keys/test_key_fragments.py
@@ -74,6 +74,10 @@ def test_cfrag_serialization_with_proof_and_metadata(alices_keys, bobs_keys):
     # Example of potential metadata to describe the re-encryption request
     metadata = b'This is an example of metadata for re-encryption request'
 
+    capsule.set_correctness_keys(delegating=delegating_pubkey,
+                                     receiving=receiving_pubkey,
+                                     verifying=signing_privkey.get_pubkey())
+
     cfrag = pre.reencrypt(kfrags[0], capsule, provide_proof=True, metadata=metadata)
     cfrag_bytes = cfrag.to_bytes()
 
@@ -108,6 +112,10 @@ def test_cfrag_serialization_with_proof_but_no_metadata(alices_keys, bobs_keys):
     _unused_key, capsule = pre._encapsulate(delegating_pubkey)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
                              receiving_pubkey, 1, 2)
+
+    capsule.set_correctness_keys(delegating=delegating_pubkey,
+                                 receiving=receiving_pubkey,
+                                 verifying=signing_privkey.get_pubkey())
 
     cfrag = pre.reencrypt(kfrags[0], capsule, provide_proof=True)
     cfrag_bytes = cfrag.to_bytes()
@@ -146,6 +154,10 @@ def test_cfrag_serialization_no_proof_no_metadata(alices_keys, bobs_keys):
     _unused_key, capsule = pre._encapsulate(delegating_pubkey)
     kfrags = pre.split_rekey(delegating_privkey, signer_alice,
                              receiving_pubkey, 1, 2)
+
+    capsule.set_correctness_keys(delegating=delegating_pubkey,
+                                 receiving=receiving_pubkey,
+                                 verifying=signing_privkey.get_pubkey())
 
     cfrag = pre.reencrypt(kfrags[0], capsule, provide_proof=False)
     cfrag_bytes = cfrag.to_bytes()

--- a/tests/test_simple_api.py
+++ b/tests/test_simple_api.py
@@ -154,7 +154,15 @@ def test_lifecycle_with_serialization(N, M, curve=default_curve()):
     cfrags_bytes = list()
     for kfrag_bytes in kfrags_bytes:
         params = UmbralParameters(curve=curve)
+        delegating_pubkey = UmbralPublicKey.from_bytes(delegating_pubkey_bytes, params)
+        signing_pubkey = UmbralPublicKey.from_bytes(signing_pubkey_bytes, params)
+        receiving_pubkey = UmbralPublicKey.from_bytes(receiving_pubkey_bytes, params)
+
         capsule = pre.Capsule.from_bytes(capsule_bytes, params)
+        capsule.set_correctness_keys(delegating=delegating_pubkey,
+                                     receiving=receiving_pubkey,
+                                     verifying=signing_pubkey)
+
         # TODO: use params instead of curve?
         kfrag = KFrag.from_bytes(kfrag_bytes, params.curve)
 
@@ -164,6 +172,9 @@ def test_lifecycle_with_serialization(N, M, curve=default_curve()):
         del capsule
         del kfrag
         del params
+        del delegating_pubkey
+        del signing_pubkey
+        del receiving_pubkey
 
     ## DECRYPTION DOMAIN (i.e., Bob's side)
     params = UmbralParameters(curve=curve)

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -154,6 +154,10 @@ def test_cfrags():
                           CapsuleFrag.from_bytes(bytes.fromhex(json_kfrag['cfrag'])))
                             for json_kfrag in vector_suite['vectors']]
 
+    capsule.set_correctness_keys(delegating=delegating_key,
+                                 receiving=receiving_key,
+                                 verifying=verifying_key)
+
     for kfrag, cfrag in kfrags_n_cfrags:
         assert kfrag.verify(signing_pubkey=verifying_key,
                             delegating_pubkey=delegating_key,

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -100,6 +100,14 @@ class KFrag(object):
                receiving_pubkey: UmbralPublicKey) -> bool:
         return verify_kfrag(self, delegating_pubkey, signing_pubkey, receiving_pubkey)
 
+    def verify_for_capsule(self, capsule : 'Capsule') -> bool:
+
+        correctness_keys = capsule.get_correctness_keys()
+
+        return self.verify(signing_pubkey=correctness_keys["verifying"],
+                           delegating_pubkey=correctness_keys["delegating"],
+                           receiving_pubkey=correctness_keys["receiving"])
+
     def __bytes__(self) -> bytes:
         return self.to_bytes()
 

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -32,6 +32,12 @@ from umbral.signing import Signature
 
 
 class KFrag(object):
+
+    class NotValid(ValueError):
+        """
+        raised if the KFrag does not pass verification.
+        """
+
     def __init__(self, id: bytes, bn_key: CurveBN, point_noninteractive: Point,
                  point_commitment: Point, point_xcoord: Point, signature: Signature) -> None:
         self._id = id

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -223,9 +223,6 @@ class UmbralPublicKey(object):
 
         return umbral_pubkey
 
-    def get_pubkey(self):
-        raise NotImplementedError
-
     def to_cryptography_pubkey(self) -> _EllipticCurvePublicKey:
         """
         Returns a cryptography.io EllipticCurvePublicKey from the Umbral key.

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -381,7 +381,10 @@ def reencrypt(kfrag: KFrag, capsule: Capsule, provide_proof: bool = True,
               metadata: Optional[bytes] = None) -> CapsuleFrag:
 
     if not capsule.verify():
-        raise capsule.NotValid
+        raise Capsule.NotValid
+
+    if not kfrag.verify_for_capsule(capsule):
+        raise KFrag.NotValid
 
     rk = kfrag._bn_key
     e1 = rk * capsule._point_e


### PR DESCRIPTION
This PR enforces KFrag validation before re-encryption. Since KFrag validation requires knowledge of the correctness keys, and these can be obtained from the capsule, now Ursula has to set the correctness keys in the capsule before re-encryption. 

**Motivation:** Working on new stuff for #201, I introduced a serialization bug by mistake which went mostly undetected by the test suite. The bug was probabilistic, so it took me a lot of time to kill it. Apart from the fact that there are weak spots in the tests, the most alarming problem for me is that it was possible to deserialize invalid KFrags and use them to perform re-encryption and correctness proofs, which of course were invalid. This can be detected at decryption time, but of course this is not desirable, and could lead to a lot of problems for Ursulas.

Although this concern has already been raised for the NuCypher network (https://github.com/nucypher/nucypher/issues/167), I feel we should do some in-depth defense here and enforce this too at the pyUmbral level. 

**Other stuff:** This PR removes `UmbralPublicKey.get_pubkey()` method. 