### PR TITLE
Some __repr__ and input validation

### DIFF
--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -117,6 +117,9 @@ class KFrag(object):
     def __hash__(self):
         return hash(bytes(self._id))
 
+    def __repr__(self):
+        return "{}:{}".format(self.__class__.__name__, self._id.hex()[:15])
+
 
 class CorrectnessProof(object):
     def __init__(self, point_e2: Point, point_v2: Point, point_kfrag_commitment: Point,
@@ -277,3 +280,6 @@ class CapsuleFrag(object):
 
     def __bytes__(self) -> bytes:
         return self.to_bytes()
+
+    def __repr__(self):
+        return "CFrag:{}".format(self._point_e1.to_bytes().hex()[2:17])

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -256,7 +256,7 @@ class UmbralPublicKey(object):
         return self.point_key.to_bytes()
 
     def __repr__(self):
-        return "{}:{}".format(self.__class__, self.point_key.to_bytes().hex()[:15])
+        return "{}:{}".format(self.__class__.__name__, self.point_key.to_bytes().hex()[:15])
 
     def __eq__(self, other: Optional[Union[bytes, 'UmbralPublicKey', int]]) -> bool:
         if type(other) == bytes:

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -278,7 +278,7 @@ class Capsule(object):
             # This is not constant time obviously, but it's hard to imagine how this is valuable as
             # an attacker already knows about her own Capsule.  It's possible that a Bob, having
             # activated a Capsule, will make it available for comparison via an API amidst other
-            # (dormat) Capsules.  Then an attacker can, by alternating between activated and dormant
+            # (dormant) Capsules.  Then an attacker can, by alternating between activated and dormant
             # Capsules, determine if a given Capsule is activated.  Do we care about this?
             # Again, it's hard to imagine why.
             return False
@@ -295,6 +295,8 @@ class Capsule(object):
     def __len__(self) -> int:
         return len(self._attached_cfrags)
 
+    def __repr__(self):
+        return "{}:{}".format(self.__class__.__name__, hex(int(self._bn_sig))[2:17])
 
 def split_rekey(delegating_privkey: UmbralPrivateKey, signer: Signer,
                 receiving_pubkey: UmbralPublicKey,


### PR DESCRIPTION
A really small PR with some pending stuff:

- Implements `__repr__` for `CapsuleFrag`, `Capsule`, `UmbralPublicKey`, and `KFrag`
- Input validation on `pre.decrypt` and `pre.reencrypt`