### PR TITLE
Improved verification of KFrags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,15 @@ workflows:
             - run_tests-35
             - run_tests-36
             - run_tests-37
+      - notebook_tests-36:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - bundle_dependencies-36
+          #- run_tests-35
+          #- run_tests-36
+          #- run_tests-37
       - reencryption_memory_profile-36:
           filters:
             tags:
@@ -225,6 +234,23 @@ jobs:
               pipenv run make doctest
       - store_artifacts:
           path: ./docs/build/doctest/output.txt
+
+  notebook_tests-36:
+    <<: *python_36_base
+    steps:
+    - checkout
+    # - restore_cache:
+    #     key: v2-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile.lock" }}-py36
+    - run:
+        name: Install dependencies
+        command: pipenv sync --three --dev
+    - run:
+        name: Run py.test on Jupyter Notebook stored output
+        command: |
+            pipenv install -e . --dev --skip-lock
+            pipenv run pytest --nbval docs/notebooks/pyUmbral\ Simple\ API.ipynb --junitxml=./reports/pytest/nbval-results.xml
+    - store_test_results:
+        path: /reports/pytest
 
   reencryption_memory_profile-36:
     <<: *python_36_base

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ cryptography = ">=2.3"
 pynacl="*"
 # NuCypher
 bytestringsplitter = "*"
+constantSorrow = {git = "https://github.com/nucypher/constantSorrow.git", ref = "nucypher-depend"}
 
 [dev-packages]
 bumpversion = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -31,6 +31,7 @@ sphinx = "*"
 sphinx-autobuild = "*"
 # Testing libraries
 hypothesis = "*"
+nbval = "*"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ cryptography = ">=2.3"
 pynacl="*"
 # NuCypher
 bytestringsplitter = "*"
-constantSorrow = {git = "https://github.com/nucypher/constantSorrow.git", ref = "nucypher-depend"}
+constant-sorrow = "*"
 
 [dev-packages]
 bumpversion = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4365b58ce6790560629f248397b2c0f99eb78a75036e5168e1d96798dacf5685"
+            "sha256": "2fbdecd67617c10b2dff802bb18c67a93042c40b143a822732326b8b6750b199"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -156,6 +156,14 @@
             ],
             "version": "==0.7.12"
         },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
+        },
         "argh": {
             "hashes": [
                 "sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3",
@@ -184,6 +192,13 @@
                 "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
             ],
             "version": "==2.6.0"
+        },
+        "backcall": {
+            "hashes": [
+                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
+                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+            ],
+            "version": "==0.1.0"
         },
         "bumpversion": {
             "hashes": [
@@ -256,6 +271,13 @@
             "index": "pypi",
             "version": "==5.0a2"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:2c51dff8ef3c447388fe5e4453d24a2bf128d3a4c32af3fabef1f01c6851ab82",
+                "sha256:c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c"
+            ],
+            "version": "==4.3.0"
+        },
         "docutils": {
             "hashes": [
                 "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
@@ -288,12 +310,61 @@
             "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==1.1.0"
         },
+        "ipykernel": {
+            "hashes": [
+                "sha256:3e0ffdf545c0bf80d9dab6523ec6829831408c474772487aeb6eb9f0348b6a1e",
+                "sha256:7cd5e90bc882c13f9c5e76330cb5242280e293cbe9f1a622508762124a103a82"
+            ],
+            "version": "==5.0.0"
+        },
+        "ipython": {
+            "hashes": [
+                "sha256:47b17ea874454a5c2eacc2732b04a750d260b01ba479323155ac8a39031f5535",
+                "sha256:9fed506c3772c875a3048bc134a25e6f5e997b1569b2636f6a5d891f34cbfd46"
+            ],
+            "version": "==7.0.1"
+        },
+        "ipython-genutils": {
+            "hashes": [
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
+                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+            ],
+            "version": "==0.2.0"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:0191c447165f798e6a730285f2eee783fff81b0d3df261945ecb80983b5c3ca7",
+                "sha256:b7493f73a2febe0dc33d51c99b474547f7f6c0b2c8fb2b21f453eef204c12148"
+            ],
+            "version": "==0.13.1"
+        },
         "jinja2": {
             "hashes": [
                 "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
                 "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
             ],
             "version": "==2.10"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:3ae8afd6f4ca6417f14bf43ef61341311598f14234cdb4174fe43d42b236a3c8",
+                "sha256:dfd8426040892c8d0ef6da574085f282569f189cb24b70091a66c21c12d6705e"
+            ],
+            "version": "==3.0.0a3"
+        },
+        "jupyter-client": {
+            "hashes": [
+                "sha256:27befcf0446b01e29853014d6a902dd101ad7d7f94e2252b1adca17c3466b761",
+                "sha256:59e6d791e22a8002ad0e80b78c6fd6deecab4f9e1b1aa1a22f4213de271b29ea"
+            ],
+            "version": "==5.2.3"
+        },
+        "jupyter-core": {
+            "hashes": [
+                "sha256:927d713ffa616ea11972534411544589976b2493fc7e09ad946e010aa7eb9970",
+                "sha256:ba70754aa680300306c699790128f6fbd8c306ee5927976cbe48adacf240c0b7"
+            ],
+            "version": "==4.4.0"
         },
         "livereload": {
             "hashes": [
@@ -347,12 +418,34 @@
             ],
             "version": "==0.4.1"
         },
+        "nbformat": {
+            "hashes": [
+                "sha256:b9a0dbdbd45bb034f4f8893cafd6f652ea08c8c1674ba83f2dc55d3955743b0b",
+                "sha256:f7494ef0df60766b7cabe0a3651556345a963b74dbc16bc7c18479041170d402"
+            ],
+            "version": "==4.4.0"
+        },
+        "nbval": {
+            "hashes": [
+                "sha256:3f18b87af4e94ccd073263dd58cd3eebabe9f5e4d6ab535b39d3af64811c7eda",
+                "sha256:74ff5e2c90a50b1ddf7edd02978c4e43221b1ee252dc14fcaa4230aae4492eda"
+            ],
+            "index": "pypi",
+            "version": "==0.9.1"
+        },
         "packaging": {
             "hashes": [
                 "sha256:0886227f54515e592aaa2e5a553332c73962917f2831f1b0f9b9f4380a4b9807",
                 "sha256:f95a1e147590f204328170981833854229bb2912ac3d5f89e2a8ccd2834800c9"
             ],
             "version": "==18.0"
+        },
+        "parso": {
+            "hashes": [
+                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
+                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
+            ],
+            "version": "==0.3.1"
         },
         "pathtools": {
             "hashes": [
@@ -367,6 +460,21 @@
             ],
             "version": "==4.3.0"
         },
+        "pexpect": {
+            "hashes": [
+                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
+                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
+            ],
+            "markers": "sys_platform != 'win32'",
+            "version": "==4.6.0"
+        },
+        "pickleshare": {
+            "hashes": [
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
+            ],
+            "version": "==0.7.5"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
@@ -380,6 +488,21 @@
                 "sha256:b16a84bb29c2954db44c29be38b17c659c9c27e33918dec16b90d375cc596f1c"
             ],
             "version": "==0.3.1"
+        },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:5eff0c9fd652384ecfe730bbcdf3658868725c6928fbf608d9338834d7a974b6",
+                "sha256:81da9ecf6ca6806a549697529af8ec3ac5b739c13ac14607218e650db1b53131",
+                "sha256:c67c1c264d8a0d9e1070e9272bacee00f76c81daab7bc4bf09ff991bd1e224a7"
+            ],
+            "version": "==2.0.5"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+            ],
+            "version": "==0.6.0"
         },
         "py": {
             "hashes": [
@@ -424,6 +547,12 @@
             "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.2.*'",
             "version": "==2.2.2"
         },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:4024f838472cba9ea1ccbc638e0bcafec2efda28594a9905177ec365f1a95fea"
+            ],
+            "version": "==0.14.4"
+        },
         "pytest": {
             "hashes": [
                 "sha256:7e258ee50338f4e46957f9e09a0f10fb1c2d05493fa901d113a8dafd0790de4e",
@@ -465,6 +594,13 @@
             "index": "pypi",
             "version": "==0.3.2"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+            ],
+            "version": "==2.7.3"
+        },
         "pytz": {
             "hashes": [
                 "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
@@ -482,6 +618,37 @@
             ],
             "version": "==4.2b4"
         },
+        "pyzmq": {
+            "hashes": [
+                "sha256:25a0715c8f69cf72f67cfe5a68a3f3ed391c67c063d2257bec0fe7fc2c7f08f8",
+                "sha256:2bab63759632c6b9e0d5bf19cc63c3b01df267d660e0abcf230cf0afaa966349",
+                "sha256:30ab49d99b24bf0908ebe1cdfa421720bfab6f93174e4883075b7ff38cc555ba",
+                "sha256:32c7ca9fc547a91e3c26fc6080b6982e46e79819e706eb414dd78f635a65d946",
+                "sha256:41219ae72b3cc86d97557fe5b1ef5d1adc1057292ec597b50050874a970a39cf",
+                "sha256:4b8c48a9a13cea8f1f16622f9bd46127108af14cd26150461e3eab71e0de3e46",
+                "sha256:55724997b4a929c0d01b43c95051318e26ddbae23565018e138ae2dc60187e59",
+                "sha256:65f0a4afae59d4fc0aad54a917ab599162613a761b760ba167d66cc646ac3786",
+                "sha256:6f88591a8b246f5c285ee6ce5c1bf4f6bd8464b7f090b1333a446b6240a68d40",
+                "sha256:75022a4c60dcd8765bb9ca32f6de75a0ec83b0d96e0309dc479f4c7b21f26cb7",
+                "sha256:76ea493bfab18dcb090d825f3662b5612e2def73dffc196d51a5194b0294a81d",
+                "sha256:7b60c045b80709e4e3c085bab9b691e71761b44c2b42dbb047b8b498e7bc16b3",
+                "sha256:8e6af2f736734aef8ed6f278f9f552ec7f37b1a6b98e59b887484a840757f67d",
+                "sha256:9ac2298e486524331e26390eac14e4627effd3f8e001d4266ed9d8f1d2d31cce",
+                "sha256:9ba650f493a9bc1f24feca1d90fce0e5dd41088a252ac9840131dfbdbf3815ca",
+                "sha256:a02a4a385e394e46012dc83d2e8fd6523f039bb52997c1c34a2e0dd49ed839c1",
+                "sha256:a3ceee84114d9f5711fa0f4db9c652af0e4636c89eabc9b7f03a3882569dd1ed",
+                "sha256:a72b82ac1910f2cf61a49139f4974f994984475f771b0faa730839607eeedddf",
+                "sha256:ab136ac51027e7c484c53138a0fab4a8a51e80d05162eb7b1585583bcfdbad27",
+                "sha256:c095b224300bcac61e6c445e27f9046981b1ac20d891b2f1714da89d34c637c8",
+                "sha256:c5cc52d16c06dc2521340d69adda78a8e1031705924e103c0eb8fc8af861d810",
+                "sha256:d612e9833a89e8177f8c1dc68d7b4ff98d3186cd331acd616b01bbdab67d3a7b",
+                "sha256:e828376a23c66c6fe90dcea24b4b72cd774f555a6ee94081670872918df87a19",
+                "sha256:e9767c7ab2eb552796440168d5c6e23a99ecaade08dda16266d43ad461730192",
+                "sha256:ebf8b800d42d217e4710d1582b0c8bff20cdcb4faad7c7213e52644034300924"
+            ],
+            "markers": "python_version != '3.0*' and python_version >= '2.7' and python_version != '3.1*' and python_version != '3.2*'",
+            "version": "==17.1.2"
+        },
         "requests": {
             "hashes": [
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
@@ -496,6 +663,12 @@
                 "sha256:b64b767befbe6f5fd918603ab7d6bbff07fc4c431bae2f471e195677a0c9b327"
             ],
             "version": "==17.12.0"
+        },
+        "simplegeneric": {
+            "hashes": [
+                "sha256:dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173"
+            ],
+            "version": "==0.8.1"
         },
         "six": {
             "hashes": [
@@ -548,6 +721,13 @@
             "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==5.1.1"
         },
+        "traitlets": {
+            "hashes": [
+                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835",
+                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"
+            ],
+            "version": "==4.3.2"
+        },
         "typed-ast": {
             "hashes": [
                 "sha256:0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58",
@@ -589,6 +769,13 @@
                 "sha256:965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
             ],
             "version": "==0.9.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "49c29523ea460ce5a70cbae65ff2be3d529de04bd53077012da1e538a756ecfc"
+            "sha256": "4365b58ce6790560629f248397b2c0f99eb78a75036e5168e1d96798dacf5685"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -66,6 +66,10 @@
             ],
             "version": "==1.11.5"
         },
+        "constantsorrow": {
+            "git": "https://github.com/nucypher/constantSorrow.git",
+            "ref": "9a0b3901c53bc584920c46ea891e68acbe1345cb"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:02602e1672b62e803e08617ec286041cc453e8d43f093a5f4162095506bc0beb",
@@ -106,46 +110,35 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
             ],
-            "version": "==2.18"
+            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
+            "version": "==2.19"
         },
         "pynacl": {
             "hashes": [
-                "sha256:04e30e5bdeeb2d5b34107f28cd2f5bbfdc6c616f3be88fc6f53582ff1669eeca",
-                "sha256:0bfa0d94d2be6874e40f896e0a67e290749151e7de767c5aefbad1121cad7512",
-                "sha256:11aa4e141b2456ce5cecc19c130e970793fa3a2c2e6fbb8ad65b28f35aa9e6b6",
-                "sha256:13bdc1fe084ff9ac7653ae5a924cae03bf4bb07c6667c9eb5b6eb3c570220776",
-                "sha256:14339dc233e7a9dda80a3800e64e7ff89d0878ba23360eea24f1af1b13772cac",
-                "sha256:1d33e775fab3f383167afb20b9927aaf4961b953d76eeb271a5703a6d756b65b",
-                "sha256:2a42b2399d0428619e58dac7734838102d35f6dcdee149e0088823629bf99fbb",
-                "sha256:2dce05ac8b3c37b9e2f65eab56c544885607394753e9613fd159d5e2045c2d98",
-                "sha256:63cfccdc6217edcaa48369191ae4dca0c390af3c74f23c619e954973035948cd",
-                "sha256:6453b0dae593163ffc6db6f9c9c1597d35c650598e2c39c0590d1757207a1ac2",
-                "sha256:73a5a96fb5fbf2215beee2353a128d382dbca83f5341f0d3c750877a236569ef",
-                "sha256:8abb4ef79161a5f58848b30ab6fb98d8c466da21fdd65558ce1d7afc02c70b5f",
-                "sha256:8ac1167195b32a8755de06efd5b2d2fe76fc864517dab66aaf65662cc59e1988",
-                "sha256:8f505f42f659012794414fa57c498404e64db78f1d98dfd40e318c569f3c783b",
-                "sha256:9c8a06556918ee8e3ab48c65574f318f5a0a4d31437fc135da7ee9d4f9080415",
-                "sha256:a1e25fc5650cf64f01c9e435033e53a4aca9de30eb9929d099f3bb078e18f8f2",
-                "sha256:be71cd5fce04061e1f3d39597f93619c80cdd3558a6c9ba99a546f144a8d8101",
-                "sha256:c5b1a7a680218dee9da0f1b5e24072c46b3c275d35712bc1d505b85bb03441c0",
-                "sha256:cb785db1a9468841a1265c9215c60fe5d7af2fb1b209e3316a152704607fc582",
-                "sha256:cf6877124ae6a0698404e169b3ba534542cfbc43f939d46b927d956daf0a373a",
-                "sha256:d0eb5b2795b7ee2cbcfcadacbe95a13afbda048a262bd369da9904fecb568975",
-                "sha256:d3a934e2b9f20abac009d5b6951067cfb5486889cb913192b4d8288b216842f1",
-                "sha256:d795f506bcc9463efb5ebb0f65ed77921dcc9e0a50499dedd89f208445de9ecb",
-                "sha256:d8aaf7e5d6b0e0ef7d6dbf7abeb75085713d0100b4eb1a4e4e857de76d77ac45",
-                "sha256:de2aaca8386cf4d70f1796352f2346f48ddb0bed61dc43a3ce773ba12e064031",
-                "sha256:e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9",
-                "sha256:eb2acabbd487a46b38540a819ef67e477a674481f84a82a7ba2234b9ba46f752",
-                "sha256:eeee629828d0eb4f6d98ac41e9a3a6461d114d1d0aa111a8931c049359298da0",
-                "sha256:f5836463a3c0cca300295b229b6c7003c415a9d11f8f9288ddbd728e2746524c",
-                "sha256:f5ce9e26d25eb0b2d96f3ef0ad70e1d3ae89b5d60255c462252a3e456a48c053",
-                "sha256:fabf73d5d0286f9e078774f3435601d2735c94ce9e514ac4fb945701edead7e4"
+                "sha256:05c26f93964373fc0abe332676cb6735f0ecad27711035b9472751faa8521255",
+                "sha256:0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c",
+                "sha256:0d0a8171a68edf51add1e73d2159c4bc19fc0718e79dec51166e940856c2f28e",
+                "sha256:1c780712b206317a746ace34c209b8c29dbfd841dfbc02aa27f2084dd3db77ae",
+                "sha256:2424c8b9f41aa65bbdbd7a64e73a7450ebb4aa9ddedc6a081e7afcc4c97f7621",
+                "sha256:2d23c04e8d709444220557ae48ed01f3f1086439f12dbf11976e849a4926db56",
+                "sha256:30f36a9c70450c7878053fa1344aca0145fd47d845270b43a7ee9192a051bf39",
+                "sha256:37aa336a317209f1bb099ad177fef0da45be36a2aa664507c5d72015f956c310",
+                "sha256:4943decfc5b905748f0756fdd99d4f9498d7064815c4cf3643820c9028b711d1",
+                "sha256:57ef38a65056e7800859e5ba9e6091053cd06e1038983016effaffe0efcd594a",
+                "sha256:5bd61e9b44c543016ce1f6aef48606280e45f892a928ca7068fba30021e9b786",
+                "sha256:6482d3017a0c0327a49dddc8bd1074cc730d45db2ccb09c3bac1f8f32d1eb61b",
+                "sha256:7d3ce02c0784b7cbcc771a2da6ea51f87e8716004512493a2b69016326301c3b",
+                "sha256:a14e499c0f5955dcc3991f785f3f8e2130ed504fa3a7f44009ff458ad6bdd17f",
+                "sha256:a39f54ccbcd2757d1d63b0ec00a00980c0b382c62865b61a505163943624ab20",
+                "sha256:aabb0c5232910a20eec8563503c153a8e78bbf5459490c49ab31f6adf3f3a415",
+                "sha256:bd4ecb473a96ad0f90c20acba4f0bf0df91a4e03a1f4dd6a4bdc9ca75aa3a715",
+                "sha256:e2da3c13307eac601f3de04887624939aca8ee3c9488a0bb0eca4fb9401fc6b1",
+                "sha256:f67814c38162f4deb31f68d590771a29d5ae3b1bd64b75cf232308e5c74777e0"
             ],
             "index": "pypi",
-            "version": "==1.2.1"
+            "version": "==1.3.0"
         },
         "six": {
             "hashes": [
@@ -158,10 +151,10 @@
     "develop": {
         "alabaster": {
             "hashes": [
-                "sha256:674bb3bab080f598371f4443c5008cbfeb1a5e622dd312395d2d82af2c54c456",
-                "sha256:b63b1f4dc77c074d386752ec4a8a7517600f6c0db8cd42980cae17ab7b3275d7"
+                "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
+                "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
             ],
-            "version": "==0.7.11"
+            "version": "==0.7.12"
         },
         "argh": {
             "hashes": [
@@ -172,17 +165,18 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "version": "==1.1.5"
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "version": "==1.2.1"
         },
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
-            "version": "==18.1.0"
+            "version": "==18.2.0"
         },
         "babel": {
             "hashes": [
@@ -201,10 +195,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
-                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
+                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
+                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
             ],
-            "version": "==2018.8.13"
+            "version": "==2018.8.24"
         },
         "chardet": {
             "hashes": [
@@ -215,10 +209,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
-                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
-            "version": "==6.7"
+            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==7.0"
         },
         "codecov": {
             "hashes": [
@@ -230,31 +225,36 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:10cfac276cf3dd0acefc49444fc4e1a0a4c23c855d9fcbd555681c3a47a328e6",
-                "sha256:18797137634b64fe488b239d3709e5f8fdea80aea09f86ec819c633a2c84f79c",
-                "sha256:316881a28d2a1a5853495092267fcacf245805b4139f0fc996f8a6c4be6fb499",
-                "sha256:3368098e2c633ec6b2af4f91abde94b5c3b8fa66857452137485f40be77aeda6",
-                "sha256:35fe7a6c06851c4c6a4c171eb796d27e023f5a1ce1e25837ea720f5b8cb76fce",
-                "sha256:3a1c8ed67a64627ef317de64356731f8f173b76457672e933db896c080e1cc2b",
-                "sha256:59fa7e9857205b8d6f6fce0eaea07409bcdffd68eaec3db7e0b1ac720d4fe0f3",
-                "sha256:6b2e2ef7572b399b0cc2f6d05c06ada40329166d6fc58beef8081fb94a41201f",
-                "sha256:712599fc602c302c540fe7e83b6d82aaf381ec5bfb4a51dc5c30f57d214d649f",
-                "sha256:7c8dbbc9e5480856125511f11a5c735cff3200e367adc3ba342dad506a25407d",
-                "sha256:7fc25906ecb0a6af0c434370da6cfbcf8badb257c5cf9a6464f5e37fe4ebc949",
-                "sha256:88d81556e00ac7e1cc9e70a2376859f41e46d187b6dd5883422aa537505f8a98",
-                "sha256:91a915f5fc88db7adace367e8ef65d1a418d29f7ade62514d604eed87c861355",
-                "sha256:9f696b90ff4886ba5a277995397a13b0600bfd97c70d8ae4241c2aecea11ee61",
-                "sha256:a863f4540446d7eeaf6bf716aee277eaf38842718e86bdb80cdca78cdf1fed0d",
-                "sha256:b3b6d8d8194e7e1300240402dfd9c54840d03621e69da821d8ffc8bbebe00137",
-                "sha256:c296ac03ba12e184bef03387d89c4a0be79daff214294917ce77df32240bf4d8",
-                "sha256:c75b3de73cc7ba2e911a907322c65dd10da216f37e7477f22dbd0098775f6345",
-                "sha256:c87c9ee13ce431305734b8e3f0bf00468a1d4f4ee60b6ef63c69282776ab94d6",
-                "sha256:c89c895ff5cfda45a5f681514b647986f76a4f984df125d210c154e5a1a2472b",
-                "sha256:c9fa8fbda281b1ddf25b8fa7ccf0564198a86c9da8a413111fcadd510a98a232",
-                "sha256:ccdf1bd8fd848690fb3d5153d0c54c41169e59804acb9652664f5f669fe25c11"
+                "sha256:0dcf381f51f589f1f797449602a7fe4e63be8a7963c259c13742af3f30be902e",
+                "sha256:11a4bb30306def2fa012e3429de44a93ef2ae3b6ad3f6b800f6c578658a5c402",
+                "sha256:166c957a38b034050a14201f64eec11fc95e17bf2ba31fc07d887db82bae1a47",
+                "sha256:184e6680f85fcc1b371f67ab732290ecf96a225448198e14ec170986db47b0aa",
+                "sha256:1904deb72c561a8e445feb190db07ca4b165ee85567894b4b85fdb9bf21a27c0",
+                "sha256:1f2003b83426cfaadebff8b9bb1fb3650134a15fda3a81434cc8415896d7a7bc",
+                "sha256:1f462997b1804f8b5d1ee2b262626fc76b746e66023eb64f529af35991167c7c",
+                "sha256:213697f49eba45b5fb05e77f63bdb7c0d13eed12dcd08e6af43224615b28b524",
+                "sha256:2557da232b0daeb55afe2f7e55f7b80c56bfa2981864c6638b32b5691da9f4c3",
+                "sha256:395a8525f1456439a5d6c248bc1397040491047e3e0e0c4ceb2059155419cd3b",
+                "sha256:43d6334b35e50e74d034ec075ffd9082c559bca624924af6c7e9d2b8aef0f362",
+                "sha256:4566c74bde36aaaef0372fb11678edf43dcc73f4eb8dbb6987250658c4a3b95a",
+                "sha256:6d39cc527c9c7a30f20bed14b5cf9a7e87ef1f3528c1847d1c81caf75a31ebb6",
+                "sha256:8bd69d3cba21d885df6fe8728cee779a722da08cf84072558956c148b5ab61e5",
+                "sha256:a1d0fcbbe0735eb66c6622266b12e60ea8d37ada405cb8f73b154c5eec467187",
+                "sha256:ab706bfbb365f232be01a536a9199ee6bfc80c9b63fb7825fdd5f4ae5cc2a12c",
+                "sha256:afbf4cee68d2f2968b06951cf16c0b18513eb59bb3af0685084de6cacb04e217",
+                "sha256:bbc8913cd5889df7eab597a4b4074a2c6c5ee6ca9aad58a9ba0f3f847b1a99df",
+                "sha256:bd5428ab378a7432e43afa52b6bb9c5d48f5029f395a97dc9ebf87fc0f2a9d8b",
+                "sha256:c3efe0185583443e04f8519818f4772d92fbbdf5f9fa23165f2f2482b20efc37",
+                "sha256:d40277e918da575d008e2955a0ca6600f870bdb3570b07ee3a754ea9301862e7",
+                "sha256:d4b6ec6951e20ea3f5d1fefe35b4bcbf692d4306f1b932c28dd2ee4cb167152c",
+                "sha256:d5837e813ad62c856bc80f988c4e24e0d2b7b22a8a1dad8c1cfcb8ff4d4750a8",
+                "sha256:d9583ae0e152c5fb0142cb55c3a11e1b13006c00d0c3e8b35ccc2d4ebfc6645e",
+                "sha256:e27380cbe4088a1df514e75aa4fe6dc9e98bbd7902cf28ab16e8b2de0f8cb344",
+                "sha256:e624daef32f8808296312e72190c7e576852cb75c27935b31c1bbbde14ab353c",
+                "sha256:ef4278e5ac1e47c731ec5e3e48351721e01d2eb4fefa9b97fcdba7495a82cfad"
             ],
             "index": "pypi",
-            "version": "==5.0a1"
+            "version": "==5.0a2"
         },
         "docutils": {
             "hashes": [
@@ -266,12 +266,12 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:57613e2ec5cce4e2f35093ccf8c384f2b1ca08c3ea4e4a18d827f4250f713c79",
-                "sha256:86192514059e32797a9439ae60e8b12968647dac43d096d9742ed06711e3cc06",
-                "sha256:d6108212edaa0c95d0f941b247580535fdf1abedbcf197fcea09aedc3b291b72"
+                "sha256:0b69b5733e17d42aa52cb53fbbf184241e42d6dbb17601a95a193ac6cc400ecb",
+                "sha256:5ee18595c50e8ad983f6f871c9c06eae514b4415649da9a097dd5bd7a2f9dfda",
+                "sha256:7a1f395dcc92b1ea955f8e73e7be0f9fcf674c76979f3f1f8b281946b9842bb8"
             ],
             "index": "pypi",
-            "version": "==3.68.1"
+            "version": "==3.74.2"
         },
         "idna": {
             "hashes": [
@@ -282,10 +282,11 @@
         },
         "imagesize": {
             "hashes": [
-                "sha256:3620cc0cadba3f7475f9940d22431fc4d407269f1be59ec9b8edcca26440cf18",
-                "sha256:5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315"
+                "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
+                "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"
             ],
-            "version": "==1.0.0"
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "version": "==1.1.0"
         },
         "jinja2": {
             "hashes": [
@@ -333,26 +334,25 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:673ea75fb750289b7d1da1331c125dc62fc1c3a8db9129bb372ae7b7d5bf300a",
-                "sha256:c770605a579fdd4a014e9f0a34b6c7a36ce69b08100ff728e96e27445cef3b3c"
+                "sha256:00b95bfdc0d5b9aa53c906e56fb91937743f2121d66684db5f947ec5d75f565d",
+                "sha256:6704586b4c2bf7dfa5e87a422be9ca57db622bab65008245759f3d4baeb219dd"
             ],
             "index": "pypi",
-            "version": "==0.620"
+            "version": "==0.630"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812",
+                "sha256:b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"
+            ],
+            "version": "==0.4.1"
         },
         "packaging": {
             "hashes": [
-                "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
-                "sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b"
+                "sha256:0886227f54515e592aaa2e5a553332c73962917f2831f1b0f9b9f4380a4b9807",
+                "sha256:f95a1e147590f204328170981833854229bb2912ac3d5f89e2a8ccd2834800c9"
             ],
-            "version": "==17.1"
-        },
-        "pathlib2": {
-            "hashes": [
-                "sha256:8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83",
-                "sha256:d1aa2a11ba7b8f7b21ab852b1fb5afb277e1bb99d5dfc663380b5015c0d80c5a"
-            ],
-            "markers": "python_version < '3.6'",
-            "version": "==2.3.2"
+            "version": "==18.0"
         },
         "pathtools": {
             "hashes": [
@@ -362,17 +362,17 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:1b8be50d938c9bb75d0eaf7eda111eec1bf6dc88a62a6412e33bf077457e0f45",
-                "sha256:b486975c0cafb6beeb50ca0e17ba047647f229087bd74e37f4a7e2cac17d2caa"
+                "sha256:1be135151a0da949af8c5d0ee9013d9eafada71237eb80b3ba8896b4f12ec5dc",
+                "sha256:cf36765bf2218654ae824ec8e14257259ba44e43b117fd573c8d07a9895adbdd"
             ],
-            "version": "==4.2.0"
+            "version": "==4.3.0"
         },
         "pluggy": {
             "hashes": [
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==0.7.1"
         },
         "port-for": {
@@ -383,11 +383,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+                "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
+                "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
-            "version": "==1.5.4"
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "version": "==1.6.0"
         },
         "py-cpuinfo": {
             "hashes": [
@@ -418,18 +418,19 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04",
-                "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010"
+                "sha256:bc6c7146b91af3f567cf6daeaec360bc07d45ffec4cf5353f4d7a208ce7ca30a",
+                "sha256:d29593d8ebe7b57d6967b62494f8c72b03ac0262b1eed63826c6f788b3606401"
             ],
-            "version": "==2.2.0"
+            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.2.*'",
+            "version": "==2.2.2"
         },
         "pytest": {
             "hashes": [
-                "sha256:3459a123ad5532852d36f6f4501dfe1acf4af1dd9541834a164666aa40395b02",
-                "sha256:96bfd45dbe863b447a3054145cd78a9d7f31475d2bce6111b133c0cc4f305118"
+                "sha256:7e258ee50338f4e46957f9e09a0f10fb1c2d05493fa901d113a8dafd0790de4e",
+                "sha256:9332147e9af2dcf46cd7ceb14d5acadb6564744ddff1fe8c17f0ce60ece7d9a2"
             ],
             "index": "pypi",
-            "version": "==3.7.2"
+            "version": "==3.8.2"
         },
         "pytest-benchmark": {
             "hashes": [
@@ -442,11 +443,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
-                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
+                "sha256:513c425e931a0344944f84ea47f3956be0e416d95acbd897a44970c8d926d5d7",
+                "sha256:e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762"
             ],
             "index": "pypi",
-            "version": "==2.5.1"
+            "version": "==2.6.0"
         },
         "pytest-mock": {
             "hashes": [
@@ -486,6 +487,7 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version < '4' and python_version >= '2.6' and python_version != '3.1.*'",
             "version": "==2.19.1"
         },
         "retype": {
@@ -511,11 +513,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:217ad9ece2156ed9f8af12b5d2c82a499ddf2c70a33c5f81864a08d8c67b9efc",
-                "sha256:a765c6db1e5b62aae857697cd4402a5c1a315a7b0854bbcd0fc8cdc524da5896"
+                "sha256:652eb8c566f18823a022bb4b6dbc868d366df332a11a0226b5bc3a798a479f17",
+                "sha256:d222626d8356de702431e813a05c68a35967e3d66c6cd1c2c89539bb179a7464"
             ],
             "index": "pypi",
-            "version": "==1.7.6"
+            "version": "==1.8.1"
         },
         "sphinx-autobuild": {
             "hashes": [
@@ -530,21 +532,21 @@
                 "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
                 "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==1.1.0"
         },
         "tornado": {
             "hashes": [
-                "sha256:1c0816fc32b7d31b98781bd8ebc7a9726d7dce67407dc353a2e66e697e138448",
-                "sha256:4f66a2172cb947387193ca4c2c3e19131f1c70fa8be470ddbbd9317fd0801582",
-                "sha256:5327ba1a6c694e0149e7d9126426b3704b1d9d520852a3e4aa9fc8fe989e4046",
-                "sha256:6a7e8657618268bb007646b9eae7661d0b57f13efc94faa33cd2588eae5912c9",
-                "sha256:a9b14804783a1d77c0bd6c66f7a9b1196cbddfbdf8bceb64683c5ae60bd1ec6f",
-                "sha256:c58757e37c4a3172949c99099d4d5106e4d7b63aa0617f9bb24bfbff712c7866",
-                "sha256:d8984742ce86c0855cccecd5c6f54a9f7532c983947cff06f3a0e2115b47f85c"
+                "sha256:0662d28b1ca9f67108c7e3b77afabfb9c7e87bde174fbda78186ecedc2499a9d",
+                "sha256:4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409",
+                "sha256:732e836008c708de2e89a31cb2fa6c0e5a70cb60492bee6f1ea1047500feaf7f",
+                "sha256:8154ec22c450df4e06b35f131adc4f2f3a12ec85981a203301d310abf580500f",
+                "sha256:8e9d728c4579682e837c92fdd98036bd5cdefa1da2aaf6acf26947e6dd0c01c5",
+                "sha256:d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb",
+                "sha256:e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*'",
-            "version": "==5.1"
+            "markers": "python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*'",
+            "version": "==5.1.1"
         },
         "typed-ast": {
             "hashes": [
@@ -579,14 +581,14 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.6'",
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version < '4' and python_version >= '2.6' and python_version != '3.1.*'",
             "version": "==1.23"
         },
         "watchdog": {
             "hashes": [
-                "sha256:7e65882adb7746039b6f3876ee174952f8eaaa34491ba34333ddf1fe35de4162"
+                "sha256:965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
             ],
-            "version": "==0.8.3"
+            "version": "==0.9.0"
         }
     }
 }

--- a/README.rst
+++ b/README.rst
@@ -54,17 +54,17 @@ Usage
                             decrypting_key=alices_private_key)
 
 
-**Split Re-Encryption Keys**
+**Re-Encryption Key Fragments**
 
 .. code-block:: python
 
-    # Alice generates "M of N" split re-encryption keys for Bob. 
+    # Alice generates "M of N" re-encryption key fragments (or "KFrags") for Bob.
     # In this example, 10 out of 20.
-    kfrags = pre.split_rekey(delegating_privkey=alices_private_key,
-                             signer=alices_signer,
-                             receiving_pubkey=bobs_public_key,
-                             threshold=10,
-                             N=20)
+    kfrags = pre.generate_kfrags(delegating_privkey=alices_private_key,
+                                 signer=alices_signer,
+                                 receiving_pubkey=bobs_public_key,
+                                 threshold=10,
+                                 N=20)
 
 
 **Re-Encryption**

--- a/docs/examples/umbral_simple_api.py
+++ b/docs/examples/umbral_simple_api.py
@@ -17,14 +17,14 @@ You should have received a copy of the GNU General Public License
 along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 """
 
-# 1
+#1
 # Sets a default curve (secp256k1)
 import random
 from umbral import pre, keys, config, signing
 
 config.set_default_curve()
 
-# 2
+#2
 # Generate an Umbral key pair
 # ---------------------------
 # First, Let's generate two asymmetric key pairs for Alice:
@@ -37,7 +37,7 @@ alices_signing_key = keys.UmbralPrivateKey.gen_key()
 alices_verifying_key = alices_signing_key.get_pubkey()
 alices_signer = signing.Signer(private_key=alices_signing_key)
 
-# 3
+#3
 # Encrypt some data for Alice
 # ---------------------------
 # Now let's encrypt data with Alice's public key.
@@ -49,7 +49,7 @@ plaintext = b'Proxy Re-encryption is cool!'
 ciphertext, capsule = pre.encrypt(alices_public_key, plaintext)
 print(ciphertext)
 
-# 4
+#4
 # Decrypt data for Alice
 # ----------------------
 # Since data was encrypted with Alice's public key,
@@ -60,18 +60,18 @@ cleartext = pre.decrypt(ciphertext=ciphertext,
                         decrypting_key=alices_private_key)
 print(cleartext)
 
-# 5
+#5
 # Bob Exists
 # -----------
 
 bobs_private_key = keys.UmbralPrivateKey.gen_key()
 bobs_public_key = bobs_private_key.get_pubkey()
 
-# 6
+#6
 # Bob receives a capsule through a side channel (s3, ipfs, Google cloud, etc)
 bob_capsule = capsule
 
-# 7
+#7
 # Attempt Bob's decryption (fail)
 try:
     fail_decrypted_data = pre.decrypt(ciphertext=ciphertext,
@@ -80,7 +80,7 @@ try:
 except:
     print("Decryption failed! Bob doesn't has access granted yet.")
 
-# 8
+#8
 # Alice grants access to Bob by generating kfrags 
 # -----------------------------------------------
 # When Alice wants to grant Bob access to open her encrypted messages, 
@@ -95,7 +95,7 @@ kfrags = pre.generate_kfrags(delegating_privkey=alices_private_key,
                              threshold=10,
                              N=20)
 
-# 9
+#9
 # Ursulas perform re-encryption
 # ------------------------------
 # Bob asks several Ursulas to re-encrypt the capsule so he can open it. 
@@ -123,7 +123,7 @@ for kfrag in kfrags:
 
 assert len(cfrags) == 10
 
-# 10
+#10
 # Bob attaches cfrags to the capsule
 # ----------------------------------
 # Bob attaches at least `threshold` `cfrags` to the capsule;
@@ -132,7 +132,7 @@ assert len(cfrags) == 10
 for cfrag in cfrags:
     bob_capsule.attach_cfrag(cfrag)
 
-# 11
+#11
 # Bob activates and opens the capsule
 # ------------------------------------
 # Finally, Bob activates and opens the capsule,

--- a/docs/examples/umbral_simple_api.py
+++ b/docs/examples/umbral_simple_api.py
@@ -90,11 +90,11 @@ except:
 # She uses her private key, and Bob's public key, and she sets a minimum 
 # threshold of 10, for 20 total shares
 
-kfrags = pre.split_rekey(delegating_privkey=alices_private_key,
-                         signer=alices_signer,
-                         receiving_pubkey=bobs_public_key,
-                         threshold=10,
-                         N=20)
+kfrags = pre.generate_kfrags(delegating_privkey=alices_private_key,
+                             signer=alices_signer,
+                             receiving_pubkey=bobs_public_key,
+                             threshold=10,
+                             N=20)
 
 
 #9

--- a/docs/examples/umbral_simple_api.py
+++ b/docs/examples/umbral_simple_api.py
@@ -17,14 +17,14 @@ You should have received a copy of the GNU General Public License
 along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 """
 
-#1
+# 1
 # Sets a default curve (secp256k1)
 import random
 from umbral import pre, keys, config, signing
 
 config.set_default_curve()
 
-#2
+# 2
 # Generate an Umbral key pair
 # ---------------------------
 # First, Let's generate two asymmetric key pairs for Alice:
@@ -37,7 +37,7 @@ alices_signing_key = keys.UmbralPrivateKey.gen_key()
 alices_verifying_key = alices_signing_key.get_pubkey()
 alices_signer = signing.Signer(private_key=alices_signing_key)
 
-#3
+# 3
 # Encrypt some data for Alice
 # ---------------------------
 # Now let's encrypt data with Alice's public key.
@@ -49,39 +49,38 @@ plaintext = b'Proxy Re-encryption is cool!'
 ciphertext, capsule = pre.encrypt(alices_public_key, plaintext)
 print(ciphertext)
 
-#4
+# 4
 # Decrypt data for Alice
 # ----------------------
 # Since data was encrypted with Alice's public key,
 # Alice can open the capsule and decrypt the ciphertext with her private key.
 
-cleartext = pre.decrypt(ciphertext=ciphertext, 
-						capsule=capsule, 
-						decrypting_key=alices_private_key)
+cleartext = pre.decrypt(ciphertext=ciphertext,
+                        capsule=capsule,
+                        decrypting_key=alices_private_key)
 print(cleartext)
 
-
-#5
+# 5
 # Bob Exists
 # -----------
 
 bobs_private_key = keys.UmbralPrivateKey.gen_key()
 bobs_public_key = bobs_private_key.get_pubkey()
 
-#6
+# 6
 # Bob receives a capsule through a side channel (s3, ipfs, Google cloud, etc)
 bob_capsule = capsule
 
-#7
+# 7
 # Attempt Bob's decryption (fail)
 try:
-    fail_decrypted_data = pre.decrypt(ciphertext=ciphertext, 
-    								  capsule=bob_capsule, 
-    								  decrypting_key=bobs_private_key)
+    fail_decrypted_data = pre.decrypt(ciphertext=ciphertext,
+                                      capsule=bob_capsule,
+                                      decrypting_key=bobs_private_key)
 except:
     print("Decryption failed! Bob doesn't has access granted yet.")
 
-#8
+# 8
 # Alice grants access to Bob by generating kfrags 
 # -----------------------------------------------
 # When Alice wants to grant Bob access to open her encrypted messages, 
@@ -96,8 +95,7 @@ kfrags = pre.generate_kfrags(delegating_privkey=alices_private_key,
                              threshold=10,
                              N=20)
 
-
-#9
+# 9
 # Ursulas perform re-encryption
 # ------------------------------
 # Bob asks several Ursulas to re-encrypt the capsule so he can open it. 
@@ -107,6 +105,7 @@ kfrags = pre.generate_kfrags(delegating_privkey=alices_private_key,
 # one for each required Ursula.
 
 import random
+
 kfrags = random.sample(kfrags,  # All kfrags from above
                        10)      # M - Threshold
 
@@ -117,29 +116,27 @@ bob_capsule.set_correctness_keys(delegating=alices_public_key,
                                  receiving=bobs_public_key,
                                  verifying=alices_verifying_key)
 
-cfrags = list()                 # Bob's cfrag collection
+cfrags = list()  # Bob's cfrag collection
 for kfrag in kfrags:
-	cfrag = pre.reencrypt(kfrag=kfrag, capsule=bob_capsule)
-	cfrags.append(cfrag)        # Bob collects a cfrag
+    cfrag = pre.reencrypt(kfrag=kfrag, capsule=bob_capsule)
+    cfrags.append(cfrag)  # Bob collects a cfrag
 
 assert len(cfrags) == 10
 
-
-#10
+# 10
 # Bob attaches cfrags to the capsule
 # ----------------------------------
 # Bob attaches at least `threshold` `cfrags` to the capsule;
 # then it can become *activated*.
 
 for cfrag in cfrags:
-	bob_capsule.attach_cfrag(cfrag)
+    bob_capsule.attach_cfrag(cfrag)
 
-#11
+# 11
 # Bob activates and opens the capsule
 # ------------------------------------
 # Finally, Bob activates and opens the capsule,
 # then decrypts the re-encrypted ciphertext.
-
 
 bob_cleartext = pre.decrypt(ciphertext=ciphertext, capsule=bob_capsule, decrypting_key=bobs_private_key)
 print(bob_cleartext)

--- a/docs/notebooks/pyUmbral Simple API.ipynb
+++ b/docs/notebooks/pyUmbral Simple API.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "from umbral.config import set_default_curve\n",
     "\n",
-    "set_default_curve()\n"
+    "set_default_curve()"
    ]
   },
   {
@@ -70,13 +70,17 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "b'\\xf7\\xc6>/\\xe2\\xe8L@d\\x88\\x18/ITvz\\xb8\\x11\\xc7#|\\xc3F\\x0c$`\\x9aj?\\x02X\\xacz\\xbd\\x0f>(\\xa7\\xa3\\xad\\x18\\xb4\\xf4\\xc3\\xc4s\\x96ZDN$ \\x0e\\xf7\\xc9$'\n"
+      "b'#\\xebQ\\xd4\\xad\\x8ah,9\\x8f\\xc9\\x18\\x84[\\x95M\\x8e\\xb1\\x85\\xf9\\xbe\\x97\\x07\\xf3\\x80@\\x11\\xab\\x82\\xac\\xa1\\xbf\\xc0\\x00e\\xecpTq\\xef\\x94\\xd94\\x94\\x1a\\xdf\\xf0\\x04)\\xf5\\r\\xc4\\xbd/:\\x8c'\n"
      ]
     }
    ],
@@ -86,7 +90,7 @@
     "\n",
     "plaintext = b'Proxy Re-encryption is cool!'\n",
     "ciphertext, capsule = pre.encrypt(alices_public_key, plaintext)\n",
-    "print(ciphertext)\n"
+    "print(ciphertext)"
    ]
   },
   {
@@ -122,7 +126,7 @@
    "metadata": {},
    "source": [
     "## Enter Bob\n",
-    "Apart from generating his keypair, we will also assume that Bob receives a capsule through a side channel (s3, ipfs, Google cloud, etc). "
+    "Apart from generating his keypair, we will also assume that Bob receives a capsule through a side channel (s3, ipfs, Google Cloud, etc). "
    ]
   },
   {
@@ -172,15 +176,15 @@
    "source": [
     "# Proxy Re-encryption\n",
     "\n",
-    "![proxy_reencryption](https://cdn-images-1.medium.com/max/1200/0*yTKUeeuKPu-aIZdw.)"
+    "<img src=\"https://cdn-images-1.medium.com/max/1200/0*yTKUeeuKPu-aIZdw.\" alt=\"Proxy Re-Encryption\" width=\"500\"/>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Alice grants access to Bob by generating kfrags \n",
-    "When Alice wants to grant Bob access to open her encrypted messages, she creates *threshold split re-encryption keys*, or *\"kfrags\"*, which are next sent to N proxies or *Ursulas*. She uses her private key, and Bob's public key, and she sets a minimum threshold of 10, for 20 total shares\n"
+    "## Alice grants access to Bob by generating KFrags \n",
+    "When Alice wants to grant Bob access to open her encrypted messages, she creates *re-encryption key fragments*, or *\"kfrags\"*, which are next sent to N proxies or *Ursulas*. She uses her private key, and Bob's public key, and she sets a minimum threshold of 10, for 20 total shares\n"
    ]
   },
   {
@@ -190,11 +194,11 @@
    "outputs": [],
    "source": [
     "M, N = 10, 20\n",
-    "kfrags = pre.split_rekey(delegating_privkey=alices_private_key, \n",
-    "                         receiving_pubkey=bobs_public_key, \n",
-    "                         signer=alices_signer,\n",
-    "                         threshold=M, \n",
-    "                         N=N)\n"
+    "kfrags = pre.generate_kfrags(delegating_privkey=alices_private_key, \n",
+    "                             receiving_pubkey=bobs_public_key, \n",
+    "                             signer=alices_signer,\n",
+    "                             threshold=M, \n",
+    "                             N=N)\n"
    ]
   },
   {
@@ -202,7 +206,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "## Ursulas Re-encrypt; Bob attaches fragments to capsule\n",
+    "## Ursulas Re-encrypt; Bob attaches fragments to `capsule`\n",
     "Bob asks several Ursulas to re-encrypt the capsule so he can open it. Each Ursula performs re-encryption on the capsule using the `kfrag` provided by Alice, obtaining this way a \"capsule fragment\", or `cfrag`. Let's mock a network or transport layer by sampling `M` random `kfrags`, one for each required Ursula. Note that each Ursula must prepare the received capsule before re-encryption by setting the proper correctness keys. Bob collects the resulting `cfrags` from several Ursulas. He must gather at least `M` `cfrags` in order to activate the capsule.\n"
    ]
   },
@@ -233,7 +237,9 @@
    "metadata": {},
    "source": [
     "## Bob activates and opens the capsule; Decrypts data from Alice.\n",
-    "Bob attaches at least `M` `cfrags` to the capsule, which has to be prepared in advance with the necessary correctness keys; only then it can become *activated*. Finally, Bob activates and opens the capsule, then decrypts the re-encrypted ciphertext."
+    "The `capsule` can become *activated* once Bob attaches at least `M` `cfrags` to it. Note that it has to be prepared in advance with the necessary `correctness_keys` (specifically, Alice's public key, Alice's signature verification key and his own public key). \n",
+    "\n",
+    "Finally, Bob activates and opens the capsule, then decrypts the re-encrypted ciphertext."
    ]
   },
   {
@@ -287,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/docs/source/using_pyumbral.rst
+++ b/docs/source/using_pyumbral.rst
@@ -111,11 +111,11 @@ which are next sent to N proxies or *Ursulas*.
 
 .. doctest:: capsule_story
 
-    >>> kfrags = pre.split_rekey(delegating_privkey=alices_private_key,
-    ...                          signer=alices_signer,
-    ...                          receiving_pubkey=bobs_public_key,
-    ...                          threshold=10,
-    ...                          N=20)
+    >>> kfrags = pre.generate_kfrags(delegating_privkey=alices_private_key,
+    ...                              signer=alices_signer,
+    ...                              receiving_pubkey=bobs_public_key,
+    ...                              threshold=10,
+    ...                              N=20)
 
 
 Bob receives a capsule

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,3 @@ def kfrags(alices_keys, bobs_keys):
                               signer=signer_alice,
                               receiving_pubkey=receiving_pubkey,
                               threshold=6, N=10)
-
-
-
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,10 @@ other_supported_curves = (
     SECP256R1
 )
 
+kfrag_signing_modes = (
+    (True, True), (True, False), (False, True), (False, False)
+)
+
 @pytest.fixture(scope='function')
 def alices_keys():
     delegating_priv = keys.UmbralPrivateKey.gen_key()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,12 +108,14 @@ def prepared_capsule(alices_keys, bobs_keys):
 @pytest.fixture(scope='function')
 def kfrags(alices_keys, bobs_keys):
     delegating_privkey, signing_privkey = alices_keys
-    delegating_pubkey = delegating_privkey.get_pubkey()
     signer_alice = Signer(signing_privkey)
 
     receiving_privkey, receiving_pubkey = bobs_keys
 
-    yield pre.split_rekey(delegating_privkey, signer_alice, receiving_pubkey, 6, 10)
+    yield pre.generate_kfrags(delegating_privkey=delegating_privkey,
+                              signer=signer_alice,
+                              receiving_pubkey=receiving_pubkey,
+                              threshold=6, N=10)
 
 
 

--- a/tests/functional/test_correctness.py
+++ b/tests/functional/test_correctness.py
@@ -22,6 +22,7 @@ import pytest
 from umbral import pre
 from umbral.point import Point
 from umbral.signing import Signer
+from umbral.fragments import CapsuleFrag
 
 
 def test_cheating_ursula_replays_old_reencryption(alices_keys, bobs_keys,
@@ -120,7 +121,7 @@ def test_cfrag_with_missing_proof_cannot_be_attached(kfrags, prepared_capsule):
     # If the proof is lost (e.g., it is chopped off a serialized CFrag or similar), 
     #  then the CFrag cannot be attached.
     cfrags[0].proof = None
-    with pytest.raises(cfrag.NoProofProvided):
+    with pytest.raises(CapsuleFrag.NoProofProvided):
         capsule.attach_cfrag(cfrags[0])
 
     # The remaining CFrags are fine, so they can be attached correctly 

--- a/tests/functional/test_correctness.py
+++ b/tests/functional/test_correctness.py
@@ -21,15 +21,16 @@ import pytest
 
 from umbral import pre
 from umbral.point import Point
+from umbral.signing import Signer
 
-def test_cheating_ursula_replays_old_reencryption(alices_keys, bobs_keys, 
+
+def test_cheating_ursula_replays_old_reencryption(alices_keys, bobs_keys,
                                                   kfrags, prepared_capsule):
-
     delegating_privkey, signing_privkey = alices_keys
     delegating_pubkey = delegating_privkey.get_pubkey()
 
     receiving_privkey, receiving_pubkey = bobs_keys
-    
+
     capsule_alice1 = prepared_capsule
 
     _unused_key2, capsule_alice2 = pre._encapsulate(delegating_pubkey)
@@ -53,8 +54,7 @@ def test_cheating_ursula_replays_old_reencryption(alices_keys, bobs_keys,
 
         cfrags.append(cfrag)
 
-
-    # CFrag 0 is not valid ...
+    #  CFrag 0 is not valid ...
     assert not cfrags[0].verify_correctness(capsule_alice1)
 
     # ... and trying to attach it raises an error.
@@ -71,11 +71,11 @@ def test_cheating_ursula_replays_old_reencryption(alices_keys, bobs_keys,
         assert cfrag_i.verify_correctness(capsule_alice1)
         capsule_alice1.attach_cfrag(cfrag_i)
         correct_cases += 1
-        
+
     assert correct_cases == len(cfrags[1:])
 
+
 def test_cheating_ursula_sends_garbage(kfrags, prepared_capsule):
-    
     capsule_alice = prepared_capsule
 
     cfrags = []
@@ -91,7 +91,7 @@ def test_cheating_ursula_sends_garbage(kfrags, prepared_capsule):
     cfrags[0]._point_e1 = Point.gen_rand()
     cfrags[0]._point_v1 = Point.gen_rand()
 
-    # Of course, this CFrag is not valid ...
+    #  Of course, this CFrag is not valid ...
     assert not cfrags[0].verify_correctness(capsule_alice)
 
     # ... and trying to attach it raises an error.
@@ -103,14 +103,13 @@ def test_cheating_ursula_sends_garbage(kfrags, prepared_capsule):
     assert len(correctness_error.offending_cfrags) == 1
 
     # The response of cheating Ursula is in cfrags[0],
-    # so the rest of CFrags chould be correct: 
+    # so the rest of CFrags should be correct:
     for cfrag_i in cfrags[1:]:
         assert cfrag_i.verify_correctness(capsule_alice)
         capsule_alice.attach_cfrag(cfrag_i)
 
 
 def test_cfrag_with_missing_proof_cannot_be_attached(kfrags, prepared_capsule):
-
     capsule = prepared_capsule
 
     cfrags = []
@@ -119,7 +118,7 @@ def test_cfrag_with_missing_proof_cannot_be_attached(kfrags, prepared_capsule):
         cfrags.append(cfrag)
 
     # If the proof is lost (e.g., it is chopped off a serialized CFrag or similar), 
-    # then the CFrag cannot be attached.
+    #  then the CFrag cannot be attached.
     cfrags[0].proof = None
     with pytest.raises(cfrag.NoProofProvided):
         capsule.attach_cfrag(cfrags[0])
@@ -130,7 +129,6 @@ def test_cfrag_with_missing_proof_cannot_be_attached(kfrags, prepared_capsule):
 
 
 def test_inconsistent_cfrags(bobs_keys, kfrags, prepared_capsule):
-
     receiving_privkey, receiving_pubkey = bobs_keys
 
     capsule = prepared_capsule
@@ -139,20 +137,47 @@ def test_inconsistent_cfrags(bobs_keys, kfrags, prepared_capsule):
     for kfrag in kfrags:
         cfrag = pre.reencrypt(kfrag, capsule)
         cfrags.append(cfrag)
-    
-    # For all cfrags that belong to the same policy, the values 
+
+    # For all cfrags that belong to the same policy, the values
     # cfrag._point_noninteractive and cfrag._point_noninteractive
-    # must be the same. If we swap them, it shouldn't be possible 
-    # to attach the cfrag to the capsule. Let's mangle the first CFrag
+    # must be the same. If we swap them, it shouldn't be possible
+    # to attach the cfrag to the capsule. Let's mangle the first CFrag
     cfrags[0]._point_noninteractive, cfrags[0]._point_xcoord = cfrags[0]._point_xcoord, cfrags[0]._point_noninteractive
     with pytest.raises(pre.UmbralCorrectnessError):
         capsule.attach_cfrag(cfrags[0])
 
-    # The remaining M cfrags should be fine. 
-    for cfrag in cfrags[1:]:   
+    #  The remaining M cfrags should be fine.
+    for cfrag in cfrags[1:]:
         capsule.attach_cfrag(cfrag)
 
     # Just for fun, let's try to reconstruct the capsule with them:
     capsule._reconstruct_shamirs_secret(receiving_privkey)
 
-    
+
+def test_kfrags_signed_without_correctness_keys(alices_keys, bobs_keys, capsule):
+    delegating_privkey, signing_privkey = alices_keys
+    delegating_pubkey = delegating_privkey.get_pubkey()
+    verifying_key = signing_privkey.get_pubkey()
+
+    receiving_privkey, receiving_pubkey = bobs_keys
+
+    kfrags = pre.split_rekey(delegating_privkey=delegating_privkey,
+                             signer=Signer(signing_privkey),
+                             receiving_pubkey=receiving_pubkey,
+                             threshold=6,
+                             N=10,
+                             sign_delegating_key=False,
+                             sign_receiving_key=False)
+
+    for kfrag in kfrags:
+        # You can verify the KFrag specifying only the verifying key
+        assert kfrag.verify(signing_pubkey=verifying_key)
+
+        # ... or if it is set in the capsule, using the capsule
+        capsule.set_correctness_keys(verifying=verifying_key)
+        assert kfrag.verify_for_capsule(capsule)
+
+        # It should even work when other keys are set in the capsule
+        assert kfrag.verify(signing_pubkey=verifying_key,
+                            delegating_pubkey=delegating_pubkey,
+                            receiving_pubkey=receiving_pubkey)

--- a/tests/functional/test_correctness.py
+++ b/tests/functional/test_correctness.py
@@ -128,32 +128,6 @@ def test_cfrag_with_missing_proof_cannot_be_attached(kfrags, prepared_capsule):
         capsule.attach_cfrag(cfrag)
 
 
-def test_inconsistent_cfrags(bobs_keys, kfrags, prepared_capsule):
-    receiving_privkey, receiving_pubkey = bobs_keys
-
-    capsule = prepared_capsule
-
-    cfrags = []
-    for kfrag in kfrags:
-        cfrag = pre.reencrypt(kfrag, capsule)
-        cfrags.append(cfrag)
-
-    # For all cfrags that belong to the same policy, the values
-    # cfrag._point_noninteractive and cfrag._point_noninteractive
-    # must be the same. If we swap them, it shouldn't be possible
-    # to attach the cfrag to the capsule. Let's mangle the first CFrag
-    cfrags[0]._point_noninteractive, cfrags[0]._point_xcoord = cfrags[0]._point_xcoord, cfrags[0]._point_noninteractive
-    with pytest.raises(pre.UmbralCorrectnessError):
-        capsule.attach_cfrag(cfrags[0])
-
-    #  The remaining M cfrags should be fine.
-    for cfrag in cfrags[1:]:
-        capsule.attach_cfrag(cfrag)
-
-    # Just for fun, let's try to reconstruct the capsule with them:
-    capsule._reconstruct_shamirs_secret(receiving_privkey)
-
-
 def test_kfrags_signed_without_correctness_keys(alices_keys, bobs_keys, capsule):
     delegating_privkey, signing_privkey = alices_keys
     delegating_pubkey = delegating_privkey.get_pubkey()

--- a/tests/functional/test_correctness.py
+++ b/tests/functional/test_correctness.py
@@ -135,13 +135,13 @@ def test_kfrags_signed_without_correctness_keys(alices_keys, bobs_keys, capsule)
 
     receiving_privkey, receiving_pubkey = bobs_keys
 
-    kfrags = pre.split_rekey(delegating_privkey=delegating_privkey,
-                             signer=Signer(signing_privkey),
-                             receiving_pubkey=receiving_pubkey,
-                             threshold=6,
-                             N=10,
-                             sign_delegating_key=False,
-                             sign_receiving_key=False)
+    kfrags = pre.generate_kfrags(delegating_privkey=delegating_privkey,
+                                 signer=Signer(signing_privkey),
+                                 receiving_pubkey=receiving_pubkey,
+                                 threshold=6,
+                                 N=10,
+                                 sign_delegating_key=False,
+                                 sign_receiving_key=False)
 
     for kfrag in kfrags:
         # You can verify the KFrag specifying only the verifying key

--- a/tests/functional/test_correctness_keys.py
+++ b/tests/functional/test_correctness_keys.py
@@ -1,0 +1,83 @@
+"""
+Copyright (C) 2018 NuCypher
+
+This file is part of pyUmbral.
+
+pyUmbral is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+pyUmbral is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import pytest
+
+from umbral import pre
+from umbral.keys import UmbralPrivateKey
+from umbral.fragments import KFrag
+
+
+def test_set_correctness_keys(alices_keys, bobs_keys, capsule, kfrags):
+    """
+    If the three keys do appear together, along with the capsule,
+    we can attach them all at once.
+    """
+
+    delegating_privkey, signing_privkey = alices_keys
+    _receiving_privkey, receiving_pubkey = bobs_keys
+
+    capsule.set_correctness_keys(delegating_privkey.get_pubkey(),
+                                 receiving_pubkey,
+                                 signing_privkey.get_pubkey()
+                                 )
+
+    for kfrag in kfrags:
+        cfrag = pre.reencrypt(kfrag, capsule)
+        capsule.attach_cfrag(cfrag)
+
+
+def test_setting_one_correctness_keys(alices_keys, capsule):
+    # The capsule doesn't have any correctness keys set initially
+    assert capsule.get_correctness_keys()['delegating'] is None
+    assert capsule.get_correctness_keys()['receiving'] is None
+    assert capsule.get_correctness_keys()['verifying'] is None
+
+    # Let's set only one of them, e.g., the delegating key
+    delegating_privkey, _signing_privkey = alices_keys
+    delegating_pubkey = delegating_privkey.get_pubkey()
+
+    details = capsule.set_correctness_keys(delegating=delegating_pubkey)
+
+    # Since we are only setting the first key ("delegating"),
+    # the other keys are not set
+    assert details == (True, False, False)
+
+    assert capsule.get_correctness_keys()['delegating'] == delegating_pubkey
+    assert capsule.get_correctness_keys()['receiving'] is None
+    assert capsule.get_correctness_keys()['verifying'] is None
+
+
+def test_set_invalid_correctness_keys(alices_keys, capsule, kfrags):
+    """
+    If the three keys do appear together, along with the capsule,
+    we can attach them all at once.
+    """
+
+    delegating_privkey, signing_privkey = alices_keys
+    unrelated_receiving_pubkey = UmbralPrivateKey.gen_key().get_pubkey()
+
+    capsule.set_correctness_keys(delegating_privkey.get_pubkey(),
+                                 unrelated_receiving_pubkey,
+                                 signing_privkey.get_pubkey()
+                                 )
+
+    for kfrag in kfrags:
+        with pytest.raises(KFrag.NotValid):
+            cfrag = pre.reencrypt(kfrag, capsule)

--- a/tests/functional/test_pre_api.py
+++ b/tests/functional/test_pre_api.py
@@ -37,5 +37,9 @@ def test_wrong_N_M_in_split_rekey(N, M, alices_keys, bobs_keys):
     _receiving_privkey, receiving_pubkey = bobs_keys
 
     with pytest.raises(ValueError):
-        _kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, M, N)
+        _kfrags = pre.generate_kfrags(delegating_privkey=delegating_privkey,
+                                      signer=signer,
+                                      receiving_pubkey=receiving_pubkey,
+                                      threshold=M,
+                                      N=N)
 

--- a/tests/functional/test_vectors.py
+++ b/tests/functional/test_vectors.py
@@ -27,6 +27,10 @@ from umbral.config import default_params
 from umbral.fragments import KFrag, CapsuleFrag
 from umbral import pre
 
+import pytest
+
+pytestmark = pytest.mark.xfail(reason="Test vectors are outdated")
+
 def test_curvebn_operations():
 
     vector_file = os.path.join('vectors', 'vectors_curvebn_operations.json')

--- a/tests/functional/test_vectors.py
+++ b/tests/functional/test_vectors.py
@@ -19,7 +19,6 @@ along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 
 import json
 import os
-from os.path import dirname, abspath
 
 from umbral.curvebn import CurveBN
 from umbral.point import Point, unsafe_hash_to_point

--- a/tests/functional/test_vectors.py
+++ b/tests/functional/test_vectors.py
@@ -188,7 +188,7 @@ def test_cfrags():
         assert new_cfrag._point_e1 == cfrag._point_e1
         assert new_cfrag._point_v1 == cfrag._point_v1
         assert new_cfrag._kfrag_id == cfrag._kfrag_id
-        assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
+        assert new_cfrag._point_precursor == cfrag._point_precursor
         assert new_cfrag._point_xcoord == cfrag._point_xcoord
         assert new_cfrag.proof is None
         assert cfrag.to_bytes() == new_cfrag.to_bytes()

--- a/tests/metrics/reencryption_benchmark.py
+++ b/tests/metrics/reencryption_benchmark.py
@@ -93,7 +93,7 @@ def test_split_rekey_performance(benchmark, m: int, n: int) -> None:
         return args, kwargs
 
     print("\nBenchmarking {function} with M:{M} of N:{N}...".format(function="pre.split_rekey", M=m, N=n))
-    benchmark.pedantic(pre.split_rekey, setup=__setup, rounds=1000)
+    benchmark.pedantic(pre.generate_kfrags, setup=__setup, rounds=1000)
     assert True  # ensure function finishes and succeeds.
 
 
@@ -111,7 +111,7 @@ def test_random_frag_reencryption_performance(benchmark, m: int, n: int) -> None
 
     def __setup():
         delegating_privkey, signer, receiving_pubkey, ciphertext, capsule = __standard_encryption_api()
-        kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, m, n)
+        kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_pubkey, m, n)
         one_kfrag, *remaining_kfrags = kfrags
         args, kwargs = tuple(), {"kfrag": one_kfrag, "capsule": capsule},
         return args, kwargs
@@ -133,7 +133,7 @@ def test_random_frag_reencryption_performance(benchmark, m: int, n: int) -> None
 def test_single_frag_reencryption_performance(benchmark, m: int, n: int) -> None:
 
     delegating_privkey, signer, receiving_pubkey, ciphertext, capsule = __standard_encryption_api()
-    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, m, n)
+    kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_pubkey, m, n)
     one_kfrag, *remaining_kfrags = kfrags
     args, kwargs = tuple(), {"kfrag": one_kfrag, "capsule": capsule},
 

--- a/tests/metrics/reencryption_benchmark.py
+++ b/tests/metrics/reencryption_benchmark.py
@@ -75,24 +75,24 @@ def __standard_encryption_api() -> tuple:
 
 
 #
-# Key Splitting Benchmarks
+# KFrag Generation Benchmarks
 #
 
 
-@pytest.mark.benchmark(group="Reencryption Key Splitting Performance",
+@pytest.mark.benchmark(group="Reencryption Key Generation Performance",
                        disable_gc=True,
                        warmup=True,
                        warmup_iterations=10)
 @pytest.mark.parametrize("m, n", FRAG_VALUES)
-def test_split_rekey_performance(benchmark, m: int, n: int) -> None:
+def test_generate_kfrags_performance(benchmark, m: int, n: int) -> None:
 
     def __setup():
         delegating_privkey, signer, receiving_pubkey, ciphertext, capsule = __standard_encryption_api()
-        args = (delegating_privkey, signer, receiving_pubkey)
-        kwargs = {"threshold": m, "N": n}
+        args = (delegating_privkey, receiving_pubkey)
+        kwargs = {"threshold": m, "N": n, "signer": signer}
         return args, kwargs
 
-    print("\nBenchmarking {function} with M:{M} of N:{N}...".format(function="pre.split_rekey", M=m, N=n))
+    print("\nBenchmarking {function} with M:{M} of N:{N}...".format(function="pre.generate_kfrags", M=m, N=n))
     benchmark.pedantic(pre.generate_kfrags, setup=__setup, rounds=1000)
     assert True  # ensure function finishes and succeeds.
 
@@ -111,7 +111,7 @@ def test_random_frag_reencryption_performance(benchmark, m: int, n: int) -> None
 
     def __setup():
         delegating_privkey, signer, receiving_pubkey, ciphertext, capsule = __standard_encryption_api()
-        kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_pubkey, m, n)
+        kfrags = pre.generate_kfrags(delegating_privkey, receiving_pubkey, m, n, signer)
         one_kfrag, *remaining_kfrags = kfrags
         args, kwargs = tuple(), {"kfrag": one_kfrag, "capsule": capsule},
         return args, kwargs
@@ -133,7 +133,7 @@ def test_random_frag_reencryption_performance(benchmark, m: int, n: int) -> None
 def test_single_frag_reencryption_performance(benchmark, m: int, n: int) -> None:
 
     delegating_privkey, signer, receiving_pubkey, ciphertext, capsule = __standard_encryption_api()
-    kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_pubkey, m, n)
+    kfrags = pre.generate_kfrags(delegating_privkey, receiving_pubkey, m, n, signer)
     one_kfrag, *remaining_kfrags = kfrags
     args, kwargs = tuple(), {"kfrag": one_kfrag, "capsule": capsule},
 

--- a/tests/metrics/reencryption_firehose.py
+++ b/tests/metrics/reencryption_firehose.py
@@ -49,7 +49,7 @@ def __produce_kfrags_and_capsule(m: int, n: int) -> Tuple[List[KFrag], Capsule]:
     plain_data = os.urandom(32)
     ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data)
 
-    kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_pubkey, m, n)
+    kfrags = pre.generate_kfrags(delegating_privkey, receiving_pubkey, m, n, signer)
 
     capsule.set_correctness_keys(delegating=delegating_pubkey,
                                  receiving=receiving_pubkey,
@@ -65,18 +65,18 @@ def firehose(m: int=6, n: int=10) -> None:
     one_kfrag, *remaining_kfrags = kfrags
 
     print('Re-encrypting...')
-    successful_rencryptions = 0
+    successful_reencryptions = 0
     for iteration in range(int(REENCRYPTIONS)):
 
         _cfrag = pre.reencrypt(one_kfrag, capsule)    # <<< REENCRYPTION HAPPENS HERE
 
-        successful_rencryptions += 1
+        successful_reencryptions += 1
         if iteration % 20 == 0:
             print('Performed {} Re-encryptions...'.format(iteration))
 
-    failure_message = "A Reencryption failed. {} of {} succeeded".format(successful_rencryptions, REENCRYPTIONS)
-    assert successful_rencryptions == REENCRYPTIONS, failure_message
-    print("Successfully performed {} reencryptions".format(successful_rencryptions), end='\n')
+    failure_message = "A Reencryption failed. {} of {} succeeded".format(successful_reencryptions, REENCRYPTIONS)
+    assert successful_reencryptions == REENCRYPTIONS, failure_message
+    print("Successfully performed {} reencryptions".format(successful_reencryptions), end='\n')
 
 
 if __name__ == "__main__":

--- a/tests/metrics/reencryption_firehose.py
+++ b/tests/metrics/reencryption_firehose.py
@@ -49,7 +49,7 @@ def __produce_kfrags_and_capsule(m: int, n: int) -> Tuple[List[KFrag], Capsule]:
     plain_data = os.urandom(32)
     ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data)
 
-    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, m, n)
+    kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_pubkey, m, n)
 
     capsule.set_correctness_keys(delegating=delegating_pubkey,
                                  receiving=receiving_pubkey,

--- a/tests/scenario/test_lifecycle_multidomain.py
+++ b/tests/scenario/test_lifecycle_multidomain.py
@@ -25,11 +25,12 @@ from umbral.config import default_curve
 from umbral.params import UmbralParameters
 from umbral.signing import Signer
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
-from ..conftest import parameters, wrong_parameters, other_supported_curves
+from ..conftest import parameters, other_supported_curves, kfrag_signing_modes
 
 
 @pytest.mark.parametrize("N, M", parameters)
-def test_lifecycle_with_serialization(N, M, curve=default_curve()):
+@pytest.mark.parametrize("signing_mode", kfrag_signing_modes)
+def test_lifecycle_with_serialization(N, M, signing_mode, curve=default_curve()):
     """
     This test is a variant of test_simple_api, but with intermediate 
     serialization/deserialization steps, modeling how pyUmbral artifacts 
@@ -62,7 +63,17 @@ def test_lifecycle_with_serialization(N, M, curve=default_curve()):
     receiving_pubkey = UmbralPublicKey.from_bytes(receiving_pubkey_bytes, params)
 
     signer = Signer(signing_privkey)
-    kfrags = pre.generate_kfrags(delegating_privkey, receiving_pubkey, M, N, signer)
+
+    sign_delegating_key, sign_receiving_key = signing_mode
+
+    kfrags = pre.generate_kfrags(delegating_privkey=delegating_privkey,
+                                 receiving_pubkey=receiving_pubkey,
+                                 threshold=M,
+                                 N=N,
+                                 signer=signer,
+                                 sign_delegating_key=sign_delegating_key,
+                                 sign_receiving_key=sign_receiving_key)
+
     kfrags_bytes = tuple(map(bytes, kfrags))
 
     del kfrags
@@ -152,5 +163,6 @@ def test_lifecycle_with_serialization(N, M, curve=default_curve()):
 
 @pytest.mark.parametrize("curve", other_supported_curves)
 @pytest.mark.parametrize("N, M", parameters)
-def test_lifecycle_with_serialization_on_multiple_curves(N, M, curve):
-    test_lifecycle_with_serialization(N, M, curve)
+@pytest.mark.parametrize("signing_mode", kfrag_signing_modes)
+def test_lifecycle_with_serialization_on_multiple_curves(N, M, signing_mode, curve):
+    test_lifecycle_with_serialization(N, M, signing_mode, curve)

--- a/tests/scenario/test_lifecycle_multidomain.py
+++ b/tests/scenario/test_lifecycle_multidomain.py
@@ -64,7 +64,7 @@ def test_lifecycle_with_serialization(N, M, curve=default_curve()):
     receiving_pubkey = UmbralPublicKey.from_bytes(receiving_pubkey_bytes, params)
 
     signer = Signer(signing_privkey)
-    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, M, N)
+    kfrags = pre.generate_kfrags(delegating_privkey, receiving_pubkey, M, N, signer)
     kfrags_bytes = tuple(map(bytes, kfrags))
 
     del kfrags

--- a/tests/scenario/test_lifecycle_multidomain.py
+++ b/tests/scenario/test_lifecycle_multidomain.py
@@ -118,7 +118,7 @@ def test_lifecycle_with_serialization(N, M, curve=default_curve()):
         # TODO: use params instead of curve?
         kfrag = KFrag.from_bytes(kfrag_bytes, params.curve)
 
-        assert kfrag.verify(signing_pubkey, delegating_pubkey, receiving_pubkey)
+        assert kfrag.verify(signing_pubkey, delegating_pubkey, receiving_pubkey, params)
 
         cfrag_bytes = bytes(pre.reencrypt(kfrag, capsule))
         cfrags_bytes.append(cfrag_bytes)

--- a/tests/scenario/test_lifecycle_multidomain.py
+++ b/tests/scenario/test_lifecycle_multidomain.py
@@ -18,8 +18,6 @@ along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import pytest
-from cryptography.exceptions import InvalidTag
-from cryptography.hazmat.primitives.asymmetric import ec
 
 from umbral import pre
 from umbral.fragments import KFrag, CapsuleFrag

--- a/tests/scenario/test_simple_api.py
+++ b/tests/scenario/test_simple_api.py
@@ -64,7 +64,7 @@ def test_simple_api(N, M, curve=default_curve()):
     assert cleartext == plain_data
 
     # Split Re-Encryption Key Generation (aka Delegation)
-    kfrags = pre.split_rekey(delegating_privkey, signer, receiving_pubkey, M, N)
+    kfrags = pre.generate_kfrags(delegating_privkey, receiving_pubkey, M, N, signer)
 
 
     # Capsule preparation (necessary before re-encryotion and activation)

--- a/tests/scenario/test_simple_api.py
+++ b/tests/scenario/test_simple_api.py
@@ -97,4 +97,4 @@ def test_simple_api(N, M, curve=default_curve()):
 @pytest.mark.parametrize("N, M", parameters)
 def test_simple_api_on_multiple_curves(N, M, curve):
     test_simple_api(N, M, curve)
-    
+

--- a/tests/scenario/test_simple_api.py
+++ b/tests/scenario/test_simple_api.py
@@ -76,7 +76,7 @@ def test_simple_api(N, M, curve=default_curve()):
     cfrags = list()
     for kfrag in kfrags[:M]:
         # Ursula checks that the received kfrag is valid
-        assert kfrag.verify(signing_pubkey, delegating_pubkey, receiving_pubkey)
+        assert kfrag.verify(signing_pubkey, delegating_pubkey, receiving_pubkey, params)
 
         # Re-encryption by an Ursula
         cfrag = pre.reencrypt(kfrag, capsule)

--- a/tests/unit/test_capsule_correctness_checks.py
+++ b/tests/unit/test_capsule_correctness_checks.py
@@ -44,8 +44,7 @@ def test_cannot_attach_cfrag_without_keys():
     cfrag = CapsuleFrag(point_e1=Point.gen_rand(),
                         point_v1=Point.gen_rand(),
                         kfrag_id=os.urandom(10),
-                        point_noninteractive=Point.gen_rand(),
-                        point_xcoord=Point.gen_rand(),
+                        point_precursor=Point.gen_rand(),
                         )
 
     with pytest.raises(TypeError):
@@ -67,8 +66,7 @@ def test_cannot_attach_cfrag_without_proof():
     cfrag = CapsuleFrag(point_e1=Point.gen_rand(),
                         point_v1=Point.gen_rand(),
                         kfrag_id=os.urandom(10),
-                        point_noninteractive=Point.gen_rand(),
-                        point_xcoord=Point.gen_rand(),
+                        point_precursor=Point.gen_rand(),
                         )
     key_details = capsule.set_correctness_keys(
         UmbralPrivateKey.gen_key().get_pubkey(),

--- a/tests/unit/test_capsule_correctness_checks.py
+++ b/tests/unit/test_capsule_correctness_checks.py
@@ -21,9 +21,8 @@ import os
 
 import pytest
 
-from umbral import pre
 from umbral.curvebn import CurveBN
-from umbral.fragments import CapsuleFrag, KFrag
+from umbral.fragments import CapsuleFrag
 from umbral.keys import UmbralPrivateKey
 from umbral.point import Point
 from umbral.pre import Capsule
@@ -51,43 +50,6 @@ def test_cannot_attach_cfrag_without_keys():
 
     with pytest.raises(TypeError):
         capsule.attach_cfrag(cfrag)
-
-
-def test_set_correctness_keys(alices_keys, bobs_keys, capsule, kfrags):
-    """
-    If the three keys do appear together, along with the capsule,
-    we can attach them all at once.
-    """
-
-    delegating_privkey, signing_privkey = alices_keys
-    _receiving_privkey, receiving_pubkey = bobs_keys
-
-    capsule.set_correctness_keys(delegating_privkey.get_pubkey(),
-                                 receiving_pubkey,
-                                 signing_privkey.get_pubkey()
-                                )
-
-    for kfrag in kfrags:
-        cfrag = pre.reencrypt(kfrag, capsule)
-        capsule.attach_cfrag(cfrag)
-
-def test_set_invalid_correctness_keys(alices_keys, capsule, kfrags):
-    """
-    If the three keys do appear together, along with the capsule,
-    we can attach them all at once.
-    """
-
-    delegating_privkey, signing_privkey = alices_keys
-    unrelated_receiving_pubkey = UmbralPrivateKey.gen_key().get_pubkey()
-
-    capsule.set_correctness_keys(delegating_privkey.get_pubkey(),
-                                 unrelated_receiving_pubkey,
-                                 signing_privkey.get_pubkey()
-                                )
-
-    for kfrag in kfrags:
-        with pytest.raises(KFrag.NotValid):
-            cfrag = pre.reencrypt(kfrag, capsule)
 
 
 def test_cannot_attach_cfrag_without_proof():

--- a/tests/unit/test_capsule_operations.py
+++ b/tests/unit/test_capsule_operations.py
@@ -71,7 +71,7 @@ def test_capsule_equality():
     activated_capsule = Capsule(params,
                                 point_e_prime=Point.gen_rand(),
                                 point_v_prime=Point.gen_rand(),
-                                point_noninteractive=Point.gen_rand())
+                                point_precursor=Point.gen_rand())
 
     assert activated_capsule != one_capsule
 

--- a/tests/unit/test_capsule_operations.py
+++ b/tests/unit/test_capsule_operations.py
@@ -68,13 +68,6 @@ def test_capsule_equality():
 
     assert one_capsule != another_capsule
 
-    activated_capsule = Capsule(params,
-                                point_e_prime=Point.gen_rand(),
-                                point_v_prime=Point.gen_rand(),
-                                point_precursor=Point.gen_rand())
-
-    assert activated_capsule != one_capsule
-
 
 def test_decapsulation_by_alice(alices_keys):
     params = default_params()
@@ -113,25 +106,9 @@ def test_capsule_as_dict_key(alices_keys, bobs_keys):
     plain_data = b'peace at dawn'
     ciphertext, capsule = pre.encrypt(delegating_pubkey, plain_data)
 
-    capsule.set_correctness_keys(delegating=delegating_pubkey,
-                                 receiving=receiving_pubkey,
-                                 verifying=signing_pubkey)
-
     # We can use the capsule as a key, and successfully lookup using it.
     some_dict = {capsule: "Thing that Bob wants to try per-Capsule"}
     assert some_dict[capsule] == "Thing that Bob wants to try per-Capsule"
-
-    kfrags = pre.split_rekey(delegating_privkey, signer_alice, receiving_pubkey , 1, 2)
-    cfrag = pre.reencrypt(kfrags[0], capsule)
-    capsule.attach_cfrag(cfrag)
-
-    cfrag = pre.reencrypt(kfrags[1], capsule)
-    capsule.attach_cfrag(cfrag)
-
-    # Even if we activate the capsule, it still serves as the same key.
-    cleartext = pre.decrypt(ciphertext, capsule, receiving_privkey)
-    assert some_dict[capsule] == "Thing that Bob wants to try per-Capsule"
-    assert cleartext == plain_data
 
     # And if we change the value for this key, all is still well.
     some_dict[capsule] = "Bob has changed his mind."

--- a/tests/unit/test_capsule_serializers.py
+++ b/tests/unit/test_capsule_serializers.py
@@ -25,7 +25,7 @@ from umbral.point import Point
 
 
 def test_capsule_serialization(capsule):
-    params = capsule._umbral_params
+    params = capsule.params
     capsule_bytes = capsule.to_bytes()
     capsule_bytes_casted = bytes(capsule)
     assert capsule_bytes == capsule_bytes_casted
@@ -40,40 +40,15 @@ def test_capsule_serialization(capsule):
     assert new_capsule == capsule
 
     # Second, we show that the original components (which is all we have here since we haven't activated) are the same:
-    assert new_capsule.original_components() == capsule.original_components()
+    assert new_capsule.components() == capsule.components()
+
 
     # Third, we can directly compare the private original component attributes
     # (though this is not a supported approach):
+    # TODO: revisit if/when these attributes are made public
     assert new_capsule._point_e == capsule._point_e
     assert new_capsule._point_v == capsule._point_v
     assert new_capsule._bn_sig == capsule._bn_sig
-
-
-def test_activated_capsule_serialization(prepared_capsule, kfrags, bobs_keys):
-    capsule = prepared_capsule
-    params = capsule._umbral_params
-    receiving_privkey, _receiving_pubkey = bobs_keys
-
-    for kfrag in kfrags:
-        cfrag = pre.reencrypt(kfrag, capsule)
-        
-        capsule.attach_cfrag(cfrag)
-
-        capsule._reconstruct_shamirs_secret(receiving_privkey)
-        rec_capsule_bytes = capsule.to_bytes()
-
-        assert len(rec_capsule_bytes) == pre.Capsule.expected_bytes_length(activated=True)
-
-        new_rec_capsule = pre.Capsule.from_bytes(rec_capsule_bytes, params)
-
-        # Again, the same three perspectives on equality.
-        assert new_rec_capsule == capsule
-
-        assert new_rec_capsule.activated_components() == capsule.activated_components()
-
-        assert new_rec_capsule._point_e_prime == capsule._point_e_prime
-        assert new_rec_capsule._point_v_prime == capsule._point_v_prime
-        assert new_rec_capsule._point_precursor == capsule._point_precursor
 
 
 def test_cannot_create_capsule_from_bogus_material(alices_keys):
@@ -90,15 +65,3 @@ def test_cannot_create_capsule_from_bogus_material(alices_keys):
                                                         point_e=Point.gen_rand(),
                                                         point_v=Point.gen_rand(),
                                                         bn_sig=42)
-
-    with pytest.raises(TypeError):
-        capsule_of_questionable_parentage = pre.Capsule(params,
-                                                        point_e_prime=Point.gen_rand(),
-                                                        point_v_prime=42,
-                                                        point_noninteractive=Point.gen_rand())
-
-    with pytest.raises(TypeError):
-        capsule_of_questionable_parentage = pre.Capsule(params,
-                                                        point_e_prime=Point.gen_rand(),
-                                                        point_v_prime=Point.gen_rand(),
-                                                        point_noninteractive=42)

--- a/tests/unit/test_capsule_serializers.py
+++ b/tests/unit/test_capsule_serializers.py
@@ -59,7 +59,6 @@ def test_activated_capsule_serialization(prepared_capsule, kfrags, bobs_keys):
         
         capsule.attach_cfrag(cfrag)
 
-
         capsule._reconstruct_shamirs_secret(receiving_privkey)
         rec_capsule_bytes = capsule.to_bytes()
 
@@ -74,7 +73,7 @@ def test_activated_capsule_serialization(prepared_capsule, kfrags, bobs_keys):
 
         assert new_rec_capsule._point_e_prime == capsule._point_e_prime
         assert new_rec_capsule._point_v_prime == capsule._point_v_prime
-        assert new_rec_capsule._point_noninteractive == capsule._point_noninteractive
+        assert new_rec_capsule._point_precursor == capsule._point_precursor
 
 
 def test_cannot_create_capsule_from_bogus_material(alices_keys):

--- a/tests/unit/test_cfrags.py
+++ b/tests/unit/test_cfrags.py
@@ -37,7 +37,7 @@ def test_cfrag_serialization_with_proof_and_metadata(prepared_capsule, kfrags):
         assert new_cfrag._point_e1 == cfrag._point_e1
         assert new_cfrag._point_v1 == cfrag._point_v1
         assert new_cfrag._kfrag_id == cfrag._kfrag_id
-        assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
+        assert new_cfrag._point_precursor == cfrag._point_precursor
 
         new_proof = new_cfrag.proof
         assert new_proof is not None
@@ -68,7 +68,7 @@ def test_cfrag_serialization_with_proof_but_no_metadata(prepared_capsule, kfrags
         assert new_cfrag._point_e1 == cfrag._point_e1
         assert new_cfrag._point_v1 == cfrag._point_v1
         assert new_cfrag._kfrag_id == cfrag._kfrag_id
-        assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
+        assert new_cfrag._point_precursor == cfrag._point_precursor
 
         new_proof = new_cfrag.proof
         assert new_proof is not None
@@ -95,7 +95,7 @@ def test_cfrag_serialization_no_proof_no_metadata(prepared_capsule, kfrags):
         assert new_cfrag._point_e1 == cfrag._point_e1
         assert new_cfrag._point_v1 == cfrag._point_v1
         assert new_cfrag._kfrag_id == cfrag._kfrag_id
-        assert new_cfrag._point_noninteractive == cfrag._point_noninteractive
+        assert new_cfrag._point_precursor == cfrag._point_precursor
 
         new_proof = new_cfrag.proof
         assert new_proof is None

--- a/tests/unit/test_kfrags.py
+++ b/tests/unit/test_kfrags.py
@@ -30,11 +30,10 @@ def test_kfrag_serialization(alices_keys, bobs_keys, kfrags):
         assert len(kfrag_bytes) == KFrag.expected_bytes_length()
 
         new_kfrag = KFrag.from_bytes(kfrag_bytes)
-        assert new_kfrag._id == kfrag._id
+        assert new_kfrag.id == kfrag.id
         assert new_kfrag._bn_key == kfrag._bn_key
-        assert new_kfrag._point_noninteractive == kfrag._point_noninteractive
+        assert new_kfrag._point_precursor == kfrag._point_precursor
         assert new_kfrag._point_commitment == kfrag._point_commitment
-        assert new_kfrag._point_xcoord == kfrag._point_xcoord
 
         assert new_kfrag.verify(signing_pubkey=signing_privkey.get_pubkey(),
                                 delegating_pubkey=delegating_privkey.get_pubkey(),
@@ -48,7 +47,7 @@ def test_kfrag_verify_for_capsule(prepared_capsule, kfrags):
         assert kfrag.verify_for_capsule(prepared_capsule)
 
         # If we alter some element, the verification fails
-        previous_id, kfrag._id = kfrag._id, bytes(32)
+        previous_id, kfrag._id = kfrag.id, bytes(32)
         assert not kfrag.verify_for_capsule(prepared_capsule)    
 
         # Let's restore the KFrag, and alter the re-encryption key instead

--- a/tests/unit/test_kfrags.py
+++ b/tests/unit/test_kfrags.py
@@ -34,6 +34,9 @@ def test_kfrag_serialization(alices_keys, bobs_keys, kfrags):
         assert new_kfrag._bn_key == kfrag._bn_key
         assert new_kfrag._point_precursor == kfrag._point_precursor
         assert new_kfrag._point_commitment == kfrag._point_commitment
+        assert new_kfrag.keys_in_signature == kfrag.keys_in_signature
+        assert new_kfrag.signature_for_proxy == kfrag.signature_for_proxy
+        assert new_kfrag.signature_for_bob == kfrag.signature_for_bob
 
         assert new_kfrag.verify(signing_pubkey=signing_privkey.get_pubkey(),
                                 delegating_pubkey=delegating_privkey.get_pubkey(),
@@ -47,11 +50,11 @@ def test_kfrag_verify_for_capsule(prepared_capsule, kfrags):
         assert kfrag.verify_for_capsule(prepared_capsule)
 
         # If we alter some element, the verification fails
-        previous_id, kfrag._id = kfrag.id, bytes(32)
+        previous_id, kfrag.id = kfrag.id, bytes(32)
         assert not kfrag.verify_for_capsule(prepared_capsule)    
 
         # Let's restore the KFrag, and alter the re-encryption key instead
-        kfrag._id = previous_id
+        kfrag.id = previous_id
         kfrag._bn_key += kfrag._bn_key
         assert not kfrag.verify_for_capsule(prepared_capsule)    
         

--- a/tests/unit/test_kfrags.py
+++ b/tests/unit/test_kfrags.py
@@ -57,7 +57,7 @@ def test_kfrag_verify_for_capsule(prepared_capsule, kfrags):
         kfrag.id = previous_id
         kfrag._bn_key += kfrag._bn_key
         assert not kfrag.verify_for_capsule(prepared_capsule)    
-        
+
 
 def test_kfrag_as_dict_key(kfrags):
     dict_with_kfrags_as_keys = dict()
@@ -65,3 +65,5 @@ def test_kfrag_as_dict_key(kfrags):
     dict_with_kfrags_as_keys[kfrags[1]] = "No llamas here.  Definitely not."
 
     assert dict_with_kfrags_as_keys[kfrags[0]] != dict_with_kfrags_as_keys[kfrags[1]]
+
+

--- a/tests/unit/test_kfrags.py
+++ b/tests/unit/test_kfrags.py
@@ -20,7 +20,6 @@ along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 from umbral.fragments import KFrag
 
 
-
 def test_kfrag_serialization(alices_keys, bobs_keys, kfrags):
     
     delegating_privkey, signing_privkey = alices_keys
@@ -43,6 +42,7 @@ def test_kfrag_serialization(alices_keys, bobs_keys, kfrags):
 
         assert new_kfrag == kfrag
 
+
 def test_kfrag_verify_for_capsule(prepared_capsule, kfrags):
     for kfrag in kfrags:
         assert kfrag.verify_for_capsule(prepared_capsule)
@@ -51,14 +51,14 @@ def test_kfrag_verify_for_capsule(prepared_capsule, kfrags):
         previous_id, kfrag._id = kfrag._id, bytes(32)
         assert not kfrag.verify_for_capsule(prepared_capsule)    
 
-        # Let's restore the KFrag, and alter the re-encryption key instead
+        # Let's restore the KFrag, and alter the re-encryption key instead
         kfrag._id = previous_id
         kfrag._bn_key += kfrag._bn_key
         assert not kfrag.verify_for_capsule(prepared_capsule)    
         
 
 def test_kfrag_as_dict_key(kfrags):
-    dict_with_kfrags_as_keys = {}
+    dict_with_kfrags_as_keys = dict()
     dict_with_kfrags_as_keys[kfrags[0]] = "Some llamas.  Definitely some llamas."
     dict_with_kfrags_as_keys[kfrags[1]] = "No llamas here.  Definitely not."
 

--- a/tests/unit/test_serialization_property_based.py
+++ b/tests/unit/test_serialization_property_based.py
@@ -49,12 +49,12 @@ signatures = tuples(integers(min_value=1, max_value=backend._bn_to_int(curve.ord
 
 # # utility
 def assert_kfrag_eq(k0, k1):
-    assert(all([ k0._id                   == k1._id
-               , k0._bn_key               == k1._bn_key
-               , k0._point_noninteractive == k1._point_noninteractive
-               , k0._point_commitment     == k1._point_commitment
-               , k0._point_xcoord         == k1._point_xcoord
-               , k0.signature             == k1.signature
+    assert(all([ k0.id                == k1.id
+               , k0._bn_key           == k1._bn_key
+               , k0._point_precursor  == k1._point_precursor
+               , k0._point_commitment == k1._point_commitment
+               , k0.signature_for_bob == k1.signature_for_bob
+               , k0.signature_for_proxy == k1.signature_for_proxy
                ]))
 
 def assert_cp_eq(c0, c1):
@@ -79,10 +79,11 @@ def test_bn_roundtrip(bn):
 def test_point_roundtrip(p, c):
     assert(p == Point.from_bytes(p.to_bytes(is_compressed=c)))
 
-@given(binary(min_size=bn_size, max_size=bn_size), bns, points, points, points, signatures)
+@given(binary(min_size=bn_size, max_size=bn_size), bns, points, points, signatures, signatures)
 @settings(max_examples=max_examples, timeout=unlimited)
-def test_kfrag_roundtrip(d, b0, p0, p1, p2, sig):
-    k = KFrag(d, b0, p0, p1, p2, sig)
+def test_kfrag_roundtrip(d, b0, p0, p1, sig_proxy, sig_bob):
+    k = KFrag(identifier=d, bn_key=b0, point_commitment=p0, point_precursor=p1,
+              signature_for_proxy=sig_proxy, signature_for_bob=sig_bob)
     assert_kfrag_eq(k, KFrag.from_bytes(k.to_bytes()))
 
 @given(points, points, bns)

--- a/tests/unit/test_serialization_property_based.py
+++ b/tests/unit/test_serialization_property_based.py
@@ -92,13 +92,6 @@ def test_capsule_roundtrip_0(p0, p1, b):
     c = Capsule(params=params, point_e=p0, point_v=p1, bn_sig=b)
     assert(c == Capsule.from_bytes(c.to_bytes(), params=params))
 
-@given(points, points, bns, points, points, points)
-@settings(max_examples=max_examples, timeout=unlimited)
-def test_capsule_roundtrip_1(p0, p1, b, p2, p3, p4):
-    c = Capsule(params=params, point_e=p0, point_v=p1, bn_sig=b, 
-                point_e_prime=p2, point_v_prime=p3, point_noninteractive=p4)
-    assert(c == Capsule.from_bytes(c.to_bytes(), params))
-
 @given(points, points, points, points, bns, signatures)
 @settings(max_examples=max_examples, timeout=unlimited)
 def test_cp_roundtrip(p0, p1, p2, p3, b0, sig):

--- a/tests/unit/test_umbral_keys.py
+++ b/tests/unit/test_umbral_keys.py
@@ -203,7 +203,7 @@ def test_umbral_public_key_as_dict_key():
     another_umbral_pub_key = another_umbral_priv_key.get_pubkey()
 
     with pytest.raises(KeyError):
-        d[another_umbral_pub_key]
+        _ = d[another_umbral_pub_key]
 
     d[another_umbral_pub_key] = False
 

--- a/umbral/__about__.py
+++ b/umbral/__about__.py
@@ -8,7 +8,7 @@ __title__ = "umbral"
 
 __url__ = "https://github.com/nucypher/pyUmbral"
 
-__summary__ = 'Nucypher\'s Umbral Proxy Re-Encryption Implementation',
+__summary__ = 'NuCypher\'s Umbral Proxy Re-Encryption Implementation',
 
 __version__ = "0.1.0-alpha.4"
 

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -152,7 +152,7 @@ def verify_kfrag(kfrag: 'KFrag',
 
     u = params.u
 
-    id = kfrag._id
+    kfrag_id = kfrag._id
     key = kfrag._bn_key
     u1 = kfrag._point_commitment
     ni = kfrag._point_noninteractive
@@ -169,7 +169,7 @@ def verify_kfrag(kfrag: 'KFrag',
     if receiving_pubkey is None:
         receiving_pubkey = b'\x00' * pubkey_size
 
-    validity_input = (id, delegating_pubkey, receiving_pubkey, u1, ni, xcoord)
+    validity_input = (kfrag_id, delegating_pubkey, receiving_pubkey, u1, ni, xcoord)
 
     kfrag_validity_message = bytes().join(bytes(item) for item in validity_input)
     valid_kfrag_signature = kfrag.signature.verify(kfrag_validity_message, signing_pubkey)

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -55,9 +55,9 @@ def prove_cfrag_correctness(cfrag: 'CapsuleFrag',
     v2 = t * v
     u2 = t * u
 
-    hash_input = (e, e1, e2, v, v1, v2, u, u1, u2)
+    hash_input = [e, e1, e2, v, v1, v2, u, u1, u2]
     if metadata is not None:
-        hash_input += (metadata,)
+        hash_input.append(metadata)
     h = CurveBN.hash(*hash_input, params=params)
     ########
 
@@ -98,9 +98,9 @@ def assess_cfrag_correctness(cfrag: 'CapsuleFrag', capsule: 'Capsule') -> bool:
         else:
             raise
 
-    hash_input = (e, e1, e2, v, v1, v2, u, u1, u2)
+    hash_input = [e, e1, e2, v, v1, v2, u, u1, u2]
     if cfrag.proof.metadata is not None:
-        hash_input += (cfrag.proof.metadata,)
+        hash_input.append(cfrag.proof.metadata)
     h = CurveBN.hash(*hash_input, params=params)
     ########
 

--- a/umbral/_pre.py
+++ b/umbral/_pre.py
@@ -150,7 +150,7 @@ def verify_kfrag(kfrag: 'KFrag',
 
     #  We check that the commitment is well-formed
     correct_commitment = commitment == key * u
-    validity_input = [kfrag_id, commitment, precursor, (kfrag.keys_in_signature,)]
+    validity_input = [kfrag_id, commitment, precursor, kfrag.keys_in_signature]
 
     if kfrag.delegating_key_in_signature():
         validity_input.append(delegating_pubkey)

--- a/umbral/config.py
+++ b/umbral/config.py
@@ -28,7 +28,11 @@ class _CONFIG:
     __curve = None
     __params = None
     __CURVE_TO_USE_IF_NO_DEFAULT_IS_SET_BY_USER = SECP256K1
-    __WARNING_IF_NO_DEFAULT_SET = "No default curve has been set.  Using SECP256K1.  A slight performance penalty has been incurred for only this call.  Set a default curve with umbral.config.set_default_curve()."
+    __WARNING_IF_NO_DEFAULT_SET = "No default curve has been set.  " \
+                                  "Using SECP256K1.  " \
+                                  "A slight performance penalty has been " \
+                                  "incurred for only this call.  Set a default " \
+                                  "curve with umbral.config.set_default_curve()."
 
     class UmbralConfigurationError(RuntimeError):
         """Raised when somebody does something dumb re: configuration."""
@@ -42,13 +46,13 @@ class _CONFIG:
     def params(cls) -> UmbralParameters:
         if not cls.__params:
             cls.__set_curve_by_default()
-        return cls.__params
+        return cls.__params  # type: ignore
 
     @classmethod
     def curve(cls) -> Curve:
         if not cls.__curve:
             cls.__set_curve_by_default()
-        return cls.__curve
+        return cls.__curve  # type: ignore
 
     @classmethod
     def set_curve(cls, curve: Optional[Curve] = None) -> None:

--- a/umbral/config.py
+++ b/umbral/config.py
@@ -45,7 +45,7 @@ class _CONFIG:
         return cls.__params
 
     @classmethod
-    def curve(cls) -> Type[Curve]:
+    def curve(cls) -> Curve:
         if not cls.__curve:
             cls.__set_curve_by_default()
         return cls.__curve
@@ -67,7 +67,7 @@ def set_default_curve(curve: Optional[Curve] = None) -> None:
     return _CONFIG.set_curve(curve)
 
 
-def default_curve() -> Type[Curve]:
+def default_curve() -> Curve:
     return _CONFIG.curve()
 
 

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -56,8 +56,8 @@ class Curve:
         self.__generator = openssl._get_ec_generator_by_group(self.ec_group)
 
         # Init cache
-        self.__field_order_size_in_bytes = None
-        self.__group_order_size_in_bytes = None
+        self.__field_order_size_in_bytes = 0
+        self.__group_order_size_in_bytes = 0
 
     @classmethod
     def from_name(cls, name: str) -> 'Curve':
@@ -93,15 +93,14 @@ class Curve:
 
     @property
     def field_order_size_in_bytes(self) -> int:
-        if self.__field_order_size_in_bytes is None:
-            backend = default_backend()
+        if not self.__field_order_size_in_bytes:
             size_in_bits = openssl._get_ec_group_degree(self.__ec_group)
             self.__field_order_size_in_bytes = (size_in_bits + 7) // 8
         return self.__field_order_size_in_bytes
 
     @property
     def group_order_size_in_bytes(self) -> int:
-        if self.__group_order_size_in_bytes is None:
+        if not self.__group_order_size_in_bytes:
             BN_num_bytes = default_backend()._lib.BN_num_bytes
             self.__group_order_size_in_bytes = BN_num_bytes(self.order)
         return self.__group_order_size_in_bytes

--- a/umbral/curvebn.py
+++ b/umbral/curvebn.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives import hashes
@@ -36,7 +36,7 @@ class CurveBN(object):
     constant time operations.
     """
 
-    def __init__(self, bignum, curve: Curve):
+    def __init__(self, bignum, curve: Curve) -> None:
         on_curve = openssl._bn_is_on_curve(bignum, curve)
         if not on_curve:
             raise ValueError("The provided BIGNUM is not on the provided curve.")
@@ -146,7 +146,7 @@ class CurveBN(object):
         """
         return backend._bn_to_int(self.bignum)
 
-    def __eq__(self, other : Union[int, 'CurveBN']) -> bool:
+    def __eq__(self, other) -> bool:
         """
         Compares the two BIGNUMS or int.
         """
@@ -158,7 +158,7 @@ class CurveBN(object):
         # -1 less than, 0 is equal to, 1 is greater than
         return not bool(backend._lib.BN_cmp(self.bignum, other.bignum))
 
-    def __pow__(self, other : Union[int, 'CurveBN']) -> 'CurveBN':
+    def __pow__(self, other: Union[int, 'CurveBN']) -> 'CurveBN':
         """
         Performs a BN_mod_exp on two BIGNUMS.
 
@@ -168,6 +168,8 @@ class CurveBN(object):
         if type(other) == int:
             other = openssl._int_to_bn(other)
             other = CurveBN(other, self.curve)
+
+        other = cast('CurveBN', other)  # This is just for mypy
 
         power = openssl._get_new_BN()
         with backend._tmp_bn_ctx() as bn_ctx, openssl._tmp_bn_mont_ctx(self.curve.order) as bn_mont_ctx:
@@ -194,7 +196,7 @@ class CurveBN(object):
 
         return CurveBN(product, self.curve)
 
-    def __truediv__(self, other : 'CurveBN') -> 'CurveBN':
+    def __truediv__(self, other: 'CurveBN') -> 'CurveBN':
         """
         Performs a BN_div on two BIGNUMs (modulo the order of the curve).
 
@@ -215,7 +217,6 @@ class CurveBN(object):
 
         return CurveBN(product, self.curve)
 
-
     def __add__(self, other : Union[int, 'CurveBN']) -> 'CurveBN':
         """
         Performs a BN_mod_add on two BIGNUMs.
@@ -223,6 +224,8 @@ class CurveBN(object):
         if type(other) == int:
             other = openssl._int_to_bn(other)
             other = CurveBN(other, self.curve)
+
+        other = cast('CurveBN', other)  # This is just for mypy
             
         op_sum = openssl._get_new_BN()
         with backend._tmp_bn_ctx() as bn_ctx:
@@ -240,6 +243,8 @@ class CurveBN(object):
         if type(other) == int:
             other = openssl._int_to_bn(other)
             other = CurveBN(other, self.curve)
+
+        other = cast('CurveBN', other)  # This is just for mypy
 
         diff = openssl._get_new_BN()
         with backend._tmp_bn_ctx() as bn_ctx:
@@ -283,13 +288,15 @@ class CurveBN(object):
 
         return CurveBN(the_opposite, self.curve)
 
-    def __mod__(self, other : Union[int, 'CurveBN']) -> 'CurveBN':
+    def __mod__(self, other: Union[int, 'CurveBN']) -> 'CurveBN':
         """
         Performs a BN_nnmod on two BIGNUMS.
         """
         if type(other) == int:
             other = openssl._int_to_bn(other)
             other = CurveBN(other, self.curve)
+
+        other = cast('CurveBN', other)  # This is just for mypy
 
         rem = openssl._get_new_BN()
         with backend._tmp_bn_ctx() as bn_ctx:

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -173,7 +173,7 @@ class KFrag(object):
 
 class CorrectnessProof(object):
     def __init__(self, point_e2: Point, point_v2: Point, point_kfrag_commitment: Point,
-                 point_kfrag_pok: Point, bn_sig: CurveBN, kfrag_signature: bytes,
+                 point_kfrag_pok: Point, bn_sig: CurveBN, kfrag_signature: Signature,
                  metadata: Optional[bytes] = None) -> None:
         self._point_e2 = point_e2
         self._point_v2 = point_v2

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -97,8 +97,8 @@ class KFrag(object):
 
     def verify(self,
                signing_pubkey: UmbralPublicKey,
-               delegating_pubkey: UmbralPublicKey,
-               receiving_pubkey: UmbralPublicKey,
+               delegating_pubkey: UmbralPublicKey = None,
+               receiving_pubkey: UmbralPublicKey = None,
                params: Optional[UmbralParameters] = None,
               ) -> bool:
 

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -31,11 +31,12 @@ from umbral.point import Point
 from umbral.signing import Signature
 from umbral.params import UmbralParameters
 
-#TODO: Use ConstantSorrow for this
-NO_KEY = 0x00
-DELEGATING_ONLY = 0x01
-RECEIVING_ONLY = 0x02
-DELEGATING_AND_RECEIVING = 0x03
+from constant_sorrow.constants import NO_KEY, DELEGATING_ONLY, RECEIVING_ONLY, DELEGATING_AND_RECEIVING
+
+NO_KEY(b'\x00')
+DELEGATING_ONLY(b'\x01')
+RECEIVING_ONLY(b'\x02')
+DELEGATING_AND_RECEIVING(b'\x03')
 
 
 class KFrag(object):
@@ -99,7 +100,7 @@ class KFrag(object):
             (CurveBN, bn_size, arguments),  # bn_key
             (Point, point_size, arguments),  # point_commitment
             (Point, point_size, arguments),  # point_precursor
-            (int, 1, {'byteorder': 'big'}),  # keys_in_signature
+            1,  # keys_in_signature
             (Signature, signature_size, arguments),  # signature_for_proxy
             (Signature, signature_size, arguments),  # signature_for_bob
         )
@@ -122,7 +123,7 @@ class KFrag(object):
         precursor = self._point_precursor.to_bytes()
         signature_for_proxy = bytes(self.signature_for_proxy)
         signature_for_bob = bytes(self.signature_for_bob)
-        mode = self.keys_in_signature.to_bytes(1, 'big')
+        mode = bytes(self.keys_in_signature)
 
         return self.id + key + commitment + precursor \
              + mode + signature_for_proxy + signature_for_bob

--- a/umbral/fragments.py
+++ b/umbral/fragments.py
@@ -24,11 +24,12 @@ from bytestring_splitter import BytestringSplitter
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 
 from umbral._pre import assess_cfrag_correctness, verify_kfrag
-from umbral.config import default_curve
+from umbral.config import default_curve, default_params
 from umbral.curvebn import CurveBN
 from umbral.keys import UmbralPublicKey
 from umbral.point import Point
 from umbral.signing import Signature
+from umbral.params import UmbralParameters
 
 
 class KFrag(object):
@@ -97,14 +98,24 @@ class KFrag(object):
     def verify(self,
                signing_pubkey: UmbralPublicKey,
                delegating_pubkey: UmbralPublicKey,
-               receiving_pubkey: UmbralPublicKey) -> bool:
-        return verify_kfrag(self, delegating_pubkey, signing_pubkey, receiving_pubkey)
+               receiving_pubkey: UmbralPublicKey,
+               params: Optional[UmbralParameters] = None,
+              ) -> bool:
 
-    def verify_for_capsule(self, capsule : 'Capsule') -> bool:
+        if params is None:
+            params = default_params()
+        return verify_kfrag(kfrag=self,
+                            params=params,
+                            delegating_pubkey=delegating_pubkey,
+                            signing_pubkey=signing_pubkey,
+                            receiving_pubkey=receiving_pubkey)
+
+    def verify_for_capsule(self, capsule: 'Capsule') -> bool:
 
         correctness_keys = capsule.get_correctness_keys()
 
-        return self.verify(signing_pubkey=correctness_keys["verifying"],
+        return self.verify(params=capsule._umbral_params,
+                           signing_pubkey=correctness_keys["verifying"],
                            delegating_pubkey=correctness_keys["delegating"],
                            receiving_pubkey=correctness_keys["receiving"])
 

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -18,7 +18,7 @@ along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 """
 
 import os
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, Any
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.backends.openssl.ec import _EllipticCurvePrivateKey, _EllipticCurvePublicKey
@@ -42,7 +42,7 @@ class UmbralPrivateKey(object):
         """
         self.params = params
         self.bn_key = bn_key
-        self.pubkey = UmbralPublicKey(self.bn_key * params.g, params=params)
+        self.pubkey = UmbralPublicKey(self.bn_key * params.g, params=params)  # type: ignore
 
     @classmethod
     def gen_key(cls, params: Optional[UmbralParameters] = None) -> 'UmbralPrivateKey':
@@ -269,17 +269,17 @@ class UmbralPublicKey(object):
     def __repr__(self):
         return "{}:{}".format(self.__class__.__name__, self.point_key.to_bytes().hex()[:15])
 
-    def __eq__(self, other: Optional[Union[bytes, 'UmbralPublicKey', int]]) -> bool:
+    def __eq__(self, other: Any) -> bool:
         if type(other) == bytes:
             is_eq = bytes(other) == bytes(self)
-        elif hasattr(other, "point_key"):
-            is_eq = self.point_key == other.point_key
+        elif hasattr(other, "point_key") and hasattr(other, "params"):
+            is_eq = (self.point_key, self.params) == (other.point_key, other.params)
         else:
             is_eq = False
         return is_eq
 
     def __hash__(self) -> int:
-        return int.from_bytes(self, byteorder="big")
+        return int.from_bytes(self.to_bytes(), byteorder="big")
 
 
 class UmbralKeyingMaterial(object):

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -32,6 +32,7 @@ from umbral.config import default_params
 from umbral.curvebn import CurveBN
 from umbral.params import UmbralParameters
 from umbral.point import Point
+from umbral.curve import Curve
 
 
 class UmbralPrivateKey(object):
@@ -209,6 +210,16 @@ class UmbralPublicKey(object):
 
         point_key = Point.from_bytes(key_bytes, params.curve)
         return cls(point_key, params)
+
+    @classmethod
+    def expected_bytes_length(cls, curve: Optional[Curve] = None,
+                              is_compressed: bool = True):
+        """
+        Returns the size (in bytes) of an UmbralPublicKey given a curve.
+        If no curve is provided, it uses the default curve.
+        By default, it assumes compressed representation (is_compressed = True).
+        """
+        return Point.expected_bytes_length(curve=curve, is_compressed=is_compressed)
 
     def to_bytes(self, encoder: Callable = None, is_compressed: bool = True):
         """

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -33,7 +33,7 @@ class UmbralParameters(object):
         parameters_seed = b'NuCypher/UmbralParameters/'
         self.u = unsafe_hash_to_point(g_bytes, self, parameters_seed + b'u')
 
-    def __eq__(self, other: 'UmbralParameters') -> bool:
+    def __eq__(self, other) -> bool:
 
         # TODO: This is not comparing the order, which currently is an OpenSSL pointer
         self_attributes = self.curve, self.g, self.CURVE_KEY_SIZE_BYTES, self.u

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -17,9 +17,6 @@ You should have received a copy of the GNU General Public License
 along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 """
 
-from cryptography.hazmat.backends.openssl import backend
-
-from umbral import openssl
 from umbral.curve import Curve
 
 

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -41,10 +41,11 @@ class Point(object):
 
     @classmethod
     def expected_bytes_length(cls, curve: Optional[Curve] = None,
-                              is_compressed: bool=True):
+                              is_compressed: bool = True):
         """
-        Returns the size (in bytes) of a compressed Point given a curve.
+        Returns the size (in bytes) of a Point given a curve.
         If no curve is provided, it uses the default curve.
+        By default, it assumes compressed representation (is_compressed = True).
         """
         curve = curve if curve is not None else default_curve()
 

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -161,7 +161,7 @@ class Point(object):
         # 1 is not-equal, 0 is equal, -1 is error
         return not bool(is_equal)
 
-    def __mul__(self, other) -> 'Point':
+    def __mul__(self, other: CurveBN) -> 'Point':
         """
         Performs an EC_POINT_mul on an EC_POINT and a BIGNUM.
         """

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -152,7 +152,7 @@ class Capsule(object):
 
         if current_key is None:
             if key is None:
-                raise TypeError("The {} key is not set and you didn't pass one.".format(key_type))
+                return False
             elif self._umbral_params != key.params:
                 raise TypeError("You are trying to set a key with different UmbralParameters.")
             else:

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -298,6 +298,7 @@ class Capsule(object):
     def __repr__(self):
         return "{}:{}".format(self.__class__.__name__, hex(int(self._bn_sig))[2:17])
 
+
 def split_rekey(delegating_privkey: UmbralPrivateKey,
                 signer: Signer,
                 receiving_pubkey: UmbralPublicKey,
@@ -305,7 +306,7 @@ def split_rekey(delegating_privkey: UmbralPrivateKey,
                 N: int,
                 sign_delegating_key : Optional[bool] = True,
                 sign_receiving_key : Optional[bool] = True,
-                ) -> List[KFrag]:
+               ) -> List[KFrag]:
     """
     Creates a re-encryption key from Alice to Bob and splits it in KFrags,
     using Shamir's Secret Sharing. Requires a threshold number of KFrags
@@ -360,9 +361,9 @@ def split_rekey(delegating_privkey: UmbralPrivateKey,
 
     kfrags = []
     for _ in range(N):
-        id = os.urandom(bn_size)
+        kfrag_id = os.urandom(bn_size)
 
-        share_x = CurveBN.hash(id, hashed_dh_tuple, params=params)
+        share_x = CurveBN.hash(kfrag_id, hashed_dh_tuple, params=params)
 
         rk = poly_eval(coeffs, share_x)
 
@@ -374,12 +375,12 @@ def split_rekey(delegating_privkey: UmbralPrivateKey,
         if not sign_receiving_key:
             receiving_pubkey = b'\x00' * pubkey_size
 
-        validity_input = (id, delegating_pubkey, receiving_pubkey, u1, ni, xcoord)
+        validity_input = (kfrag_id, delegating_pubkey, receiving_pubkey, u1, ni, xcoord)
 
         kfrag_validity_message = bytes().join(bytes(item) for item in validity_input)
         signature = signer(kfrag_validity_message)
 
-        kfrag = KFrag(id=id,
+        kfrag = KFrag(id=kfrag_id,
                       bn_key=rk,
                       point_noninteractive=ni,
                       point_commitment=u1,

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -229,11 +229,13 @@ def generate_kfrags(delegating_privkey: UmbralPrivateKey,
 
     dh_point = private_precursor * bob_pubkey_point
 
+    from constant_sorrow import constants
+
     # Secret value 'd' allows to make Umbral non-interactive
     d = CurveBN.hash(precursor,
                      bob_pubkey_point,
                      dh_point,
-                     b"NON-INTERACTIVE",
+                     bytes(constants.NON_INTERACTIVE),
                      params=params)
 
     # Coefficients of the generating polynomial
@@ -253,7 +255,7 @@ def generate_kfrags(delegating_privkey: UmbralPrivateKey,
         share_index = CurveBN.hash(precursor,
                                    bob_pubkey_point,
                                    dh_point,
-                                   b"X-COORDINATE",
+                                   bytes(constants.X_COORDINATE),
                                    kfrag_id,
                                    params=params)
 
@@ -376,12 +378,14 @@ def _decapsulate_reencrypted(receiving_privkey: UmbralPrivateKey, capsule: Capsu
     precursor = capsule._attached_cfrags[0]._point_precursor
     dh_point = priv_key * precursor
 
+    from constant_sorrow import constants
+
     # Combination of CFrags via Shamir's Secret Sharing reconstruction
     if len(capsule._attached_cfrags) > 1:
         xs = [CurveBN.hash(precursor,
                            pub_key,
                            dh_point,
-                           b"X-COORDINATE",
+                           bytes(constants.X_COORDINATE),
                            cfrag._kfrag_id,
                            params=params)
               for cfrag in capsule._attached_cfrags]
@@ -405,7 +409,7 @@ def _decapsulate_reencrypted(receiving_privkey: UmbralPrivateKey, capsule: Capsu
     d = CurveBN.hash(precursor,
                      pub_key,
                      dh_point,
-                     b"NON-INTERACTIVE",
+                     bytes(constants.NON_INTERACTIVE),
                      params=params)
 
     e, v, s = capsule.components()

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -399,10 +399,9 @@ def split_rekey(delegating_privkey: UmbralPrivateKey,
 def reencrypt(kfrag: KFrag, capsule: Capsule, provide_proof: bool = True, 
               metadata: Optional[bytes] = None) -> CapsuleFrag:
 
-    if capsule is None or not capsule.verify():
+    if not isinstance(capsule, Capsule) or not capsule.verify():
         raise Capsule.NotValid
-
-    if kfrag is None or not kfrag.verify_for_capsule(capsule):
+    elif not isinstance(kfrag, KFrag) or not kfrag.verify_for_capsule(capsule):
         raise KFrag.NotValid
 
     rk = kfrag._bn_key
@@ -545,6 +544,10 @@ def decrypt(ciphertext: bytes, capsule: Capsule, decrypting_key: UmbralPrivateKe
 
     if not isinstance(ciphertext, bytes) or len(ciphertext) < DEM_NONCE_SIZE:
         raise ValueError("Input ciphertext must be a bytes object of length >= {}".format(DEM_NONCE_SIZE))
+    elif not isinstance(capsule, Capsule) or not capsule.verify():
+        raise Capsule.NotValid
+    elif not isinstance(decrypting_key, UmbralPrivateKey):
+        raise TypeError("The decrypting key is not an UmbralPrivateKey")
 
     if capsule._attached_cfrags:
         # Since there are cfrags attached, we assume this is Bob opening the Capsule.

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -283,7 +283,7 @@ def generate_kfrags(delegating_privkey: UmbralPrivateKey,
         else:
             mode = NO_KEY
 
-        validity_message_for_proxy = [kfrag_id, commitment, precursor, (mode,)]
+        validity_message_for_proxy = [kfrag_id, commitment, precursor, mode]
 
         if sign_delegating_key:
             validity_message_for_proxy.append(delegating_pubkey)

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -35,7 +35,6 @@ from umbral.signing import Signer
 from umbral.utils import poly_eval, lambda_coeff, kdf
 from umbral.curve import Curve
 
-
 class GenericUmbralError(Exception):
     pass
 
@@ -169,7 +168,6 @@ class Capsule(object):
 
     def components(self) -> Tuple[Point, Point, CurveBN]:
         return self._point_e, self._point_v, self._bn_sig
-
 
     def __bytes__(self) -> bytes:
         return self.to_bytes()

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -192,20 +192,20 @@ class Capsule(object):
         return "{}:{}".format(self.__class__.__name__, hex(int(self._bn_sig))[2:17])
 
 
-def split_rekey(delegating_privkey: UmbralPrivateKey,
-                signer: Signer,
-                receiving_pubkey: UmbralPublicKey,
-                threshold: int,
-                N: int,
-                sign_delegating_key : Optional[bool] = True,
-                sign_receiving_key : Optional[bool] = True,
-               ) -> List[KFrag]:
+def generate_kfrags(delegating_privkey: UmbralPrivateKey,
+                    receiving_pubkey: UmbralPublicKey,
+                    threshold: int,
+                    N: int,
+                    signer: Signer,
+                    sign_delegating_key: Optional[bool] = True,
+                    sign_receiving_key: Optional[bool] = True,
+                    ) -> List[KFrag]:
     """
     Creates a re-encryption key from Alice's delegating public key to Bob's
     receiving public key, and splits it in KFrags, using Shamir's Secret Sharing.
     Requires a threshold number of KFrags out of N.
 
-    Returns a dictionary which includes the list of N KFrags
+    Returns a list of N KFrags
     """
 
     if threshold <= 0 or threshold > N:

--- a/umbral/signing.py
+++ b/umbral/signing.py
@@ -105,7 +105,7 @@ class Signature:
     def __radd__(self, other: bytes) -> bytes:
         return other + bytes(self)
 
-    def __eq__(self, other: 'Signature') -> bool:
+    def __eq__(self, other) -> bool:
         simple_bytes_match = hmac.compare_digest(bytes(self), bytes(other))
         der_encoded_match = hmac.compare_digest(self._der_encoded_bytes(), bytes(other))
         return simple_bytes_match or der_encoded_match

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -24,13 +24,14 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from umbral.curvebn import CurveBN
+from umbral.point import Point
 
 
 def lambda_coeff(id_i: CurveBN, selected_ids: List[CurveBN]) -> CurveBN:
     ids = [x for x in selected_ids if x != id_i]
 
     if not ids:
-        return None
+        CurveBN.from_int(1, id_i.curve)
 
     result = ids[0] / (ids[0] - id_i)
     for id_j in ids[1:]:
@@ -47,7 +48,7 @@ def poly_eval(coeff: List[CurveBN], x: CurveBN) -> CurveBN:
     return result
 
 
-def kdf(ecpoint: 'Point', key_length: int) -> bytes:
+def kdf(ecpoint: Point, key_length: int) -> bytes:
     data = ecpoint.to_bytes(is_compressed=True)
 
     return HKDF(

--- a/vectors/generate_test_vectors.py
+++ b/vectors/generate_test_vectors.py
@@ -53,7 +53,7 @@ receiving_key = receiving_privkey.get_pubkey()
 
 signer = Signer(signing_privkey)
 
-kfrags = pre.split_rekey(delegating_privkey, signer, receiving_key, 6, 10)
+kfrags = pre.generate_kfrags(delegating_privkey, signer, receiving_key, 6, 10)
 
 plain_data = b'peace at dawn'
 

--- a/vectors/generate_test_vectors.py
+++ b/vectors/generate_test_vectors.py
@@ -60,9 +60,9 @@ plain_data = b'peace at dawn'
 ciphertext, capsule = pre.encrypt(delegating_key, plain_data)
 
 cfrag = pre.reencrypt(kfrags[0], capsule)
-points = [  capsule._point_e, cfrag._point_e1, cfrag.proof._point_e2, 
-            capsule._point_v, cfrag._point_v1, cfrag.proof._point_v2,
-            capsule._umbral_params.u, cfrag.proof._point_kfrag_commitment, cfrag.proof._point_kfrag_pok ]
+points = [capsule._point_e, cfrag._point_e1, cfrag.proof._point_e2,
+          capsule._point_v, cfrag._point_v1, cfrag.proof._point_v2,
+          capsule.params.u, cfrag.proof._point_kfrag_commitment, cfrag.proof._point_kfrag_pok]
 
 z = cfrag.proof.bn_sig
 


### PR DESCRIPTION
The original goal of this PR is to update pyUmbral so that it allows NuCypher to be in sync. In particular, knowledge of delegating and receiving public keys is now optional to KFrag validity; this is decided by Alice when generating the kfrags using the new flags `sign_delegating_key` and `sign_receiving_key`. Apart from this, there are many improvements in this PR, like for example, removing the activated capsule state, or the test automation for pyUmbral's Jupyter notebook.

This PR is based on #218, which I closed since there were a lot of changes since then.

More detailed description of the changes:
- [x] KFrags have now two signatures (one to be verified by the proxy and another by Bob)
- [x] Correctness keys are optional in the signature for the proxy. 
- [x] API change: `pre.split_rekey` --> `pre.generate_kfrags`
- [x] Remove activated capsule state from `Capsule`
- [x] Update Jupyter notebook and automate testing using pytest's plugin nbval
- [x] Update README, docs, and scripts

**TODO** (once PR is approved):
- [ ] Regenerate test vectors
- [ ] Bump version


 