### PR TITLE
[WIP] KFrag validity no longer requires knowledge of delegating and receiving public keys

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ cryptography = ">=2.3"
 pynacl="*"
 # NuCypher
 bytestringsplitter = "*"
+constantSorrow = {git = "https://github.com/nucypher/constantSorrow.git", ref = "nucypher-depend"}
 
 [dev-packages]
 bumpversion = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "49c29523ea460ce5a70cbae65ff2be3d529de04bd53077012da1e538a756ecfc"
+            "sha256": "4365b58ce6790560629f248397b2c0f99eb78a75036e5168e1d96798dacf5685"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -66,6 +66,10 @@
             ],
             "version": "==1.11.5"
         },
+        "constantsorrow": {
+            "git": "https://github.com/nucypher/constantSorrow.git",
+            "ref": "9a0b3901c53bc584920c46ea891e68acbe1345cb"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:02602e1672b62e803e08617ec286041cc453e8d43f093a5f4162095506bc0beb",
@@ -106,46 +110,35 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
             ],
-            "version": "==2.18"
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
+            "version": "==2.19"
         },
         "pynacl": {
             "hashes": [
-                "sha256:04e30e5bdeeb2d5b34107f28cd2f5bbfdc6c616f3be88fc6f53582ff1669eeca",
-                "sha256:0bfa0d94d2be6874e40f896e0a67e290749151e7de767c5aefbad1121cad7512",
-                "sha256:11aa4e141b2456ce5cecc19c130e970793fa3a2c2e6fbb8ad65b28f35aa9e6b6",
-                "sha256:13bdc1fe084ff9ac7653ae5a924cae03bf4bb07c6667c9eb5b6eb3c570220776",
-                "sha256:14339dc233e7a9dda80a3800e64e7ff89d0878ba23360eea24f1af1b13772cac",
-                "sha256:1d33e775fab3f383167afb20b9927aaf4961b953d76eeb271a5703a6d756b65b",
-                "sha256:2a42b2399d0428619e58dac7734838102d35f6dcdee149e0088823629bf99fbb",
-                "sha256:2dce05ac8b3c37b9e2f65eab56c544885607394753e9613fd159d5e2045c2d98",
-                "sha256:63cfccdc6217edcaa48369191ae4dca0c390af3c74f23c619e954973035948cd",
-                "sha256:6453b0dae593163ffc6db6f9c9c1597d35c650598e2c39c0590d1757207a1ac2",
-                "sha256:73a5a96fb5fbf2215beee2353a128d382dbca83f5341f0d3c750877a236569ef",
-                "sha256:8abb4ef79161a5f58848b30ab6fb98d8c466da21fdd65558ce1d7afc02c70b5f",
-                "sha256:8ac1167195b32a8755de06efd5b2d2fe76fc864517dab66aaf65662cc59e1988",
-                "sha256:8f505f42f659012794414fa57c498404e64db78f1d98dfd40e318c569f3c783b",
-                "sha256:9c8a06556918ee8e3ab48c65574f318f5a0a4d31437fc135da7ee9d4f9080415",
-                "sha256:a1e25fc5650cf64f01c9e435033e53a4aca9de30eb9929d099f3bb078e18f8f2",
-                "sha256:be71cd5fce04061e1f3d39597f93619c80cdd3558a6c9ba99a546f144a8d8101",
-                "sha256:c5b1a7a680218dee9da0f1b5e24072c46b3c275d35712bc1d505b85bb03441c0",
-                "sha256:cb785db1a9468841a1265c9215c60fe5d7af2fb1b209e3316a152704607fc582",
-                "sha256:cf6877124ae6a0698404e169b3ba534542cfbc43f939d46b927d956daf0a373a",
-                "sha256:d0eb5b2795b7ee2cbcfcadacbe95a13afbda048a262bd369da9904fecb568975",
-                "sha256:d3a934e2b9f20abac009d5b6951067cfb5486889cb913192b4d8288b216842f1",
-                "sha256:d795f506bcc9463efb5ebb0f65ed77921dcc9e0a50499dedd89f208445de9ecb",
-                "sha256:d8aaf7e5d6b0e0ef7d6dbf7abeb75085713d0100b4eb1a4e4e857de76d77ac45",
-                "sha256:de2aaca8386cf4d70f1796352f2346f48ddb0bed61dc43a3ce773ba12e064031",
-                "sha256:e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9",
-                "sha256:eb2acabbd487a46b38540a819ef67e477a674481f84a82a7ba2234b9ba46f752",
-                "sha256:eeee629828d0eb4f6d98ac41e9a3a6461d114d1d0aa111a8931c049359298da0",
-                "sha256:f5836463a3c0cca300295b229b6c7003c415a9d11f8f9288ddbd728e2746524c",
-                "sha256:f5ce9e26d25eb0b2d96f3ef0ad70e1d3ae89b5d60255c462252a3e456a48c053",
-                "sha256:fabf73d5d0286f9e078774f3435601d2735c94ce9e514ac4fb945701edead7e4"
+                "sha256:05c26f93964373fc0abe332676cb6735f0ecad27711035b9472751faa8521255",
+                "sha256:0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c",
+                "sha256:0d0a8171a68edf51add1e73d2159c4bc19fc0718e79dec51166e940856c2f28e",
+                "sha256:1c780712b206317a746ace34c209b8c29dbfd841dfbc02aa27f2084dd3db77ae",
+                "sha256:2424c8b9f41aa65bbdbd7a64e73a7450ebb4aa9ddedc6a081e7afcc4c97f7621",
+                "sha256:2d23c04e8d709444220557ae48ed01f3f1086439f12dbf11976e849a4926db56",
+                "sha256:30f36a9c70450c7878053fa1344aca0145fd47d845270b43a7ee9192a051bf39",
+                "sha256:37aa336a317209f1bb099ad177fef0da45be36a2aa664507c5d72015f956c310",
+                "sha256:4943decfc5b905748f0756fdd99d4f9498d7064815c4cf3643820c9028b711d1",
+                "sha256:57ef38a65056e7800859e5ba9e6091053cd06e1038983016effaffe0efcd594a",
+                "sha256:5bd61e9b44c543016ce1f6aef48606280e45f892a928ca7068fba30021e9b786",
+                "sha256:6482d3017a0c0327a49dddc8bd1074cc730d45db2ccb09c3bac1f8f32d1eb61b",
+                "sha256:7d3ce02c0784b7cbcc771a2da6ea51f87e8716004512493a2b69016326301c3b",
+                "sha256:a14e499c0f5955dcc3991f785f3f8e2130ed504fa3a7f44009ff458ad6bdd17f",
+                "sha256:a39f54ccbcd2757d1d63b0ec00a00980c0b382c62865b61a505163943624ab20",
+                "sha256:aabb0c5232910a20eec8563503c153a8e78bbf5459490c49ab31f6adf3f3a415",
+                "sha256:bd4ecb473a96ad0f90c20acba4f0bf0df91a4e03a1f4dd6a4bdc9ca75aa3a715",
+                "sha256:e2da3c13307eac601f3de04887624939aca8ee3c9488a0bb0eca4fb9401fc6b1",
+                "sha256:f67814c38162f4deb31f68d590771a29d5ae3b1bd64b75cf232308e5c74777e0"
             ],
             "index": "pypi",
-            "version": "==1.2.1"
+            "version": "==1.3.0"
         },
         "six": {
             "hashes": [
@@ -158,10 +151,10 @@
     "develop": {
         "alabaster": {
             "hashes": [
-                "sha256:674bb3bab080f598371f4443c5008cbfeb1a5e622dd312395d2d82af2c54c456",
-                "sha256:b63b1f4dc77c074d386752ec4a8a7517600f6c0db8cd42980cae17ab7b3275d7"
+                "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
+                "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
             ],
-            "version": "==0.7.11"
+            "version": "==0.7.12"
         },
         "argh": {
             "hashes": [
@@ -172,17 +165,18 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "version": "==1.1.5"
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "version": "==1.2.1"
         },
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
-            "version": "==18.1.0"
+            "version": "==18.2.0"
         },
         "babel": {
             "hashes": [
@@ -201,10 +195,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
-                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
+                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
+                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
             ],
-            "version": "==2018.8.13"
+            "version": "==2018.8.24"
         },
         "chardet": {
             "hashes": [
@@ -215,10 +209,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
-                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
-            "version": "==6.7"
+            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==7.0"
         },
         "codecov": {
             "hashes": [
@@ -230,31 +225,36 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:10cfac276cf3dd0acefc49444fc4e1a0a4c23c855d9fcbd555681c3a47a328e6",
-                "sha256:18797137634b64fe488b239d3709e5f8fdea80aea09f86ec819c633a2c84f79c",
-                "sha256:316881a28d2a1a5853495092267fcacf245805b4139f0fc996f8a6c4be6fb499",
-                "sha256:3368098e2c633ec6b2af4f91abde94b5c3b8fa66857452137485f40be77aeda6",
-                "sha256:35fe7a6c06851c4c6a4c171eb796d27e023f5a1ce1e25837ea720f5b8cb76fce",
-                "sha256:3a1c8ed67a64627ef317de64356731f8f173b76457672e933db896c080e1cc2b",
-                "sha256:59fa7e9857205b8d6f6fce0eaea07409bcdffd68eaec3db7e0b1ac720d4fe0f3",
-                "sha256:6b2e2ef7572b399b0cc2f6d05c06ada40329166d6fc58beef8081fb94a41201f",
-                "sha256:712599fc602c302c540fe7e83b6d82aaf381ec5bfb4a51dc5c30f57d214d649f",
-                "sha256:7c8dbbc9e5480856125511f11a5c735cff3200e367adc3ba342dad506a25407d",
-                "sha256:7fc25906ecb0a6af0c434370da6cfbcf8badb257c5cf9a6464f5e37fe4ebc949",
-                "sha256:88d81556e00ac7e1cc9e70a2376859f41e46d187b6dd5883422aa537505f8a98",
-                "sha256:91a915f5fc88db7adace367e8ef65d1a418d29f7ade62514d604eed87c861355",
-                "sha256:9f696b90ff4886ba5a277995397a13b0600bfd97c70d8ae4241c2aecea11ee61",
-                "sha256:a863f4540446d7eeaf6bf716aee277eaf38842718e86bdb80cdca78cdf1fed0d",
-                "sha256:b3b6d8d8194e7e1300240402dfd9c54840d03621e69da821d8ffc8bbebe00137",
-                "sha256:c296ac03ba12e184bef03387d89c4a0be79daff214294917ce77df32240bf4d8",
-                "sha256:c75b3de73cc7ba2e911a907322c65dd10da216f37e7477f22dbd0098775f6345",
-                "sha256:c87c9ee13ce431305734b8e3f0bf00468a1d4f4ee60b6ef63c69282776ab94d6",
-                "sha256:c89c895ff5cfda45a5f681514b647986f76a4f984df125d210c154e5a1a2472b",
-                "sha256:c9fa8fbda281b1ddf25b8fa7ccf0564198a86c9da8a413111fcadd510a98a232",
-                "sha256:ccdf1bd8fd848690fb3d5153d0c54c41169e59804acb9652664f5f669fe25c11"
+                "sha256:0dcf381f51f589f1f797449602a7fe4e63be8a7963c259c13742af3f30be902e",
+                "sha256:11a4bb30306def2fa012e3429de44a93ef2ae3b6ad3f6b800f6c578658a5c402",
+                "sha256:166c957a38b034050a14201f64eec11fc95e17bf2ba31fc07d887db82bae1a47",
+                "sha256:184e6680f85fcc1b371f67ab732290ecf96a225448198e14ec170986db47b0aa",
+                "sha256:1904deb72c561a8e445feb190db07ca4b165ee85567894b4b85fdb9bf21a27c0",
+                "sha256:1f2003b83426cfaadebff8b9bb1fb3650134a15fda3a81434cc8415896d7a7bc",
+                "sha256:1f462997b1804f8b5d1ee2b262626fc76b746e66023eb64f529af35991167c7c",
+                "sha256:213697f49eba45b5fb05e77f63bdb7c0d13eed12dcd08e6af43224615b28b524",
+                "sha256:2557da232b0daeb55afe2f7e55f7b80c56bfa2981864c6638b32b5691da9f4c3",
+                "sha256:395a8525f1456439a5d6c248bc1397040491047e3e0e0c4ceb2059155419cd3b",
+                "sha256:43d6334b35e50e74d034ec075ffd9082c559bca624924af6c7e9d2b8aef0f362",
+                "sha256:4566c74bde36aaaef0372fb11678edf43dcc73f4eb8dbb6987250658c4a3b95a",
+                "sha256:6d39cc527c9c7a30f20bed14b5cf9a7e87ef1f3528c1847d1c81caf75a31ebb6",
+                "sha256:8bd69d3cba21d885df6fe8728cee779a722da08cf84072558956c148b5ab61e5",
+                "sha256:a1d0fcbbe0735eb66c6622266b12e60ea8d37ada405cb8f73b154c5eec467187",
+                "sha256:ab706bfbb365f232be01a536a9199ee6bfc80c9b63fb7825fdd5f4ae5cc2a12c",
+                "sha256:afbf4cee68d2f2968b06951cf16c0b18513eb59bb3af0685084de6cacb04e217",
+                "sha256:bbc8913cd5889df7eab597a4b4074a2c6c5ee6ca9aad58a9ba0f3f847b1a99df",
+                "sha256:bd5428ab378a7432e43afa52b6bb9c5d48f5029f395a97dc9ebf87fc0f2a9d8b",
+                "sha256:c3efe0185583443e04f8519818f4772d92fbbdf5f9fa23165f2f2482b20efc37",
+                "sha256:d40277e918da575d008e2955a0ca6600f870bdb3570b07ee3a754ea9301862e7",
+                "sha256:d4b6ec6951e20ea3f5d1fefe35b4bcbf692d4306f1b932c28dd2ee4cb167152c",
+                "sha256:d5837e813ad62c856bc80f988c4e24e0d2b7b22a8a1dad8c1cfcb8ff4d4750a8",
+                "sha256:d9583ae0e152c5fb0142cb55c3a11e1b13006c00d0c3e8b35ccc2d4ebfc6645e",
+                "sha256:e27380cbe4088a1df514e75aa4fe6dc9e98bbd7902cf28ab16e8b2de0f8cb344",
+                "sha256:e624daef32f8808296312e72190c7e576852cb75c27935b31c1bbbde14ab353c",
+                "sha256:ef4278e5ac1e47c731ec5e3e48351721e01d2eb4fefa9b97fcdba7495a82cfad"
             ],
             "index": "pypi",
-            "version": "==5.0a1"
+            "version": "==5.0a2"
         },
         "docutils": {
             "hashes": [
@@ -266,12 +266,12 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:57613e2ec5cce4e2f35093ccf8c384f2b1ca08c3ea4e4a18d827f4250f713c79",
-                "sha256:86192514059e32797a9439ae60e8b12968647dac43d096d9742ed06711e3cc06",
-                "sha256:d6108212edaa0c95d0f941b247580535fdf1abedbcf197fcea09aedc3b291b72"
+                "sha256:0b69b5733e17d42aa52cb53fbbf184241e42d6dbb17601a95a193ac6cc400ecb",
+                "sha256:5ee18595c50e8ad983f6f871c9c06eae514b4415649da9a097dd5bd7a2f9dfda",
+                "sha256:7a1f395dcc92b1ea955f8e73e7be0f9fcf674c76979f3f1f8b281946b9842bb8"
             ],
             "index": "pypi",
-            "version": "==3.68.1"
+            "version": "==3.74.2"
         },
         "idna": {
             "hashes": [
@@ -282,10 +282,11 @@
         },
         "imagesize": {
             "hashes": [
-                "sha256:3620cc0cadba3f7475f9940d22431fc4d407269f1be59ec9b8edcca26440cf18",
-                "sha256:5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315"
+                "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
+                "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"
             ],
-            "version": "==1.0.0"
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "version": "==1.1.0"
         },
         "jinja2": {
             "hashes": [
@@ -333,26 +334,25 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:673ea75fb750289b7d1da1331c125dc62fc1c3a8db9129bb372ae7b7d5bf300a",
-                "sha256:c770605a579fdd4a014e9f0a34b6c7a36ce69b08100ff728e96e27445cef3b3c"
+                "sha256:00b95bfdc0d5b9aa53c906e56fb91937743f2121d66684db5f947ec5d75f565d",
+                "sha256:6704586b4c2bf7dfa5e87a422be9ca57db622bab65008245759f3d4baeb219dd"
             ],
             "index": "pypi",
-            "version": "==0.620"
+            "version": "==0.630"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812",
+                "sha256:b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"
+            ],
+            "version": "==0.4.1"
         },
         "packaging": {
             "hashes": [
-                "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
-                "sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b"
+                "sha256:0886227f54515e592aaa2e5a553332c73962917f2831f1b0f9b9f4380a4b9807",
+                "sha256:f95a1e147590f204328170981833854229bb2912ac3d5f89e2a8ccd2834800c9"
             ],
-            "version": "==17.1"
-        },
-        "pathlib2": {
-            "hashes": [
-                "sha256:8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83",
-                "sha256:d1aa2a11ba7b8f7b21ab852b1fb5afb277e1bb99d5dfc663380b5015c0d80c5a"
-            ],
-            "markers": "python_version < '3.6'",
-            "version": "==2.3.2"
+            "version": "==18.0"
         },
         "pathtools": {
             "hashes": [
@@ -362,17 +362,17 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:1b8be50d938c9bb75d0eaf7eda111eec1bf6dc88a62a6412e33bf077457e0f45",
-                "sha256:b486975c0cafb6beeb50ca0e17ba047647f229087bd74e37f4a7e2cac17d2caa"
+                "sha256:1be135151a0da949af8c5d0ee9013d9eafada71237eb80b3ba8896b4f12ec5dc",
+                "sha256:cf36765bf2218654ae824ec8e14257259ba44e43b117fd573c8d07a9895adbdd"
             ],
-            "version": "==4.2.0"
+            "version": "==4.3.0"
         },
         "pluggy": {
             "hashes": [
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==0.7.1"
         },
         "port-for": {
@@ -383,11 +383,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+                "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
+                "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
-            "version": "==1.5.4"
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "version": "==1.6.0"
         },
         "py-cpuinfo": {
             "hashes": [
@@ -418,18 +418,19 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04",
-                "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010"
+                "sha256:bc6c7146b91af3f567cf6daeaec360bc07d45ffec4cf5353f4d7a208ce7ca30a",
+                "sha256:d29593d8ebe7b57d6967b62494f8c72b03ac0262b1eed63826c6f788b3606401"
             ],
-            "version": "==2.2.0"
+            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.2.*'",
+            "version": "==2.2.2"
         },
         "pytest": {
             "hashes": [
-                "sha256:3459a123ad5532852d36f6f4501dfe1acf4af1dd9541834a164666aa40395b02",
-                "sha256:96bfd45dbe863b447a3054145cd78a9d7f31475d2bce6111b133c0cc4f305118"
+                "sha256:7e258ee50338f4e46957f9e09a0f10fb1c2d05493fa901d113a8dafd0790de4e",
+                "sha256:9332147e9af2dcf46cd7ceb14d5acadb6564744ddff1fe8c17f0ce60ece7d9a2"
             ],
             "index": "pypi",
-            "version": "==3.7.2"
+            "version": "==3.8.2"
         },
         "pytest-benchmark": {
             "hashes": [
@@ -442,11 +443,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
-                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
+                "sha256:513c425e931a0344944f84ea47f3956be0e416d95acbd897a44970c8d926d5d7",
+                "sha256:e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762"
             ],
             "index": "pypi",
-            "version": "==2.5.1"
+            "version": "==2.6.0"
         },
         "pytest-mock": {
             "hashes": [
@@ -486,6 +487,7 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version < '4' and python_version >= '2.6' and python_version != '3.1.*'",
             "version": "==2.19.1"
         },
         "retype": {
@@ -511,11 +513,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:217ad9ece2156ed9f8af12b5d2c82a499ddf2c70a33c5f81864a08d8c67b9efc",
-                "sha256:a765c6db1e5b62aae857697cd4402a5c1a315a7b0854bbcd0fc8cdc524da5896"
+                "sha256:652eb8c566f18823a022bb4b6dbc868d366df332a11a0226b5bc3a798a479f17",
+                "sha256:d222626d8356de702431e813a05c68a35967e3d66c6cd1c2c89539bb179a7464"
             ],
             "index": "pypi",
-            "version": "==1.7.6"
+            "version": "==1.8.1"
         },
         "sphinx-autobuild": {
             "hashes": [
@@ -530,21 +532,21 @@
                 "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
                 "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==1.1.0"
         },
         "tornado": {
             "hashes": [
-                "sha256:1c0816fc32b7d31b98781bd8ebc7a9726d7dce67407dc353a2e66e697e138448",
-                "sha256:4f66a2172cb947387193ca4c2c3e19131f1c70fa8be470ddbbd9317fd0801582",
-                "sha256:5327ba1a6c694e0149e7d9126426b3704b1d9d520852a3e4aa9fc8fe989e4046",
-                "sha256:6a7e8657618268bb007646b9eae7661d0b57f13efc94faa33cd2588eae5912c9",
-                "sha256:a9b14804783a1d77c0bd6c66f7a9b1196cbddfbdf8bceb64683c5ae60bd1ec6f",
-                "sha256:c58757e37c4a3172949c99099d4d5106e4d7b63aa0617f9bb24bfbff712c7866",
-                "sha256:d8984742ce86c0855cccecd5c6f54a9f7532c983947cff06f3a0e2115b47f85c"
+                "sha256:0662d28b1ca9f67108c7e3b77afabfb9c7e87bde174fbda78186ecedc2499a9d",
+                "sha256:4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409",
+                "sha256:732e836008c708de2e89a31cb2fa6c0e5a70cb60492bee6f1ea1047500feaf7f",
+                "sha256:8154ec22c450df4e06b35f131adc4f2f3a12ec85981a203301d310abf580500f",
+                "sha256:8e9d728c4579682e837c92fdd98036bd5cdefa1da2aaf6acf26947e6dd0c01c5",
+                "sha256:d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb",
+                "sha256:e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
-            "version": "==5.1"
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "version": "==5.1.1"
         },
         "typed-ast": {
             "hashes": [
@@ -579,14 +581,14 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.6'",
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version < '4' and python_version >= '2.6' and python_version != '3.1.*'",
             "version": "==1.23"
         },
         "watchdog": {
             "hashes": [
-                "sha256:7e65882adb7746039b6f3876ee174952f8eaaa34491ba34333ddf1fe35de4162"
+                "sha256:965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
             ],
-            "version": "==0.8.3"
+            "version": "==0.9.0"
         }
     }
 }

--- a/docs/examples/umbral_simple_api.py
+++ b/docs/examples/umbral_simple_api.py
@@ -90,11 +90,11 @@ except:
 # She uses her private key, and Bob's public key, and she sets a minimum 
 # threshold of 10, for 20 total shares
 
-kfrags = pre.split_rekey(delegating_privkey=alices_private_key,
-                         signer=alices_signer,
-                         receiving_pubkey=bobs_public_key,
-                         threshold=10,
-                         N=20)
+kfrags = pre.generate_kfrags(delegating_privkey=alices_private_key,
+                             signer=alices_signer,
+                             receiving_pubkey=bobs_public_key,
+                             threshold=10,
+                             N=20)
 
 
 #9

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,12 +108,14 @@ def prepared_capsule(alices_keys, bobs_keys):
 @pytest.fixture(scope='function')
 def kfrags(alices_keys, bobs_keys):
     delegating_privkey, signing_privkey = alices_keys
-    delegating_pubkey = delegating_privkey.get_pubkey()
     signer_alice = Signer(signing_privkey)
 
     receiving_privkey, receiving_pubkey = bobs_keys
 
-    yield pre.split_rekey(delegating_privkey, signer_alice, receiving_pubkey, 6, 10)
+    yield pre.generate_kfrags(delegating_privkey=delegating_privkey,
+                              signer=signer_alice,
+                              receiving_pubkey=receiving_pubkey,
+                              threshold=6, N=10)
 
 
 

--- a/tests/functional/test_correctness.py
+++ b/tests/functional/test_correctness.py
@@ -135,13 +135,13 @@ def test_kfrags_signed_without_correctness_keys(alices_keys, bobs_keys, capsule)
 
     receiving_privkey, receiving_pubkey = bobs_keys
 
-    kfrags = pre.split_rekey(delegating_privkey=delegating_privkey,
-                             signer=Signer(signing_privkey),
-                             receiving_pubkey=receiving_pubkey,
-                             threshold=6,
-                             N=10,
-                             sign_delegating_key=False,
-                             sign_receiving_key=False)
+    kfrags = pre.generate_kfrags(delegating_privkey=delegating_privkey,
+                                 signer=Signer(signing_privkey),
+                                 receiving_pubkey=receiving_pubkey,
+                                 threshold=6,
+                                 N=10,
+                                 sign_delegating_key=False,
+                                 sign_receiving_key=False)
 
     for kfrag in kfrags:
         assert kfrag.verify(signing_pubkey=signing_privkey.get_pubkey(),

--- a/tests/functional/test_correctness.py
+++ b/tests/functional/test_correctness.py
@@ -21,15 +21,16 @@ import pytest
 
 from umbral import pre
 from umbral.point import Point
+from umbral.signing import Signer
 
-def test_cheating_ursula_replays_old_reencryption(alices_keys, bobs_keys, 
+
+def test_cheating_ursula_replays_old_reencryption(alices_keys, bobs_keys,
                                                   kfrags, prepared_capsule):
-
     delegating_privkey, signing_privkey = alices_keys
     delegating_pubkey = delegating_privkey.get_pubkey()
 
     receiving_privkey, receiving_pubkey = bobs_keys
-    
+
     capsule_alice1 = prepared_capsule
 
     _unused_key2, capsule_alice2 = pre._encapsulate(delegating_pubkey)
@@ -53,8 +54,7 @@ def test_cheating_ursula_replays_old_reencryption(alices_keys, bobs_keys,
 
         cfrags.append(cfrag)
 
-
-    # CFrag 0 is not valid ...
+    #  CFrag 0 is not valid ...
     assert not cfrags[0].verify_correctness(capsule_alice1)
 
     # ... and trying to attach it raises an error.
@@ -71,11 +71,11 @@ def test_cheating_ursula_replays_old_reencryption(alices_keys, bobs_keys,
         assert cfrag_i.verify_correctness(capsule_alice1)
         capsule_alice1.attach_cfrag(cfrag_i)
         correct_cases += 1
-        
+
     assert correct_cases == len(cfrags[1:])
 
+
 def test_cheating_ursula_sends_garbage(kfrags, prepared_capsule):
-    
     capsule_alice = prepared_capsule
 
     cfrags = []
@@ -91,7 +91,7 @@ def test_cheating_ursula_sends_garbage(kfrags, prepared_capsule):
     cfrags[0]._point_e1 = Point.gen_rand()
     cfrags[0]._point_v1 = Point.gen_rand()
 
-    # Of course, this CFrag is not valid ...
+    #  Of course, this CFrag is not valid ...
     assert not cfrags[0].verify_correctness(capsule_alice)
 
     # ... and trying to attach it raises an error.
@@ -110,7 +110,6 @@ def test_cheating_ursula_sends_garbage(kfrags, prepared_capsule):
 
 
 def test_cfrag_with_missing_proof_cannot_be_attached(kfrags, prepared_capsule):
-
     capsule = prepared_capsule
 
     cfrags = []
@@ -119,7 +118,7 @@ def test_cfrag_with_missing_proof_cannot_be_attached(kfrags, prepared_capsule):
         cfrags.append(cfrag)
 
     # If the proof is lost (e.g., it is chopped off a serialized CFrag or similar), 
-    # then the CFrag cannot be attached.
+    #  then the CFrag cannot be attached.
     cfrags[0].proof = None
     with pytest.raises(cfrag.NoProofProvided):
         capsule.attach_cfrag(cfrags[0])
@@ -130,7 +129,6 @@ def test_cfrag_with_missing_proof_cannot_be_attached(kfrags, prepared_capsule):
 
 
 def test_inconsistent_cfrags(bobs_keys, kfrags, prepared_capsule):
-
     receiving_privkey, receiving_pubkey = bobs_keys
 
     capsule = prepared_capsule
@@ -139,20 +137,48 @@ def test_inconsistent_cfrags(bobs_keys, kfrags, prepared_capsule):
     for kfrag in kfrags:
         cfrag = pre.reencrypt(kfrag, capsule)
         cfrags.append(cfrag)
-    
-    # For all cfrags that belong to the same policy, the values 
+
+    # For all cfrags that belong to the same policy, the values
     # cfrag._point_noninteractive and cfrag._point_noninteractive
-    # must be the same. If we swap them, it shouldn't be possible 
-    # to attach the cfrag to the capsule. Let's mangle the first CFrag
+    # must be the same. If we swap them, it shouldn't be possible
+    # to attach the cfrag to the capsule. Let's mangle the first CFrag
     cfrags[0]._point_noninteractive, cfrags[0]._point_xcoord = cfrags[0]._point_xcoord, cfrags[0]._point_noninteractive
     with pytest.raises(pre.UmbralCorrectnessError):
         capsule.attach_cfrag(cfrags[0])
 
-    # The remaining M cfrags should be fine. 
-    for cfrag in cfrags[1:]:   
+    #  The remaining M cfrags should be fine.
+    for cfrag in cfrags[1:]:
         capsule.attach_cfrag(cfrag)
 
     # Just for fun, let's try to reconstruct the capsule with them:
     capsule._reconstruct_shamirs_secret(receiving_privkey)
 
-    
+
+def test_kfrags_signed_without_correctness_keys(alices_keys, bobs_keys, capsule):
+    delegating_privkey, signing_privkey = alices_keys
+    delegating_pubkey = delegating_privkey.get_pubkey()
+    verifying_key = signing_privkey.get_pubkey()
+
+    receiving_privkey, receiving_pubkey = bobs_keys
+
+    kfrags = pre.split_rekey(delegating_privkey=delegating_privkey,
+                             signer=Signer(signing_privkey),
+                             receiving_pubkey=receiving_pubkey,
+                             threshold=6,
+                             N=10,
+                             sign_delegating_key=False,
+                             sign_receiving_key=False)
+
+    for kfrag in kfrags:
+        assert kfrag.verify(signing_pubkey=signing_privkey.get_pubkey(),
+                            delegating_pubkey=None,
+                            receiving_pubkey=None)
+
+        capsule.set_correctness_keys(verifying=verifying_key)
+
+        assert kfrag.verify_for_capsule(capsule)
+
+    for kfrag in kfrags:
+        assert kfrag.verify(signing_pubkey=verifying_key,
+                            delegating_pubkey=delegating_pubkey,
+                            receiving_pubkey=receiving_pubkey)

--- a/tests/functional/test_correctness.py
+++ b/tests/functional/test_correctness.py
@@ -128,32 +128,6 @@ def test_cfrag_with_missing_proof_cannot_be_attached(kfrags, prepared_capsule):
         capsule.attach_cfrag(cfrag)
 
 
-def test_inconsistent_cfrags(bobs_keys, kfrags, prepared_capsule):
-    receiving_privkey, receiving_pubkey = bobs_keys
-
-    capsule = prepared_capsule
-
-    cfrags = []
-    for kfrag in kfrags:
-        cfrag = pre.reencrypt(kfrag, capsule)
-        cfrags.append(cfrag)
-
-    # For all cfrags that belong to the same policy, the values
-    # cfrag._point_noninteractive and cfrag._point_noninteractive
-    # must be the same. If we swap them, it shouldn't be possible
-    # to attach the cfrag to the capsule. Let's mangle the first CFrag
-    cfrags[0]._point_noninteractive, cfrags[0]._point_xcoord = cfrags[0]._point_xcoord, cfrags[0]._point_noninteractive
-    with pytest.raises(pre.UmbralCorrectnessError):
-        capsule.attach_cfrag(cfrags[0])
-
-    #  The remaining M cfrags should be fine.
-    for cfrag in cfrags[1:]:
-        capsule.attach_cfrag(cfrag)
-
-    # Just for fun, let's try to reconstruct the capsule with them:
-    capsule._reconstruct_shamirs_secret(receiving_privkey)
-
-
 def test_kfrags_signed_without_correctness_keys(alices_keys, bobs_keys, capsule):
     delegating_privkey, signing_privkey = alices_keys
     delegating_pubkey = delegating_privkey.get_pubkey()

--- a/tests/functional/test_correctness_keys.py
+++ b/tests/functional/test_correctness_keys.py
@@ -1,0 +1,83 @@
+"""
+Copyright (C) 2018 NuCypher
+
+This file is part of pyUmbral.
+
+pyUmbral is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+pyUmbral is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import pytest
+
+from umbral import pre
+from umbral.keys import UmbralPrivateKey
+from umbral.fragments import KFrag
+
+
+def test_set_correctness_keys(alices_keys, bobs_keys, capsule, kfrags):
+    """
+    If the three keys do appear together, along with the capsule,
+    we can attach them all at once.
+    """
+
+    delegating_privkey, signing_privkey = alices_keys
+    _receiving_privkey, receiving_pubkey = bobs_keys
+
+    capsule.set_correctness_keys(delegating_privkey.get_pubkey(),
+                                 receiving_pubkey,
+                                 signing_privkey.get_pubkey()
+                                 )
+
+    for kfrag in kfrags:
+        cfrag = pre.reencrypt(kfrag, capsule)
+        capsule.attach_cfrag(cfrag)
+
+
+def test_setting_one_correctness_keys(alices_keys, capsule):
+    # The capsule doesn't have any correctness keys set initially
+    assert capsule.get_correctness_keys()['delegating'] is None
+    assert capsule.get_correctness_keys()['receiving'] is None
+    assert capsule.get_correctness_keys()['verifying'] is None
+
+    # Let's set only one of them, e.g., the delegating key
+    delegating_privkey, _signing_privkey = alices_keys
+    delegating_pubkey = delegating_privkey.get_pubkey()
+
+    details = capsule.set_correctness_keys(delegating=delegating_pubkey)
+
+    # Since we are only setting the first key ("delegating"),
+    # the other keys are not set
+    assert details == (True, False, False)
+
+    assert capsule.get_correctness_keys()['delegating'] == delegating_pubkey
+    assert capsule.get_correctness_keys()['receiving'] is None
+    assert capsule.get_correctness_keys()['verifying'] is None
+
+
+def test_set_invalid_correctness_keys(alices_keys, capsule, kfrags):
+    """
+    If the three keys do appear together, along with the capsule,
+    we can attach them all at once.
+    """
+
+    delegating_privkey, signing_privkey = alices_keys
+    unrelated_receiving_pubkey = UmbralPrivateKey.gen_key().get_pubkey()
+
+    capsule.set_correctness_keys(delegating_privkey.get_pubkey(),
+                                 unrelated_receiving_pubkey,
+                                 signing_privkey.get_pubkey()
+                                 )
+
+    for kfrag in kfrags:
+        with pytest.raises(KFrag.NotValid):
+            cfrag = pre.reencrypt(kfrag, capsule)

--- a/tests/functional/test_pre_api.py
+++ b/tests/functional/test_pre_api.py
@@ -37,5 +37,9 @@ def test_wrong_N_M_in_split_rekey(N, M, alices_keys, bobs_keys):
     _receiving_privkey, receiving_pubkey = bobs_keys
 
     with pytest.raises(ValueError):
-        _kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, M, N)
+        _kfrags = pre.generate_kfrags(delegating_privkey=delegating_privkey,
+                                      signer=signer,
+                                      receiving_pubkey=receiving_pubkey,
+                                      threshold=M,
+                                      N=N)
 

--- a/tests/functional/test_vectors.py
+++ b/tests/functional/test_vectors.py
@@ -188,7 +188,7 @@ def test_cfrags():
         assert new_cfrag._point_e1 == cfrag._point_e1
         assert new_cfrag._point_v1 == cfrag._point_v1
         assert new_cfrag._kfrag_id == cfrag._kfrag_id
-        assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
+        assert new_cfrag._point_precursor == cfrag._point_precursor
         assert new_cfrag._point_xcoord == cfrag._point_xcoord
         assert new_cfrag.proof is None
         assert cfrag.to_bytes() == new_cfrag.to_bytes()

--- a/tests/metrics/reencryption_benchmark.py
+++ b/tests/metrics/reencryption_benchmark.py
@@ -93,7 +93,7 @@ def test_split_rekey_performance(benchmark, m: int, n: int) -> None:
         return args, kwargs
 
     print("\nBenchmarking {function} with M:{M} of N:{N}...".format(function="pre.split_rekey", M=m, N=n))
-    benchmark.pedantic(pre.split_rekey, setup=__setup, rounds=1000)
+    benchmark.pedantic(pre.generate_kfrags, setup=__setup, rounds=1000)
     assert True  # ensure function finishes and succeeds.
 
 
@@ -111,7 +111,7 @@ def test_random_frag_reencryption_performance(benchmark, m: int, n: int) -> None
 
     def __setup():
         delegating_privkey, signer, receiving_pubkey, ciphertext, capsule = __standard_encryption_api()
-        kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, m, n)
+        kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_pubkey, m, n)
         one_kfrag, *remaining_kfrags = kfrags
         args, kwargs = tuple(), {"kfrag": one_kfrag, "capsule": capsule},
         return args, kwargs
@@ -133,7 +133,7 @@ def test_random_frag_reencryption_performance(benchmark, m: int, n: int) -> None
 def test_single_frag_reencryption_performance(benchmark, m: int, n: int) -> None:
 
     delegating_privkey, signer, receiving_pubkey, ciphertext, capsule = __standard_encryption_api()
-    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, m, n)
+    kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_pubkey, m, n)
     one_kfrag, *remaining_kfrags = kfrags
     args, kwargs = tuple(), {"kfrag": one_kfrag, "capsule": capsule},
 

--- a/tests/metrics/reencryption_firehose.py
+++ b/tests/metrics/reencryption_firehose.py
@@ -49,7 +49,7 @@ def __produce_kfrags_and_capsule(m: int, n: int) -> Tuple[List[KFrag], Capsule]:
     plain_data = os.urandom(32)
     ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data)
 
-    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, m, n)
+    kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_pubkey, m, n)
 
     capsule.set_correctness_keys(delegating=delegating_pubkey,
                                  receiving=receiving_pubkey,

--- a/tests/scenario/test_lifecycle_multidomain.py
+++ b/tests/scenario/test_lifecycle_multidomain.py
@@ -64,7 +64,7 @@ def test_lifecycle_with_serialization(N, M, curve=default_curve()):
     receiving_pubkey = UmbralPublicKey.from_bytes(receiving_pubkey_bytes, params)
 
     signer = Signer(signing_privkey)
-    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, M, N)
+    kfrags = pre.generate_kfrags(delegating_privkey, receiving_pubkey, M, N, signer)
     kfrags_bytes = tuple(map(bytes, kfrags))
 
     del kfrags

--- a/tests/scenario/test_lifecycle_multidomain.py
+++ b/tests/scenario/test_lifecycle_multidomain.py
@@ -118,7 +118,7 @@ def test_lifecycle_with_serialization(N, M, curve=default_curve()):
         # TODO: use params instead of curve?
         kfrag = KFrag.from_bytes(kfrag_bytes, params.curve)
 
-        assert kfrag.verify(signing_pubkey, delegating_pubkey, receiving_pubkey)
+        assert kfrag.verify(signing_pubkey, delegating_pubkey, receiving_pubkey, params)
 
         cfrag_bytes = bytes(pre.reencrypt(kfrag, capsule))
         cfrags_bytes.append(cfrag_bytes)

--- a/tests/scenario/test_simple_api.py
+++ b/tests/scenario/test_simple_api.py
@@ -64,7 +64,7 @@ def test_simple_api(N, M, curve=default_curve()):
     assert cleartext == plain_data
 
     # Split Re-Encryption Key Generation (aka Delegation)
-    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, M, N)
+    kfrags = pre.generate_kfrags(delegating_privkey, receiving_pubkey, M, N, signer)
 
 
     # Capsule preparation (necessary before re-encryotion and activation)

--- a/tests/scenario/test_simple_api.py
+++ b/tests/scenario/test_simple_api.py
@@ -97,4 +97,4 @@ def test_simple_api(N, M, curve=default_curve()):
 @pytest.mark.parametrize("N, M", parameters)
 def test_simple_api_on_multiple_curves(N, M, curve):
     test_simple_api(N, M, curve)
-    
+

--- a/tests/scenario/test_simple_api.py
+++ b/tests/scenario/test_simple_api.py
@@ -76,7 +76,7 @@ def test_simple_api(N, M, curve=default_curve()):
     cfrags = list()
     for kfrag in kfrags[:M]:
         # Ursula checks that the received kfrag is valid
-        assert kfrag.verify(signing_pubkey, delegating_pubkey, receiving_pubkey)
+        assert kfrag.verify(signing_pubkey, delegating_pubkey, receiving_pubkey, params)
 
         # Re-encryption by an Ursula
         cfrag = pre.reencrypt(kfrag, capsule)

--- a/tests/unit/test_capsule_correctness_checks.py
+++ b/tests/unit/test_capsule_correctness_checks.py
@@ -44,8 +44,7 @@ def test_cannot_attach_cfrag_without_keys():
     cfrag = CapsuleFrag(point_e1=Point.gen_rand(),
                         point_v1=Point.gen_rand(),
                         kfrag_id=os.urandom(10),
-                        point_noninteractive=Point.gen_rand(),
-                        point_xcoord=Point.gen_rand(),
+                        point_precursor=Point.gen_rand(),
                         )
 
     with pytest.raises(TypeError):
@@ -67,8 +66,7 @@ def test_cannot_attach_cfrag_without_proof():
     cfrag = CapsuleFrag(point_e1=Point.gen_rand(),
                         point_v1=Point.gen_rand(),
                         kfrag_id=os.urandom(10),
-                        point_noninteractive=Point.gen_rand(),
-                        point_xcoord=Point.gen_rand(),
+                        point_precursor=Point.gen_rand(),
                         )
     key_details = capsule.set_correctness_keys(
         UmbralPrivateKey.gen_key().get_pubkey(),

--- a/tests/unit/test_capsule_correctness_checks.py
+++ b/tests/unit/test_capsule_correctness_checks.py
@@ -21,9 +21,8 @@ import os
 
 import pytest
 
-from umbral import pre
 from umbral.curvebn import CurveBN
-from umbral.fragments import CapsuleFrag, KFrag
+from umbral.fragments import CapsuleFrag
 from umbral.keys import UmbralPrivateKey
 from umbral.point import Point
 from umbral.pre import Capsule
@@ -51,43 +50,6 @@ def test_cannot_attach_cfrag_without_keys():
 
     with pytest.raises(TypeError):
         capsule.attach_cfrag(cfrag)
-
-
-def test_set_correctness_keys(alices_keys, bobs_keys, capsule, kfrags):
-    """
-    If the three keys do appear together, along with the capsule,
-    we can attach them all at once.
-    """
-
-    delegating_privkey, signing_privkey = alices_keys
-    _receiving_privkey, receiving_pubkey = bobs_keys
-
-    capsule.set_correctness_keys(delegating_privkey.get_pubkey(),
-                                 receiving_pubkey,
-                                 signing_privkey.get_pubkey()
-                                )
-
-    for kfrag in kfrags:
-        cfrag = pre.reencrypt(kfrag, capsule)
-        capsule.attach_cfrag(cfrag)
-
-def test_set_invalid_correctness_keys(alices_keys, capsule, kfrags):
-    """
-    If the three keys do appear together, along with the capsule,
-    we can attach them all at once.
-    """
-
-    delegating_privkey, signing_privkey = alices_keys
-    unrelated_receiving_pubkey = UmbralPrivateKey.gen_key().get_pubkey()
-
-    capsule.set_correctness_keys(delegating_privkey.get_pubkey(),
-                                 unrelated_receiving_pubkey,
-                                 signing_privkey.get_pubkey()
-                                )
-
-    for kfrag in kfrags:
-        with pytest.raises(KFrag.NotValid):
-            cfrag = pre.reencrypt(kfrag, capsule)
 
 
 def test_cannot_attach_cfrag_without_proof():

--- a/tests/unit/test_capsule_operations.py
+++ b/tests/unit/test_capsule_operations.py
@@ -71,7 +71,7 @@ def test_capsule_equality():
     activated_capsule = Capsule(params,
                                 point_e_prime=Point.gen_rand(),
                                 point_v_prime=Point.gen_rand(),
-                                point_noninteractive=Point.gen_rand())
+                                point_precursor=Point.gen_rand())
 
     assert activated_capsule != one_capsule
 

--- a/tests/unit/test_capsule_operations.py
+++ b/tests/unit/test_capsule_operations.py
@@ -68,13 +68,6 @@ def test_capsule_equality():
 
     assert one_capsule != another_capsule
 
-    activated_capsule = Capsule(params,
-                                point_e_prime=Point.gen_rand(),
-                                point_v_prime=Point.gen_rand(),
-                                point_precursor=Point.gen_rand())
-
-    assert activated_capsule != one_capsule
-
 
 def test_decapsulation_by_alice(alices_keys):
     params = default_params()
@@ -113,25 +106,9 @@ def test_capsule_as_dict_key(alices_keys, bobs_keys):
     plain_data = b'peace at dawn'
     ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data)
 
-    capsule.set_correctness_keys(delegating=delegating_pubkey,
-                                 receiving=receiving_pubkey,
-                                 verifying=signing_pubkey)
-
     # We can use the capsule as a key, and successfully lookup using it.
     some_dict = {capsule: "Thing that Bob wants to try per-Capsule"}
     assert some_dict[capsule] == "Thing that Bob wants to try per-Capsule"
-
-    kfrags = pre.split_rekey(delegating_privkey, signer_alice, receiving_pubkey , 1, 2)
-    cfrag = pre.reencrypt(kfrags[0], capsule)
-    capsule.attach_cfrag(cfrag)
-
-    cfrag = pre.reencrypt(kfrags[1], capsule)
-    capsule.attach_cfrag(cfrag)
-
-    # Even if we activate the capsule, it still serves as the same key.
-    cleartext = pre.decrypt(ciphertext, capsule, receiving_privkey)
-    assert some_dict[capsule] == "Thing that Bob wants to try per-Capsule"
-    assert cleartext == plain_data
 
     # And if we change the value for this key, all is still well.
     some_dict[capsule] = "Bob has changed his mind."

--- a/tests/unit/test_capsule_serializers.py
+++ b/tests/unit/test_capsule_serializers.py
@@ -25,7 +25,7 @@ from umbral.point import Point
 
 
 def test_capsule_serialization(capsule):
-    params = capsule._umbral_params
+    params = capsule.params
     capsule_bytes = capsule.to_bytes()
     capsule_bytes_casted = bytes(capsule)
     assert capsule_bytes == capsule_bytes_casted
@@ -40,40 +40,15 @@ def test_capsule_serialization(capsule):
     assert new_capsule == capsule
 
     # Second, we show that the original components (which is all we have here since we haven't activated) are the same:
-    assert new_capsule.original_components() == capsule.original_components()
+    assert new_capsule.components() == capsule.components()
+
 
     # Third, we can directly compare the private original component attributes
     # (though this is not a supported approach):
+    # TODO: revisit if/when these attributes are made public
     assert new_capsule._point_e == capsule._point_e
     assert new_capsule._point_v == capsule._point_v
     assert new_capsule._bn_sig == capsule._bn_sig
-
-
-def test_activated_capsule_serialization(prepared_capsule, kfrags, bobs_keys):
-    capsule = prepared_capsule
-    params = capsule._umbral_params
-    receiving_privkey, _receiving_pubkey = bobs_keys
-
-    for kfrag in kfrags:
-        cfrag = pre.reencrypt(kfrag, capsule)
-        
-        capsule.attach_cfrag(cfrag)
-
-        capsule._reconstruct_shamirs_secret(receiving_privkey)
-        rec_capsule_bytes = capsule.to_bytes()
-
-        assert len(rec_capsule_bytes) == pre.Capsule.expected_bytes_length(activated=True)
-
-        new_rec_capsule = pre.Capsule.from_bytes(rec_capsule_bytes, params)
-
-        # Again, the same three perspectives on equality.
-        assert new_rec_capsule == capsule
-
-        assert new_rec_capsule.activated_components() == capsule.activated_components()
-
-        assert new_rec_capsule._point_e_prime == capsule._point_e_prime
-        assert new_rec_capsule._point_v_prime == capsule._point_v_prime
-        assert new_rec_capsule._point_precursor == capsule._point_precursor
 
 
 def test_cannot_create_capsule_from_bogus_material(alices_keys):
@@ -90,15 +65,3 @@ def test_cannot_create_capsule_from_bogus_material(alices_keys):
                                                         point_e=Point.gen_rand(),
                                                         point_v=Point.gen_rand(),
                                                         bn_sig=42)
-
-    with pytest.raises(TypeError):
-        capsule_of_questionable_parentage = pre.Capsule(params,
-                                                        point_e_prime=Point.gen_rand(),
-                                                        point_v_prime=42,
-                                                        point_noninteractive=Point.gen_rand())
-
-    with pytest.raises(TypeError):
-        capsule_of_questionable_parentage = pre.Capsule(params,
-                                                        point_e_prime=Point.gen_rand(),
-                                                        point_v_prime=Point.gen_rand(),
-                                                        point_noninteractive=42)

--- a/tests/unit/test_capsule_serializers.py
+++ b/tests/unit/test_capsule_serializers.py
@@ -59,7 +59,6 @@ def test_activated_capsule_serialization(prepared_capsule, kfrags, bobs_keys):
         
         capsule.attach_cfrag(cfrag)
 
-
         capsule._reconstruct_shamirs_secret(receiving_privkey)
         rec_capsule_bytes = capsule.to_bytes()
 
@@ -74,7 +73,7 @@ def test_activated_capsule_serialization(prepared_capsule, kfrags, bobs_keys):
 
         assert new_rec_capsule._point_e_prime == capsule._point_e_prime
         assert new_rec_capsule._point_v_prime == capsule._point_v_prime
-        assert new_rec_capsule._point_noninteractive == capsule._point_noninteractive
+        assert new_rec_capsule._point_precursor == capsule._point_precursor
 
 
 def test_cannot_create_capsule_from_bogus_material(alices_keys):

--- a/tests/unit/test_cfrags.py
+++ b/tests/unit/test_cfrags.py
@@ -37,7 +37,7 @@ def test_cfrag_serialization_with_proof_and_metadata(prepared_capsule, kfrags):
         assert new_cfrag._point_e1 == cfrag._point_e1
         assert new_cfrag._point_v1 == cfrag._point_v1
         assert new_cfrag._kfrag_id == cfrag._kfrag_id
-        assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
+        assert new_cfrag._point_precursor == cfrag._point_precursor
 
         new_proof = new_cfrag.proof
         assert new_proof is not None
@@ -68,7 +68,7 @@ def test_cfrag_serialization_with_proof_but_no_metadata(prepared_capsule, kfrags
         assert new_cfrag._point_e1 == cfrag._point_e1
         assert new_cfrag._point_v1 == cfrag._point_v1
         assert new_cfrag._kfrag_id == cfrag._kfrag_id
-        assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
+        assert new_cfrag._point_precursor == cfrag._point_precursor
 
         new_proof = new_cfrag.proof
         assert new_proof is not None
@@ -95,7 +95,7 @@ def test_cfrag_serialization_no_proof_no_metadata(prepared_capsule, kfrags):
         assert new_cfrag._point_e1 == cfrag._point_e1
         assert new_cfrag._point_v1 == cfrag._point_v1
         assert new_cfrag._kfrag_id == cfrag._kfrag_id
-        assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
+        assert new_cfrag._point_precursor == cfrag._point_precursor
 
         new_proof = new_cfrag.proof
         assert new_proof is None

--- a/tests/unit/test_kfrags.py
+++ b/tests/unit/test_kfrags.py
@@ -30,11 +30,10 @@ def test_kfrag_serialization(alices_keys, bobs_keys, kfrags):
         assert len(kfrag_bytes) == KFrag.expected_bytes_length()
 
         new_kfrag = KFrag.from_bytes(kfrag_bytes)
-        assert new_kfrag._id == kfrag._id
+        assert new_kfrag.id == kfrag.id
         assert new_kfrag._bn_key == kfrag._bn_key
-        assert new_kfrag._point_noninteractive == kfrag._point_noninteractive
+        assert new_kfrag._point_precursor == kfrag._point_precursor
         assert new_kfrag._point_commitment == kfrag._point_commitment
-        assert new_kfrag._point_xcoord == kfrag._point_xcoord
 
         assert new_kfrag.verify(signing_pubkey=signing_privkey.get_pubkey(),
                                 delegating_pubkey=delegating_privkey.get_pubkey(),
@@ -48,7 +47,7 @@ def test_kfrag_verify_for_capsule(prepared_capsule, kfrags):
         assert kfrag.verify_for_capsule(prepared_capsule)
 
         # If we alter some element, the verification fails
-        previous_id, kfrag._id = kfrag._id, bytes(32)
+        previous_id, kfrag._id = kfrag.id, bytes(32)
         assert not kfrag.verify_for_capsule(prepared_capsule)    
 
         # Let's restore the KFrag, and alter the re-encryption key instead

--- a/tests/unit/test_kfrags.py
+++ b/tests/unit/test_kfrags.py
@@ -34,6 +34,9 @@ def test_kfrag_serialization(alices_keys, bobs_keys, kfrags):
         assert new_kfrag._bn_key == kfrag._bn_key
         assert new_kfrag._point_precursor == kfrag._point_precursor
         assert new_kfrag._point_commitment == kfrag._point_commitment
+        assert new_kfrag.keys_in_signature == kfrag.keys_in_signature
+        assert new_kfrag.signature_for_proxy == kfrag.signature_for_proxy
+        assert new_kfrag.signature_for_bob == kfrag.signature_for_bob
 
         assert new_kfrag.verify(signing_pubkey=signing_privkey.get_pubkey(),
                                 delegating_pubkey=delegating_privkey.get_pubkey(),
@@ -47,11 +50,11 @@ def test_kfrag_verify_for_capsule(prepared_capsule, kfrags):
         assert kfrag.verify_for_capsule(prepared_capsule)
 
         # If we alter some element, the verification fails
-        previous_id, kfrag._id = kfrag.id, bytes(32)
+        previous_id, kfrag.id = kfrag.id, bytes(32)
         assert not kfrag.verify_for_capsule(prepared_capsule)    
 
         # Let's restore the KFrag, and alter the re-encryption key instead
-        kfrag._id = previous_id
+        kfrag.id = previous_id
         kfrag._bn_key += kfrag._bn_key
         assert not kfrag.verify_for_capsule(prepared_capsule)    
         

--- a/tests/unit/test_kfrags.py
+++ b/tests/unit/test_kfrags.py
@@ -20,7 +20,6 @@ along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 from umbral.fragments import KFrag
 
 
-
 def test_kfrag_serialization(alices_keys, bobs_keys, kfrags):
     
     delegating_privkey, signing_privkey = alices_keys
@@ -43,6 +42,7 @@ def test_kfrag_serialization(alices_keys, bobs_keys, kfrags):
 
         assert new_kfrag == kfrag
 
+
 def test_kfrag_verify_for_capsule(prepared_capsule, kfrags):
     for kfrag in kfrags:
         assert kfrag.verify_for_capsule(prepared_capsule)
@@ -51,14 +51,14 @@ def test_kfrag_verify_for_capsule(prepared_capsule, kfrags):
         previous_id, kfrag._id = kfrag._id, bytes(32)
         assert not kfrag.verify_for_capsule(prepared_capsule)    
 
-        # Let's restore the KFrag, and alter the re-encryption key instead
+        # Let's restore the KFrag, and alter the re-encryption key instead
         kfrag._id = previous_id
         kfrag._bn_key += kfrag._bn_key
         assert not kfrag.verify_for_capsule(prepared_capsule)    
         
 
 def test_kfrag_as_dict_key(kfrags):
-    dict_with_kfrags_as_keys = {}
+    dict_with_kfrags_as_keys = dict()
     dict_with_kfrags_as_keys[kfrags[0]] = "Some llamas.  Definitely some llamas."
     dict_with_kfrags_as_keys[kfrags[1]] = "No llamas here.  Definitely not."
 

--- a/tests/unit/test_serialization_property_based.py
+++ b/tests/unit/test_serialization_property_based.py
@@ -49,12 +49,12 @@ signatures = tuples(integers(min_value=1, max_value=backend._bn_to_int(curve.ord
 
 # # utility
 def assert_kfrag_eq(k0, k1):
-    assert(all([ k0._id                   == k1._id
-               , k0._bn_key               == k1._bn_key
-               , k0._point_noninteractive == k1._point_noninteractive
-               , k0._point_commitment     == k1._point_commitment
-               , k0._point_xcoord         == k1._point_xcoord
-               , k0.signature             == k1.signature
+    assert(all([ k0.id                == k1.id
+               , k0._bn_key           == k1._bn_key
+               , k0._point_precursor  == k1._point_precursor
+               , k0._point_commitment == k1._point_commitment
+               , k0.signature_for_bob == k1.signature_for_bob
+               , k0.signature_for_proxy == k1.signature_for_proxy
                ]))
 
 def assert_cp_eq(c0, c1):
@@ -79,10 +79,11 @@ def test_bn_roundtrip(bn):
 def test_point_roundtrip(p, c):
     assert(p == Point.from_bytes(p.to_bytes(is_compressed=c)))
 
-@given(binary(min_size=bn_size, max_size=bn_size), bns, points, points, points, signatures)
+@given(binary(min_size=bn_size, max_size=bn_size), bns, points, points, signatures, signatures)
 @settings(max_examples=max_examples, timeout=unlimited)
-def test_kfrag_roundtrip(d, b0, p0, p1, p2, sig):
-    k = KFrag(d, b0, p0, p1, p2, sig)
+def test_kfrag_roundtrip(d, b0, p0, p1, sig_proxy, sig_bob):
+    k = KFrag(identifier=d, bn_key=b0, point_commitment=p0, point_precursor=p1,
+              signature_for_proxy=sig_proxy, signature_for_bob=sig_bob)
     assert_kfrag_eq(k, KFrag.from_bytes(k.to_bytes()))
 
 @given(points, points, bns)

--- a/tests/unit/test_serialization_property_based.py
+++ b/tests/unit/test_serialization_property_based.py
@@ -92,13 +92,6 @@ def test_capsule_roundtrip_0(p0, p1, b):
     c = Capsule(params=params, point_e=p0, point_v=p1, bn_sig=b)
     assert(c == Capsule.from_bytes(c.to_bytes(), params=params))
 
-@given(points, points, bns, points, points, points)
-@settings(max_examples=max_examples, timeout=unlimited)
-def test_capsule_roundtrip_1(p0, p1, b, p2, p3, p4):
-    c = Capsule(params=params, point_e=p0, point_v=p1, bn_sig=b, 
-                point_e_prime=p2, point_v_prime=p3, point_noninteractive=p4)
-    assert(c == Capsule.from_bytes(c.to_bytes(), params))
-
 @given(points, points, points, points, bns, signatures)
 @settings(max_examples=max_examples, timeout=unlimited)
 def test_cp_roundtrip(p0, p1, p2, p3, b0, sig):

--- a/umbral/__about__.py
+++ b/umbral/__about__.py
@@ -8,7 +8,7 @@ __title__ = "umbral"
 
 __url__ = "https://github.com/nucypher/pyUmbral"
 
-__summary__ = 'Nucypher\'s Umbral Proxy Re-Encryption Implementation',
+__summary__ = 'NuCypher\'s Umbral Proxy Re-Encryption Implementation',
 
 __version__ = "0.1.0-alpha.4"
 

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -152,7 +152,7 @@ def verify_kfrag(kfrag: 'KFrag',
 
     u = params.u
 
-    id = kfrag._id
+    kfrag_id = kfrag._id
     key = kfrag._bn_key
     u1 = kfrag._point_commitment
     ni = kfrag._point_noninteractive
@@ -169,7 +169,7 @@ def verify_kfrag(kfrag: 'KFrag',
     if receiving_pubkey is None:
         receiving_pubkey = b'\x00' * pubkey_size
 
-    validity_input = (id, delegating_pubkey, receiving_pubkey, u1, ni, xcoord)
+    validity_input = (kfrag_id, delegating_pubkey, receiving_pubkey, u1, ni, xcoord)
 
     kfrag_validity_message = bytes().join(bytes(item) for item in validity_input)
     valid_kfrag_signature = kfrag.signature.verify(kfrag_validity_message, signing_pubkey)

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -150,7 +150,7 @@ def verify_kfrag(kfrag: 'KFrag',
 
     #  We check that the commitment is well-formed
     correct_commitment = commitment == key * u
-    validity_input = [kfrag_id, commitment, precursor, (kfrag.keys_in_signature,)]
+    validity_input = [kfrag_id, commitment, precursor, kfrag.keys_in_signature]
 
     if kfrag.delegating_key_in_signature():
         validity_input.append(delegating_pubkey)

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -173,7 +173,7 @@ class KFrag(object):
 
 class CorrectnessProof(object):
     def __init__(self, point_e2: Point, point_v2: Point, point_kfrag_commitment: Point,
-                 point_kfrag_pok: Point, bn_sig: CurveBN, kfrag_signature: bytes,
+                 point_kfrag_pok: Point, bn_sig: CurveBN, kfrag_signature: Signature,
                  metadata: Optional[bytes] = None) -> None:
         self._point_e2 = point_e2
         self._point_v2 = point_v2

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -31,11 +31,12 @@ from umbral.point import Point
 from umbral.signing import Signature
 from umbral.params import UmbralParameters
 
-#TODO: Use ConstantSorrow for this
-NO_KEY = 0x00
-DELEGATING_ONLY = 0x01
-RECEIVING_ONLY = 0x02
-DELEGATING_AND_RECEIVING = 0x03
+from constant_sorrow.constants import NO_KEY, DELEGATING_ONLY, RECEIVING_ONLY, DELEGATING_AND_RECEIVING
+
+NO_KEY(b'\x00')
+DELEGATING_ONLY(b'\x01')
+RECEIVING_ONLY(b'\x02')
+DELEGATING_AND_RECEIVING(b'\x03')
 
 
 class KFrag(object):
@@ -99,7 +100,7 @@ class KFrag(object):
             (CurveBN, bn_size, arguments),  # bn_key
             (Point, point_size, arguments),  # point_commitment
             (Point, point_size, arguments),  # point_precursor
-            (int, 1, {'byteorder': 'big'}),  # keys_in_signature
+            1,  # keys_in_signature
             (Signature, signature_size, arguments),  # signature_for_proxy
             (Signature, signature_size, arguments),  # signature_for_bob
         )
@@ -122,7 +123,7 @@ class KFrag(object):
         precursor = self._point_precursor.to_bytes()
         signature_for_proxy = bytes(self.signature_for_proxy)
         signature_for_bob = bytes(self.signature_for_bob)
-        mode = self.keys_in_signature.to_bytes(1, 'big')
+        mode = bytes(self.keys_in_signature)
 
         return self.id + key + commitment + precursor \
              + mode + signature_for_proxy + signature_for_bob

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -24,11 +24,12 @@ from bytestring_splitter import BytestringSplitter
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 
 from umbral._pre import assess_cfrag_correctness, verify_kfrag
-from umbral.config import default_curve
+from umbral.config import default_curve, default_params
 from umbral.curvebn import CurveBN
 from umbral.keys import UmbralPublicKey
 from umbral.point import Point
 from umbral.signing import Signature
+from umbral.params import UmbralParameters
 
 
 class KFrag(object):
@@ -97,14 +98,24 @@ class KFrag(object):
     def verify(self,
                signing_pubkey: UmbralPublicKey,
                delegating_pubkey: UmbralPublicKey,
-               receiving_pubkey: UmbralPublicKey) -> bool:
-        return verify_kfrag(self, delegating_pubkey, signing_pubkey, receiving_pubkey)
+               receiving_pubkey: UmbralPublicKey,
+               params: Optional[UmbralParameters] = None,
+              ) -> bool:
 
-    def verify_for_capsule(self, capsule : 'Capsule') -> bool:
+        if params is None:
+            params = default_params()
+        return verify_kfrag(kfrag=self,
+                            params=params,
+                            delegating_pubkey=delegating_pubkey,
+                            signing_pubkey=signing_pubkey,
+                            receiving_pubkey=receiving_pubkey)
+
+    def verify_for_capsule(self, capsule: 'Capsule') -> bool:
 
         correctness_keys = capsule.get_correctness_keys()
 
-        return self.verify(signing_pubkey=correctness_keys["verifying"],
+        return self.verify(params=capsule._umbral_params,
+                           signing_pubkey=correctness_keys["verifying"],
                            delegating_pubkey=correctness_keys["delegating"],
                            receiving_pubkey=correctness_keys["receiving"])
 

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -34,19 +34,25 @@ from umbral.params import UmbralParameters
 
 class KFrag(object):
 
+    def __init__(self,
+                 identifier: bytes,
+                 bn_key: CurveBN,
+                 point_commitment: Point,
+                 point_precursor: Point,
+                 signature_for_proxy: Signature,
+                 signature_for_bob: Signature,
+                 ) -> None:
+        self.id = identifier
+        self._bn_key = bn_key
+        self._point_commitment = point_commitment
+        self._point_precursor = point_precursor
+        self.signature_for_proxy = signature_for_proxy
+        self.signature_for_bob = signature_for_bob
+
     class NotValid(ValueError):
         """
         raised if the KFrag does not pass verification.
         """
-
-    def __init__(self, id: bytes, bn_key: CurveBN, point_noninteractive: Point,
-                 point_commitment: Point, point_xcoord: Point, signature: Signature) -> None:
-        self._id = id
-        self._bn_key = bn_key
-        self._point_noninteractive = point_noninteractive
-        self._point_commitment = point_commitment
-        self._point_xcoord = point_xcoord
-        self.signature = signature
 
     @classmethod
     def expected_bytes_length(cls, curve: Optional[EllipticCurve] = None) -> int:
@@ -58,7 +64,14 @@ class KFrag(object):
         bn_size = CurveBN.expected_bytes_length(curve)
         point_size = Point.expected_bytes_length(curve)
 
-        return (bn_size * 4) + (point_size * 3)
+        # self.id --> 1 bn_size
+        # self._bn_key --> 1 bn_size
+        # self._point_commitment --> 1 point_size
+        # self._point_precursor --> 1 point_size
+        # self.signature_for_proxy --> 2 bn_size
+        # self.signature_for_bob --> 2 bn_size
+
+        return bn_size * 6 + point_size * 2
 
     @classmethod
     def from_bytes(cls, data: bytes, curve: Optional[EllipticCurve] = None) -> 'KFrag':
@@ -69,15 +82,16 @@ class KFrag(object):
 
         bn_size = CurveBN.expected_bytes_length(curve)
         point_size = Point.expected_bytes_length(curve)
+        signature_size = Signature.expected_bytes_length(curve)
         arguments = {'curve': curve}
 
         splitter = BytestringSplitter(
             bn_size,  # id
             (CurveBN, bn_size, arguments),  # bn_key
-            (Point, point_size, arguments),  # point_noninteractive
             (Point, point_size, arguments),  # point_commitment
-            (Point, point_size, arguments),  # point_xcoord
-            (Signature, Signature.expected_bytes_length(curve), arguments)
+            (Point, point_size, arguments),  # point_precursor
+            (Signature, signature_size, arguments),  # signature_for_proxy
+            (Signature, signature_size, arguments),  # signature_for_bob
         )
         components = splitter(data)
 
@@ -88,20 +102,20 @@ class KFrag(object):
         Serialize the KFrag into a bytestring.
         """
         key = self._bn_key.to_bytes()
-        ni = self._point_noninteractive.to_bytes()
         commitment = self._point_commitment.to_bytes()
-        xcoord = self._point_xcoord.to_bytes()
-        signature = bytes(self.signature)
+        precursor = self._point_precursor.to_bytes()
+        signature_for_proxy = bytes(self.signature_for_proxy)
+        signature_for_bob = bytes(self.signature_for_bob)
 
-        return self._id + key + ni + commitment + xcoord + signature
+        return self.id + key + commitment + precursor \
+             + signature_for_proxy + signature_for_bob
 
     def verify(self,
                signing_pubkey: UmbralPublicKey,
                delegating_pubkey: UmbralPublicKey,
                receiving_pubkey: UmbralPublicKey,
                params: Optional[UmbralParameters] = None,
-              ) -> bool:
-
+               ) -> bool:
         if params is None:
             params = default_params()
         return verify_kfrag(kfrag=self,
@@ -111,10 +125,9 @@ class KFrag(object):
                             receiving_pubkey=receiving_pubkey)
 
     def verify_for_capsule(self, capsule: 'Capsule') -> bool:
-
         correctness_keys = capsule.get_correctness_keys()
 
-        return self.verify(params=capsule._umbral_params,
+        return self.verify(params=capsule.params,
                            signing_pubkey=correctness_keys["verifying"],
                            delegating_pubkey=correctness_keys["delegating"],
                            receiving_pubkey=correctness_keys["receiving"])
@@ -126,10 +139,10 @@ class KFrag(object):
         return hmac.compare_digest(bytes(self), bytes(other))
 
     def __hash__(self):
-        return hash(bytes(self._id))
+        return hash(bytes(self.id))
 
     def __repr__(self):
-        return "{}:{}".format(self.__class__.__name__, self._id.hex()[:15])
+        return "{}:{}".format(self.__class__.__name__, self.id.hex()[:15])
 
 
 class CorrectnessProof(object):
@@ -207,14 +220,12 @@ class CapsuleFrag(object):
                  point_e1: Point,
                  point_v1: Point,
                  kfrag_id: bytes,
-                 point_noninteractive: Point,
-                 point_xcoord: Point,
+                 point_precursor: Point,
                  proof: Optional[CorrectnessProof] = None) -> None:
         self._point_e1 = point_e1
         self._point_v1 = point_v1
         self._kfrag_id = kfrag_id
-        self._point_noninteractive = point_noninteractive
-        self._point_xcoord = point_xcoord
+        self._point_precursor = point_precursor
         self.proof = proof
 
     class NoProofProvided(TypeError):
@@ -233,7 +244,7 @@ class CapsuleFrag(object):
         bn_size = CurveBN.expected_bytes_length(curve)
         point_size = Point.expected_bytes_length(curve)
 
-        return (bn_size * 1) + (point_size * 4)
+        return (bn_size * 1) + (point_size * 3)
 
     @classmethod
     def from_bytes(cls, data: bytes, curve: Optional[EllipticCurve] = None) -> 'CapsuleFrag':
@@ -250,8 +261,7 @@ class CapsuleFrag(object):
             (Point, point_size, arguments),  # point_e1
             (Point, point_size, arguments),  # point_v1
             bn_size,  # kfrag_id
-            (Point, point_size, arguments),  # point_noninteractive
-            (Point, point_size, arguments)  # point_xcoord
+            (Point, point_size, arguments),  # point_precursor
         )
         components = splitter(data, return_remainder=True)
 
@@ -265,10 +275,9 @@ class CapsuleFrag(object):
         """
         e1 = self._point_e1.to_bytes()
         v1 = self._point_v1.to_bytes()
-        ni = self._point_noninteractive.to_bytes()
-        xcoord = self._point_xcoord.to_bytes()
+        precursor = self._point_precursor.to_bytes()
 
-        serialized_cfrag = e1 + v1 + self._kfrag_id + ni + xcoord
+        serialized_cfrag = e1 + v1 + self._kfrag_id + precursor
 
         if self.proof is not None:
             serialized_cfrag += self.proof.to_bytes()
@@ -278,8 +287,15 @@ class CapsuleFrag(object):
     def verify_correctness(self, capsule: 'Capsule') -> bool:
         return assess_cfrag_correctness(self, capsule)
 
-    def attach_proof(self, e2: Point, v2: Point, u1: Point, u2: Point, z3: CurveBN, kfrag_signature: Signature,
+    def attach_proof(self,
+                     e2: Point,
+                     v2: Point,
+                     u1: Point,
+                     u2: Point,
+                     z3: CurveBN,
+                     kfrag_signature: Signature,
                      metadata: Optional[bytes]) -> None:
+
         self.proof = CorrectnessProof(point_e2=e2,
                                       point_v2=v2,
                                       point_kfrag_commitment=u1,

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -32,6 +32,7 @@ from umbral.config import default_params
 from umbral.curvebn import CurveBN
 from umbral.params import UmbralParameters
 from umbral.point import Point
+from umbral.curve import Curve
 
 
 class UmbralPrivateKey(object):
@@ -209,6 +210,16 @@ class UmbralPublicKey(object):
 
         point_key = Point.from_bytes(key_bytes, params.curve)
         return cls(point_key, params)
+
+    @classmethod
+    def expected_bytes_length(cls, curve: Optional[Curve] = None,
+                              is_compressed: bool = True):
+        """
+        Returns the size (in bytes) of an UmbralPublicKey given a curve.
+        If no curve is provided, it uses the default curve.
+        By default, it assumes compressed representation (is_compressed = True).
+        """
+        return Point.expected_bytes_length(curve=curve, is_compressed=is_compressed)
 
     def to_bytes(self, encoder: Callable = None, is_compressed: bool = True):
         """

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -41,10 +41,11 @@ class Point(object):
 
     @classmethod
     def expected_bytes_length(cls, curve: Optional[Curve] = None,
-                              is_compressed: bool=True):
+                              is_compressed: bool = True):
         """
-        Returns the size (in bytes) of a compressed Point given a curve.
+        Returns the size (in bytes) of a Point given a curve.
         If no curve is provided, it uses the default curve.
+        By default, it assumes compressed representation (is_compressed = True).
         """
         curve = curve if curve is not None else default_curve()
 

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -152,7 +152,7 @@ class Capsule(object):
 
         if current_key is None:
             if key is None:
-                raise TypeError("The {} key is not set and you didn't pass one.".format(key_type))
+                return False
             elif self._umbral_params != key.params:
                 raise TypeError("You are trying to set a key with different UmbralParameters.")
             else:

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -298,6 +298,7 @@ class Capsule(object):
     def __repr__(self):
         return "{}:{}".format(self.__class__.__name__, hex(int(self._bn_sig))[2:17])
 
+
 def split_rekey(delegating_privkey: UmbralPrivateKey,
                 signer: Signer,
                 receiving_pubkey: UmbralPublicKey,
@@ -305,7 +306,7 @@ def split_rekey(delegating_privkey: UmbralPrivateKey,
                 N: int,
                 sign_delegating_key : Optional[bool] = True,
                 sign_receiving_key : Optional[bool] = True,
-                ) -> List[KFrag]:
+               ) -> List[KFrag]:
     """
     Creates a re-encryption key from Alice to Bob and splits it in KFrags,
     using Shamir's Secret Sharing. Requires a threshold number of KFrags
@@ -360,9 +361,9 @@ def split_rekey(delegating_privkey: UmbralPrivateKey,
 
     kfrags = []
     for _ in range(N):
-        id = os.urandom(bn_size)
+        kfrag_id = os.urandom(bn_size)
 
-        share_x = CurveBN.hash(id, hashed_dh_tuple, params=params)
+        share_x = CurveBN.hash(kfrag_id, hashed_dh_tuple, params=params)
 
         rk = poly_eval(coeffs, share_x)
 
@@ -374,12 +375,12 @@ def split_rekey(delegating_privkey: UmbralPrivateKey,
         if not sign_receiving_key:
             receiving_pubkey = b'\x00' * pubkey_size
 
-        validity_input = (id, delegating_pubkey, receiving_pubkey, u1, ni, xcoord)
+        validity_input = (kfrag_id, delegating_pubkey, receiving_pubkey, u1, ni, xcoord)
 
         kfrag_validity_message = bytes().join(bytes(item) for item in validity_input)
         signature = signer(kfrag_validity_message)
 
-        kfrag = KFrag(id=id,
+        kfrag = KFrag(id=kfrag_id,
                       bn_key=rk,
                       point_noninteractive=ni,
                       point_commitment=u1,

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -399,10 +399,9 @@ def split_rekey(delegating_privkey: UmbralPrivateKey,
 def reencrypt(kfrag: KFrag, capsule: Capsule, provide_proof: bool = True, 
               metadata: Optional[bytes] = None) -> CapsuleFrag:
 
-    if capsule is None or not capsule.verify():
+    if not isinstance(capsule, Capsule) or not capsule.verify():
         raise Capsule.NotValid
-
-    if kfrag is None or not kfrag.verify_for_capsule(capsule):
+    elif not isinstance(kfrag, KFrag) or not kfrag.verify_for_capsule(capsule):
         raise KFrag.NotValid
 
     rk = kfrag._bn_key
@@ -545,6 +544,10 @@ def decrypt(ciphertext: bytes, capsule: Capsule, decrypting_key: UmbralPrivateKe
 
     if not isinstance(ciphertext, bytes) or len(ciphertext) < DEM_NONCE_SIZE:
         raise ValueError("Input ciphertext must be a bytes object of length >= {}".format(DEM_NONCE_SIZE))
+    elif not isinstance(capsule, Capsule) or not capsule.verify():
+        raise Capsule.NotValid
+    elif not isinstance(decrypting_key, UmbralPrivateKey):
+        raise TypeError("The decrypting key is not an UmbralPrivateKey")
 
     if capsule._attached_cfrags:
         # Since there are cfrags attached, we assume this is Bob opening the Capsule.

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -283,7 +283,7 @@ def generate_kfrags(delegating_privkey: UmbralPrivateKey,
         else:
             mode = NO_KEY
 
-        validity_message_for_proxy = [kfrag_id, commitment, precursor, (mode,)]
+        validity_message_for_proxy = [kfrag_id, commitment, precursor, mode]
 
         if sign_delegating_key:
             validity_message_for_proxy.append(delegating_pubkey)

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -192,20 +192,20 @@ class Capsule(object):
         return "{}:{}".format(self.__class__.__name__, hex(int(self._bn_sig))[2:17])
 
 
-def split_rekey(delegating_privkey: UmbralPrivateKey,
-                signer: Signer,
-                receiving_pubkey: UmbralPublicKey,
-                threshold: int,
-                N: int,
-                sign_delegating_key : Optional[bool] = True,
-                sign_receiving_key : Optional[bool] = True,
-               ) -> List[KFrag]:
+def generate_kfrags(delegating_privkey: UmbralPrivateKey,
+                    receiving_pubkey: UmbralPublicKey,
+                    threshold: int,
+                    N: int,
+                    signer: Signer,
+                    sign_delegating_key: Optional[bool] = True,
+                    sign_receiving_key: Optional[bool] = True,
+                    ) -> List[KFrag]:
     """
     Creates a re-encryption key from Alice's delegating public key to Bob's
     receiving public key, and splits it in KFrags, using Shamir's Secret Sharing.
     Requires a threshold number of KFrags out of N.
 
-    Returns a dictionary which includes the list of N KFrags
+    Returns a list of N KFrags
     """
 
     if threshold <= 0 or threshold > N:

--- a/vectors/generate_test_vectors.py
+++ b/vectors/generate_test_vectors.py
@@ -53,7 +53,7 @@ receiving_key = receiving_privkey.get_pubkey()
 
 signer = Signer(signing_privkey)
 
-kfrags = pre.split_rekey(delegating_privkey, signer, receiving_key, 6, 10)
+kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_key, 6, 10)
 
 plain_data = b'peace at dawn'
 

--- a/vectors/generate_test_vectors.py
+++ b/vectors/generate_test_vectors.py
@@ -60,9 +60,9 @@ plain_data = b'peace at dawn'
 ciphertext, capsule = pre.encrypt(delegating_key, plain_data)
 
 cfrag = pre.reencrypt(kfrags[0], capsule)
-points = [  capsule._point_e, cfrag._point_e1, cfrag.proof._point_e2, 
-            capsule._point_v, cfrag._point_v1, cfrag.proof._point_v2,
-            capsule._umbral_params.u, cfrag.proof._point_kfrag_commitment, cfrag.proof._point_kfrag_pok ]
+points = [capsule._point_e, cfrag._point_e1, cfrag.proof._point_e2,
+          capsule._point_v, cfrag._point_v1, cfrag.proof._point_v2,
+          capsule.params.u, cfrag.proof._point_kfrag_commitment, cfrag.proof._point_kfrag_pok]
 
 z = cfrag.proof.bn_sig
 


### PR DESCRIPTION
The goal of this PR is to provide the minimum update that allows NuCypher to synchronize with current state of pyUmbral. In particular, knowledge of delegating and receiving public keys is now optional to KFrag validity; this is decided by Alice when generating the kfrags using the new flags `sign_delegating_key` and `sign_receiving_key`. 

This PR bumps pyUmbral's version: `0.1.0-alpha.4 → 0.1.1-alpha.0`