### PR TITLE
Optional KFrag validation in `pre.reencrypt()` (and other stuff)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ workflows:
           filters:
             tags:
               only: /.*/
-          requires:
-            - run_tests_35
-            - run_tests_36
-            - run_tests_37
+#          requires:  # Commented this section to speed up the build
+#            - run_tests_35
+#            - run_tests_36
+#            - run_tests_37
       - test_deploy:
           context: "NuCypher PyPI"
           requires:
@@ -177,7 +177,7 @@ commands:
         at: ~/.local/share/virtualenvs/
     - run:
         name: pyUmbral Tests (Python << parameters.python_version >>)
-        command: pipenv run pytest --cov=. --cov-report=html --junitxml=./reports/pytest/python<< parameters.python_version >>-results.xml
+        command: pipenv run pytest $(circleci tests glob tests/**/test_*.py | circleci tests split --split-by=timings) --cov=. --cov-report=html --junitxml=./reports/pytest/python<< parameters.python_version >>-results.xml
     - store_test_results:
         path: reports/pytest
     - store_artifacts:
@@ -217,18 +217,21 @@ jobs:
 
   run_tests_35:
     <<: *python_35_base
+    parallelism: 4
     steps:
     - run_tests:
         python_version: "3.5"
 
   run_tests_36:
     <<: *python_36_base
+    parallelism: 4
     steps:
     - run_tests:
         python_version: "3.6"
 
   run_tests_37:
     <<: *python_37_base
+    parallelism: 4
     steps:
     - run_tests:
         python_version: "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -13,15 +13,14 @@ pysha3 = "*"
 bytestring-splitter = "*"
 constant-sorrow = ">=0.1.0a7"
 
-
 [dev-packages]
 bumpversion = "*"
 # Pytest Plugins
-pytest = "<4"
+pytest = "*"
 pytest-mypy = "*"
 pytest-mock = "*"
 pytest-cov = "*"
-pytest-benchmark = {version = "*", extras = ["histogram"]}
+pytest-benchmark = {version = "*",extras = ["histogram"]}
 # Pytest Plugin Subdeps
 mock = "*"
 mypy = "*"

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,39 @@ pyUmbral
 =========
 v0.1.3-alpha.0
 
-.. image:: https://circleci.com/gh/nucypher/pyUmbral/tree/master.svg?style=svg
+.. start-badges
+
+.. list-table::
+    :stub-columns: 1
+
+    * - info
+      - |docs| |discord|
+    * - tests
+      - | |circleci|
+    * - package
+      - | |version| |commits-since|
+
+.. |docs| image:: https://readthedocs.org/projects/pyumbral/badge/?style=flat
+    :target: https://readthedocs.org/projects/pyumbral
+    :alt: Documentation Status
+
+.. |discord| image:: https://img.shields.io/discord/411401661714792449.svg?logo=discord
+    :target: https://discord.gg/xYqyEby
+    :alt: Discord
+
+.. |circleci| image:: https://img.shields.io/circleci/project/github/nucypher/pyUmbral.svg?logo=circleci
     :target: https://circleci.com/gh/nucypher/pyUmbral/tree/master
+    :alt: CircleCI build status
+
+.. |version| image:: https://img.shields.io/pypi/v/umbral.svg
+    :alt: PyPI Package latest release
+    :target: https://pypi.org/project/umbral
+
+.. |commits-since| image:: https://img.shields.io/github/commits-since/nucypher/pyumbral/v0.1.3-alpha.0.svg
+    :alt: Commits since latest release
+    :target: https://github.com/nucypher/pyUmbral/compare/v0.1.3-alpha.0...master
+
+.. end-badges
 
 pyUmbral is a python implementation of David Nuñez's threshold proxy re-encryption scheme: Umbral_.
 Implemented with OpenSSL_ and Cryptography.io_, pyUmbral is a referential and open-source cryptography library

--- a/tests/unit/test_signing.py
+++ b/tests/unit/test_signing.py
@@ -1,0 +1,64 @@
+"""
+Copyright (C) 2018 NuCypher
+
+This file is part of pyUmbral.
+
+pyUmbral is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+pyUmbral is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import pytest
+from cryptography.hazmat.backends.openssl import backend
+from cryptography.hazmat.primitives import hashes
+from umbral.keys import UmbralPrivateKey
+from umbral.signing import Signer, Signature, DEFAULT_HASH_ALGORITHM
+
+
+@pytest.mark.parametrize('execution_number', range(20))  # Run this test 20 times.
+def test_sign_and_verify(execution_number):
+    privkey = UmbralPrivateKey.gen_key()
+    pubkey = privkey.get_pubkey()
+    signer = Signer(private_key=privkey)
+    message = b"peace at dawn"
+    signature = signer(message=message)
+
+    # Basic signature verification
+    assert signature.verify(message, pubkey)
+    assert not signature.verify(b"another message", pubkey)
+    another_pubkey = UmbralPrivateKey.gen_key().pubkey
+    assert not signature.verify(message, another_pubkey)
+
+    # Signature serialization
+    sig_bytes = bytes(signature)
+    assert len(sig_bytes) == Signature.expected_bytes_length()
+    restored_signature = Signature.from_bytes(sig_bytes)
+    assert restored_signature == signature
+    assert restored_signature.verify(message, pubkey)
+
+
+@pytest.mark.parametrize('execution_number', range(20))  # Run this test 20 times.
+def test_prehashed_message(execution_number):
+    privkey = UmbralPrivateKey.gen_key()
+    pubkey = privkey.get_pubkey()
+    signer = Signer(private_key=privkey)
+
+    message = b"peace at dawn"
+    hash_function = hashes.Hash(DEFAULT_HASH_ALGORITHM(), backend=backend)
+    hash_function.update(message)
+    prehashed_message = hash_function.finalize()
+
+    signature = signer(message=prehashed_message, is_prehashed=True)
+
+    assert signature.verify(message=prehashed_message,
+                            verifying_key=pubkey,
+                            is_prehashed=True)

--- a/umbral/cfrags.py
+++ b/umbral/cfrags.py
@@ -29,7 +29,7 @@ from umbral.curve import Curve
 from umbral.random_oracles import hash_to_curvebn, ExtendedKeccak
 
 
-class CorrectnessProof(object):
+class CorrectnessProof():
     def __init__(self, point_e2: Point, point_v2: Point, point_kfrag_commitment: Point,
                  point_kfrag_pok: Point, bn_sig: CurveBN, kfrag_signature: Signature,
                  metadata: Optional[bytes] = None) -> None:
@@ -99,7 +99,7 @@ class CorrectnessProof(object):
         return self.to_bytes()
 
 
-class CapsuleFrag(object):
+class CapsuleFrag():
     def __init__(self,
                  point_e1: Point,
                  point_v1: Point,

--- a/umbral/cfrags.py
+++ b/umbral/cfrags.py
@@ -29,7 +29,7 @@ from umbral.curve import Curve
 from umbral.random_oracles import hash_to_curvebn, ExtendedKeccak
 
 
-class CorrectnessProof():
+class CorrectnessProof:
     def __init__(self, point_e2: Point, point_v2: Point, point_kfrag_commitment: Point,
                  point_kfrag_pok: Point, bn_sig: CurveBN, kfrag_signature: Signature,
                  metadata: Optional[bytes] = None) -> None:
@@ -99,7 +99,7 @@ class CorrectnessProof():
         return self.to_bytes()
 
 
-class CapsuleFrag():
+class CapsuleFrag:
     def __init__(self,
                  point_e1: Point,
                  point_v1: Point,

--- a/umbral/curvebn.py
+++ b/umbral/curvebn.py
@@ -26,7 +26,7 @@ from umbral.config import default_curve
 from umbral.curve import Curve
 
 
-class CurveBN(object):
+class CurveBN:
     """
     Represents an OpenSSL Bignum modulo the order of a curve. Some of these
     operations will only work with prime numbers

--- a/umbral/dem.py
+++ b/umbral/dem.py
@@ -27,7 +27,7 @@ DEM_KEYSIZE = 32
 DEM_NONCE_SIZE = 12
 
 
-class UmbralDEM(object):
+class UmbralDEM():
     def __init__(self, symm_key: bytes) -> None:
         """
         Initializes an UmbralDEM object. Requires a key to perform

--- a/umbral/dem.py
+++ b/umbral/dem.py
@@ -27,7 +27,7 @@ DEM_KEYSIZE = 32
 DEM_NONCE_SIZE = 12
 
 
-class UmbralDEM():
+class UmbralDEM:
     def __init__(self, symm_key: bytes) -> None:
         """
         Initializes an UmbralDEM object. Requires a key to perform

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -302,7 +302,7 @@ class UmbralPublicKey:
 
     @classmethod
     def expected_bytes_length(cls, curve: Optional[Curve] = None,
-                              is_compressed: bool = True):
+                              is_compressed: bool = True) -> int:
         """
         Returns the size (in bytes) of an UmbralPublicKey given a curve.
         If no curve is provided, it uses the default curve.
@@ -310,7 +310,7 @@ class UmbralPublicKey:
         """
         return Point.expected_bytes_length(curve=curve, is_compressed=is_compressed)
 
-    def to_bytes(self, encoder: Callable = None, is_compressed: bool = True):
+    def to_bytes(self, encoder: Callable = None, is_compressed: bool = True) -> bytes:
         """
         Returns an Umbral public key as bytes.
         Optionally, if an encoder function is provided it will be used to encode

--- a/umbral/kfrags.py
+++ b/umbral/kfrags.py
@@ -127,8 +127,8 @@ class KFrag():
 
     def verify(self,
                signing_pubkey: UmbralPublicKey,
-               delegating_pubkey: UmbralPublicKey = None,
-               receiving_pubkey: UmbralPublicKey = None,
+               delegating_pubkey: Optional[UmbralPublicKey] = None,
+               receiving_pubkey: Optional[UmbralPublicKey] = None,
                params: Optional[UmbralParameters] = None,
                ) -> bool:
         if params is None:

--- a/umbral/kfrags.py
+++ b/umbral/kfrags.py
@@ -36,7 +36,7 @@ RECEIVING_ONLY = b'\x02'
 DELEGATING_AND_RECEIVING = b'\x03'
 
 
-class KFrag(object):
+class KFrag():
 
     def __init__(self,
                  identifier: bytes,

--- a/umbral/kfrags.py
+++ b/umbral/kfrags.py
@@ -134,10 +134,20 @@ class KFrag():
         if params is None:
             params = default_params()
 
-        if delegating_pubkey and delegating_pubkey.params != params:
-            raise ValueError("The delegating key uses different UmbralParameters")
-        if receiving_pubkey and receiving_pubkey.params != params:
-            raise ValueError("The receiving key uses different UmbralParameters")
+        if signing_pubkey is None:
+            raise ValueError("The verifying pubkey is required to verify this KFrag.")
+
+        if self.delegating_key_in_signature():
+            if delegating_pubkey is None:
+                raise ValueError("The delegating pubkey is required to verify this KFrag.")
+            elif delegating_pubkey.params != params:
+                raise ValueError("The delegating pubkey has different UmbralParameters.")
+
+        if self.receiving_key_in_signature():
+            if receiving_pubkey is None:
+                raise ValueError("The receiving pubkey is required to verify this KFrag.")
+            elif receiving_pubkey.params != params:
+                raise ValueError("The receiving pubkey has different UmbralParameters.")
 
         u = params.u
 
@@ -148,6 +158,7 @@ class KFrag():
 
         #  We check that the commitment is well-formed
         correct_commitment = commitment == key * u
+
         validity_input = [kfrag_id, commitment, precursor, self.keys_in_signature]
 
         if self.delegating_key_in_signature():

--- a/umbral/kfrags.py
+++ b/umbral/kfrags.py
@@ -36,7 +36,7 @@ RECEIVING_ONLY = b'\x02'
 DELEGATING_AND_RECEIVING = b'\x03'
 
 
-class KFrag():
+class KFrag:
 
     def __init__(self,
                  identifier: bytes,

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -20,7 +20,7 @@ along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 from umbral.curve import Curve
 
 
-class UmbralParameters(object):
+class UmbralParameters():
     def __init__(self, curve: Curve) -> None:
         from umbral.point import Point
         from umbral.random_oracles import unsafe_hash_to_point

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -20,7 +20,7 @@ along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 from umbral.curve import Curve
 
 
-class UmbralParameters():
+class UmbralParameters:
     def __init__(self, curve: Curve) -> None:
         from umbral.point import Point
         from umbral.random_oracles import unsafe_hash_to_point

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -27,7 +27,7 @@ from umbral.curve import Curve
 from umbral.curvebn import CurveBN
 
 
-class Point():
+class Point:
     """
     Represents an OpenSSL EC_POINT except more Pythonic
     """

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -27,7 +27,7 @@ from umbral.curve import Curve
 from umbral.curvebn import CurveBN
 
 
-class Point(object):
+class Point():
     """
     Represents an OpenSSL EC_POINT except more Pythonic
     """

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -48,7 +48,7 @@ class UmbralCorrectnessError(GenericUmbralError):
         self.offending_cfrags = offending_cfrags
 
 
-class Capsule():
+class Capsule:
     def __init__(self,
                  params: UmbralParameters,
                  point_e: Point,

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -307,13 +307,18 @@ def generate_kfrags(delegating_privkey: UmbralPrivateKey,
     return kfrags
 
 
-def reencrypt(kfrag: KFrag, capsule: Capsule, provide_proof: bool = True, 
-              metadata: Optional[bytes] = None) -> CapsuleFrag:
+def reencrypt(kfrag: KFrag,
+              capsule: Capsule,
+              provide_proof: bool = True,
+              metadata: Optional[bytes] = None,
+              verify_kfrag: bool = True) -> CapsuleFrag:
 
     if not isinstance(capsule, Capsule) or not capsule.verify():
         raise Capsule.NotValid
-    elif not isinstance(kfrag, KFrag) or not kfrag.verify_for_capsule(capsule):
-        raise KFrag.NotValid
+
+    if verify_kfrag:
+        if not isinstance(kfrag, KFrag) or not kfrag.verify_for_capsule(capsule):
+            raise KFrag.NotValid
 
     rk = kfrag.bn_key
     e1 = rk * capsule.point_e  # type: Any

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -33,7 +33,7 @@ from umbral.point import Point
 from umbral.signing import Signer
 from umbral.curve import Curve
 from umbral.utils import poly_eval, lambda_coeff
-from umbral.random_oracles import kdf, hash_to_curvebn, ExtendedKeccak
+from umbral.random_oracles import kdf, hash_to_curvebn
 
 from constant_sorrow import constants
 
@@ -48,7 +48,7 @@ class UmbralCorrectnessError(GenericUmbralError):
         self.offending_cfrags = offending_cfrags
 
 
-class Capsule(object):
+class Capsule():
     def __init__(self,
                  params: UmbralParameters,
                  point_e: Point,

--- a/umbral/signing.py
+++ b/umbral/signing.py
@@ -22,8 +22,9 @@ from typing import Optional, Type
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.hashes import HashAlgorithm, SHA256
+from cryptography.hazmat.primitives.asymmetric import utils
 from cryptography.hazmat.primitives.asymmetric.ec import ECDSA
-from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
+
 
 from umbral.config import default_curve
 from umbral.curve import Curve
@@ -57,23 +58,29 @@ class Signature:
         curve = curve if curve is not None else default_curve()
         return 2 * curve.group_order_size_in_bytes
 
-    def verify(self, message: bytes, verifying_key: UmbralPublicKey) -> bool:
+    def verify(self, message: bytes,
+               verifying_key: UmbralPublicKey,
+               is_prehashed: bool = False) -> bool:
         """
         Verifies that a message's signature was valid.
 
         :param message: The message to verify
         :param verifying_key: UmbralPublicKey of the signer
-
+        :param is_prehashed: True if the message has been prehashed previously
         :return: True if valid, False if invalid
         """
         cryptography_pub_key = verifying_key.to_cryptography_pubkey()
+        if is_prehashed:
+            signature_algorithm = ECDSA(utils.Prehashed(self.hash_algorithm()))
+        else:
+            signature_algorithm = ECDSA(self.hash_algorithm())
 
         # TODO: Raise error instead of returning boolean
         try:
             cryptography_pub_key.verify(
-                self._der_encoded_bytes(),
-                message,
-                ECDSA(self.hash_algorithm())
+                signature=self._der_encoded_bytes(),
+                data=message,
+                signature_algorithm=signature_algorithm
             )
         except InvalidSignature:
             return False
@@ -86,7 +93,7 @@ class Signature:
                    curve: Optional[Curve] = None) -> 'Signature':
         curve = curve if curve is not None else default_curve()
         if der_encoded:
-            r, s = decode_dss_signature(signature_as_bytes)
+            r, s = utils.decode_dss_signature(signature_as_bytes)
         else:
             expected_len = cls.expected_bytes_length(curve)
             if not len(signature_as_bytes) == expected_len:
@@ -99,7 +106,7 @@ class Signature:
         return cls(CurveBN.from_int(r, curve), CurveBN.from_int(s, curve))
 
     def _der_encoded_bytes(self) -> bytes:
-        return encode_dss_signature(int(self.r), int(self.s))
+        return utils.encode_dss_signature(int(self.r), int(self.s))
 
     def __bytes__(self) -> bytes:
         return self.r.to_bytes() + self.s.to_bytes()
@@ -129,13 +136,18 @@ class Signer:
         self.curve = private_key.params.curve
         self.hash_algorithm = hash_algorithm
 
-    def __call__(self, message: bytes) -> Signature:
+    def __call__(self, message: bytes, is_prehashed: bool = False) -> Signature:
         """
          Signs the message with this instance's private key.
 
          :param message: Message to hash and sign
+         :param is_prehashed: True if the message has been prehashed previously
          :return: signature
          """
-        signature_algorithm = ECDSA(self.hash_algorithm())
+        if is_prehashed:
+            signature_algorithm = ECDSA(utils.Prehashed(self.hash_algorithm()))
+        else:
+            signature_algorithm = ECDSA(self.hash_algorithm())
+
         signature_der_bytes = self.__cryptography_private_key.sign(message, signature_algorithm)
         return Signature.from_bytes(signature_der_bytes, der_encoded=True, curve=self.curve)


### PR DESCRIPTION
Assorted improvements:
- Validation of KFrags is now optional when re-encrypting (although the default remains to be to validate always). This can be useful in scenarios where the re-encrypting node ("Ursula") has already verified the KFrag (which is a reasonable assumption) and she can be sure that this KFrag hasn't changed.
- Module `umbral.signing` allows to sign and verify prehashed messages.
- Introduces badges in the README.
- Improvement of the CI build time.
- Closes #227.
