### PR TITLE
Update to the README and Docs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,12 +27,13 @@ mypy = "*"
 monkeytype = "*"
 coverage = "*"
 codecov = "*"
-# Docs
-sphinx = "*"
-sphinx-autobuild = "*"
 # Testing libraries
 hypothesis = "*"
 nbval = "*"
+# Docs
+sphinx = "*"
+sphinx-autobuild = "*"
+sphinx_rtd_theme = "*"
 # Overrides vulnerable versions allowed by codecov and sphinx:
 requests = ">=2.20.0"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "af0ab7cea3eeea93fee14c6f5dc49694467b7394ee2c6be9f8f9e9c016091ece"
+            "sha256": "60c034332445dc29a4f621268c67609c5efb4b0d76ee7fa586ea8436cf70866a"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -31,80 +31,69 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
-                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
-                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
-                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
-                "sha256:3bb6bd7266598f318063e584378b8e27c67de998a43362e8fce664c54ee52d30",
-                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
-                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
-                "sha256:495c5c2d43bf6cebe0178eb3e88f9c4aa48d8934aa6e3cddb865c058da76756b",
-                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
-                "sha256:57b2533356cb2d8fac1555815929f7f5f14d68ac77b085d2326b571310f34f6e",
-                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
-                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
-                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
-                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
-                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
-                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
-                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
-                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
-                "sha256:a6a5cb8809091ec9ac03edde9304b3ad82ad4466333432b16d78ef40e0cce0d5",
-                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
-                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
-                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
-                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
-                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
-                "sha256:ca1bd81f40adc59011f58159e4aa6445fc585a32bb8ac9badf7a2c1aa23822f2",
-                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
-                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
-                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
-                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
-                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
-                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
-                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
+                "sha256:0b5f895714a7a9905148fc51978c62e8a6cbcace30904d39dcd0d9e2265bb2f6",
+                "sha256:27cdc7ba35ee6aa443271d11583b50815c4bb52be89a909d0028e86c21961709",
+                "sha256:2d4a38049ea93d5ce3c7659210393524c1efc3efafa151bd85d196fa98fce50a",
+                "sha256:3262573d0d60fc6b9d0e0e6e666db0e5045cbe8a531779aa0deb3b425ec5a282",
+                "sha256:358e96cfffc185ab8f6e7e425c7bb028931ed08d65402fbcf3f4e1bff6e66556",
+                "sha256:37c7db824b5687fbd7ea5519acfd054c905951acc53503547c86be3db0580134",
+                "sha256:39b9554dfe60f878e0c6ff8a460708db6e1b1c9cc6da2c74df2955adf83e355d",
+                "sha256:42b96a77acf8b2d06821600fa87c208046decc13bd22a4a0e65c5c973443e0da",
+                "sha256:5b37dde5035d3c219324cac0e69d96495970977f310b306fa2df5910e1f329a1",
+                "sha256:5d35819f5566d0dd254f273d60cf4a2dcdd3ae3003dfd412d40b3fe8ffd87509",
+                "sha256:5df73aa465e53549bd03c819c1bc69fb85529a5e1a693b7b6cb64408dd3970d1",
+                "sha256:7075b361f7a4d0d4165439992d0b8a3cdfad1f302bf246ed9308a2e33b046bd3",
+                "sha256:7678b5a667b0381c173abe530d7bdb0e6e3b98e062490618f04b80ca62686d96",
+                "sha256:7dfd996192ff8a535458c17f22ff5eb78b83504c34d10eefac0c77b1322609e2",
+                "sha256:8a3be5d31d02c60f84c4fd4c98c5e3a97b49f32e16861367f67c49425f955b28",
+                "sha256:9812e53369c469506b123aee9dcb56d50c82fad60c5df87feb5ff59af5b5f55c",
+                "sha256:9b6f7ba4e78c52c1a291d0c0c0bd745d19adde1a9e1c03cb899f0c6efd6f8033",
+                "sha256:a85bc1d7c3bba89b3d8c892bc0458de504f8b3bcca18892e6ed15b5f7a52ad9d",
+                "sha256:aa6b9c843ad645ebb12616de848cc4e25a40f633ccc293c3c9fe34107c02c2ea",
+                "sha256:bae1aa56ee00746798beafe486daa7cfb586cd395c6ce822ba3068e48d761bc0",
+                "sha256:bae96e26510e4825d5910a196bf6b5a11a18b87d9278db6d08413be8ea799469",
+                "sha256:bd78df3b594013b227bf31d0301566dc50ba6f40df38a70ded731d5a8f2cb071",
+                "sha256:c2711197154f46d06f73542c539a0ff5411f1951fab391e0a4ac8359badef719",
+                "sha256:d998c20e3deed234fca993fd6c8314cb7cbfda05fd170f1bd75bb5d7421c3c5a",
+                "sha256:df4f840d77d9e37136f8e6b432fecc9d6b8730f18f896e90628712c793466ce6",
+                "sha256:f5653c2581acb038319e6705d4e3593677676df14b112f13e0b5b44b6a18df1a",
+                "sha256:f7c7aa485a2e2250d455148470ffd0195eecc3d845122635202d7467d6f7b4cf",
+                "sha256:f9e2c66a6493147de835f207f198540a56b26745ce4f272fbc7c2f2cfebeb729"
             ],
-            "version": "==1.11.5"
+            "version": "==1.12.1"
         },
         "constant-sorrow": {
             "hashes": [
-                "sha256:b801391bcadfdd92e1212caab133544d60ea36ae5e2948b48b12de23e69c7baa",
-                "sha256:d0190c05bc8465e91591bf017661869e0315aae5f8b9f64fa52b86d2cd060699"
+                "sha256:0ab5ddacde6484e986703a523b721517b7230e395d2bfddea5eced7153acbf9c",
+                "sha256:8ff487bbc15d4ddcae7f0f745c56494f4267e90b20b19102d81b390803e14ded"
             ],
             "index": "pypi",
-            "version": "==0.1.0a7"
+            "version": "==0.1.0a8"
         },
         "cryptography": {
             "hashes": [
-                "sha256:05a6052c6a9f17ff78ba78f8e6eb1d777d25db3b763343a1ae89a7a8670386dd",
-                "sha256:0eb83a24c650a36f68e31a6d0a70f7ad9c358fa2506dc7b683398b92e354a038",
-                "sha256:0ff4a3d6ea86aa0c9e06e92a9f986de7ee8231f36c4da1b31c61a7e692ef3378",
-                "sha256:1699f3e916981df32afdd014fb3164db28cdb61c757029f502cb0a8c29b2fdb3",
-                "sha256:1b1f136d74f411f587b07c076149c4436a169dc19532e587460d9ced24adcc13",
-                "sha256:21e63dd20f5e5455e8b34179ac43d95b3fb1ffa54d071fd2ed5d67da82cfe6dc",
-                "sha256:2454ada8209bbde97065453a6ca488884bbb263e623d35ba183821317a58b46f",
-                "sha256:3cdc5f7ca057b2214ce4569e01b0f368b3de9d8ee01887557755ccd1c15d9427",
-                "sha256:418e7a5ec02a7056d3a4f0c0e7ea81df374205f25f4720bb0e84189aa5fd2515",
-                "sha256:471a097076a7c4ab85561d7fa9a1239bd2ae1f9fd0047520f13d8b340bf3210b",
-                "sha256:5ecaf9e7db3ca582c6de6229525d35db8a4e59dc3e8a40a331674ed90e658cbf",
-                "sha256:63b064a074f8dc61be81449796e2c3f4e308b6eba04a241a5c9f2d05e882c681",
-                "sha256:6afe324dfe6074822ccd56d80420df750e19ac30a4e56c925746c735cf22ae8b",
-                "sha256:70596e90398574b77929cd87e1ac6e43edd0e29ba01e1365fed9c26bde295aa5",
-                "sha256:70c2b04e905d3f72e2ba12c58a590817128dfca08949173faa19a42c824efa0b",
-                "sha256:8908f1db90be48b060888e9c96a0dee9d842765ce9594ff6a23da61086116bb6",
-                "sha256:af12dfc9874ac27ebe57fc28c8df0e8afa11f2a1025566476b0d50cdb8884f70",
-                "sha256:b4fc04326b2d259ddd59ed8ea20405d2e695486ab4c5e1e49b025c484845206e",
-                "sha256:da5b5dda4aa0d5e2b758cc8dfc67f8d4212e88ea9caad5f61ba132f948bab859"
+                "sha256:05b3ded5e88747d28ee3ef493f2b92cbb947c1e45cf98cfef22e6d38bb67d4af",
+                "sha256:06826e7f72d1770e186e9c90e76b4f84d90cdb917b47ff88d8dc59a7b10e2b1e",
+                "sha256:08b753df3672b7066e74376f42ce8fc4683e4fd1358d34c80f502e939ee944d2",
+                "sha256:2cd29bd1911782baaee890544c653bb03ec7d95ebeb144d714b0f5c33deb55c7",
+                "sha256:31e5637e9036d966824edaa91bf0aa39dc6f525a1c599f39fd5c50340264e079",
+                "sha256:42fad67d7072216a49e34f923d8cbda9edacbf6633b19a79655e88a1b4857063",
+                "sha256:4946b67235b9d2ea7d31307be9d5ad5959d6c4a8f98f900157b47abddf698401",
+                "sha256:522fdb2809603ee97a4d0ef2f8d617bc791eb483313ba307cb9c0a773e5e5695",
+                "sha256:6f841c7272645dd7c65b07b7108adfa8af0aaea57f27b7f59e01d41f75444c85",
+                "sha256:7d335e35306af5b9bc0560ca39f740dfc8def72749645e193dd35be11fb323b3",
+                "sha256:8504661ffe324837f5c4607347eeee4cf0fcad689163c6e9c8d3b18cf1f4a4ad",
+                "sha256:9260b201ce584d7825d900c88700aa0bd6b40d4ebac7b213857bd2babee9dbca",
+                "sha256:9a30384cc402eac099210ab9b8801b2ae21e591831253883decdb4513b77a3cd",
+                "sha256:9e29af877c29338f0cab5f049ccc8bd3ead289a557f144376c4fbc7d1b98914f",
+                "sha256:ab50da871bc109b2d9389259aac269dd1b7c7413ee02d06fe4e486ed26882159",
+                "sha256:b13c80b877e73bcb6f012813c6f4a9334fcf4b0e96681c5a15dac578f2eedfa0",
+                "sha256:bfe66b577a7118e05b04141f0f1ed0959552d45672aa7ecb3d91e319d846001e",
+                "sha256:e091bd424567efa4b9d94287a952597c05d22155a13716bf5f9f746b9dc906d3",
+                "sha256:fa2b38c8519c5a3aa6e2b4e1cf1a549b54acda6adb25397ff542068e73d1ed00"
             ],
             "index": "pypi",
-            "version": "==2.4.2"
-        },
-        "idna": {
-            "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
-            ],
-            "version": "==2.8"
+            "version": "==2.5"
         },
         "msgpack-python": {
             "hashes": [
@@ -203,10 +192,10 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
-                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
             ],
-            "version": "==1.2.1"
+            "version": "==1.3.0"
         },
         "attrs": {
             "hashes": [
@@ -303,10 +292,10 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:2c51dff8ef3c447388fe5e4453d24a2bf128d3a4c32af3fabef1f01c6851ab82",
-                "sha256:c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c"
+                "sha256:33cd704aea07b4c28b3eb2c97d288a06918275dac0ecebdaf1bc8a48d98adb9e",
+                "sha256:cabb249f4710888a2fc0e13e9a16c343d932033718ff62e1e9bc93a9d3a9122b"
             ],
-            "version": "==4.3.0"
+            "version": "==4.3.2"
         },
         "docutils": {
             "hashes": [
@@ -318,12 +307,12 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:bf5b5473eb363fa99e3d887cfb6b06a30bdcb2d1ece25499b393f8086aab4747",
-                "sha256:ce3c0a01997a4b092b7e3cd4ec235d66a56cddc4b81d7b7072fc64d4258b0f63",
-                "sha256:e82583c81e85a6a064ead04554e759d45dd7c201de30637ccecf4f94cbbb51a7"
+                "sha256:7f97f984d45f22b8895ee4d98c7f48e7ebc2c2fbf9d5ce07dad77989997821f6",
+                "sha256:cb8c89295c36db0014409c8d7c897094f538cb880a25e3dc3e86fb768787a03d",
+                "sha256:e83442d2f74ceb1d166e351308810b394802fd9758c3b89ae36ca8daadac9fd4"
             ],
             "index": "pypi",
-            "version": "==3.82.5"
+            "version": "==4.6.1"
         },
         "idna": {
             "hashes": [
@@ -348,10 +337,10 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:6a9496209b76463f1dec126ab928919aaf1f55b38beb9219af3fe202f6bbdd12",
-                "sha256:f69932b1e806b38a7818d9a1e918e5821b685715040b48e59c657b3c7961b742"
+                "sha256:06de667a9e406924f97781bda22d5d76bfb39762b678762d86a466e63f65dc39",
+                "sha256:5d3e020a6b5f29df037555e5c45ab1088d6a7cf3bd84f47e0ba501eeb0c3ec82"
             ],
-            "version": "==7.2.0"
+            "version": "==7.3.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -362,10 +351,10 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:0191c447165f798e6a730285f2eee783fff81b0d3df261945ecb80983b5c3ca7",
-                "sha256:b7493f73a2febe0dc33d51c99b474547f7f6c0b2c8fb2b21f453eef204c12148"
+                "sha256:571702b5bd167911fe9036e5039ba67f820d6502832285cde8c881ab2b2149fd",
+                "sha256:c8481b5e59d34a5c7c42e98f6625e633f6ef59353abea6437472c7ec2093f191"
             ],
-            "version": "==0.13.1"
+            "version": "==0.13.2"
         },
         "jinja2": {
             "hashes": [
@@ -376,10 +365,10 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:3ae8afd6f4ca6417f14bf43ef61341311598f14234cdb4174fe43d42b236a3c8",
-                "sha256:dfd8426040892c8d0ef6da574085f282569f189cb24b70091a66c21c12d6705e"
+                "sha256:683fe7ed58763ea0be572de5aad47cd3cc1297640916f9a8ccd222b287da7d2f",
+                "sha256:b42d7a292addb57370e6260bcbadb77e00a899fe6ec998c453f45893c41c658b"
             ],
-            "version": "==3.0.0a3"
+            "version": "==3.0.0b3"
         },
         "jupyter-client": {
             "hashes": [
@@ -445,27 +434,27 @@
         },
         "monkeytype": {
             "hashes": [
-                "sha256:96c8c432059fea74a551fd79a69a3266585cb18d2155359e0ac41e0f67d9b353",
-                "sha256:e2f7517c6c6375e90da67027a5ed57e6ccb518bcb95cfc1a08e8e26b8e25f6ea"
+                "sha256:baeeee422c17202038ccf17ca73eb97eddb65a4178a215c1ff212cfb7373eb65",
+                "sha256:ecee4162a153c8a0d2151dfc66f06ebb82e4582b0d46281798d908888bb0c9b9"
             ],
             "index": "pypi",
-            "version": "==18.2.0"
+            "version": "==19.1.1"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
-                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
+                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
             ],
-            "version": "==4.3.0"
+            "markers": "python_version > '2.7'",
+            "version": "==6.0.0"
         },
         "mypy": {
             "hashes": [
-                "sha256:12d965c9c4e8a625673aec493162cf390e66de12ef176b1f4821ac00d55f3ab3",
-                "sha256:38d5b5f835a81817dcc0af8d155bce4e9aefa03794fe32ed154d6612e83feafa"
+                "sha256:308c274eb8482fbf16006f549137ddc0d69e5a589465e37b99c4564414363ca7",
+                "sha256:e80fd6af34614a0e898a57f14296d0dacb584648f0339c2e000ddbf0f4cc2f8d"
             ],
             "index": "pypi",
-            "version": "==0.650"
+            "version": "==0.670"
         },
         "mypy-extensions": {
             "hashes": [
@@ -491,25 +480,17 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:0886227f54515e592aaa2e5a553332c73962917f2831f1b0f9b9f4380a4b9807",
-                "sha256:f95a1e147590f204328170981833854229bb2912ac3d5f89e2a8ccd2834800c9"
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
             ],
-            "version": "==18.0"
+            "version": "==19.0"
         },
         "parso": {
             "hashes": [
-                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
-                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
+                "sha256:4580328ae3f548b358f4901e38c0578229186835f0fa0846e47369796dd5bcc9",
+                "sha256:68406ebd7eafe17f8e40e15a84b56848eccbf27d7c1feb89e93d8fca395706db"
             ],
-            "version": "==0.3.1"
-        },
-        "pathlib2": {
-            "hashes": [
-                "sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742",
-                "sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
-            ],
-            "markers": "python_version < '3.6'",
-            "version": "==2.3.3"
+            "version": "==0.3.4"
         },
         "pathtools": {
             "hashes": [
@@ -519,10 +500,10 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68",
-                "sha256:f6d5b23f226a2ba58e14e49aa3b1bfaf814d0199144b95d78458212444de1387"
+                "sha256:a7953f66e1f82e4b061f43096a4bcc058f7d3d41de9b94ac871770e8bdd831a2",
+                "sha256:d717573351cfe09f49df61906cd272abaa759b3e91744396b804965ff7bff38b"
             ],
-            "version": "==5.1.1"
+            "version": "==5.1.2"
         },
         "pexpect": {
             "hashes": [
@@ -541,10 +522,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
-                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
+                "sha256:8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616",
+                "sha256:980710797ff6a041e9a73a5787804f848996ecaa6f8a1b1e08224a5894f2074a"
             ],
-            "version": "==0.8.0"
+            "version": "==0.8.1"
         },
         "port-for": {
             "hashes": [
@@ -554,11 +535,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:c1d6aff5252ab2ef391c2fe498ed8c088066f66bc64a8d5c095bbf795d9fec34",
-                "sha256:d4c47f79b635a0e70b84fdb97ebd9a274203706b1ee5ed44c10da62755cf3ec9",
-                "sha256:fd17048d8335c1e6d5ee403c3569953ba3eb8555d710bfc548faf0712666ea39"
+                "sha256:11adf3389a996a6d45cc277580d0d53e8a5afd281d0c9ec71b28e6f121463780",
+                "sha256:2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1",
+                "sha256:977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55"
             ],
-            "version": "==2.0.7"
+            "version": "==2.0.9"
         },
         "ptyprocess": {
             "hashes": [
@@ -596,58 +577,58 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:6301ecb0997a52d2d31385e62d0a4a4cf18d2f2da7054a5ddad5c366cd39cee7",
-                "sha256:82666aac15622bd7bb685a4ee7f6625dd716da3ef7473620c192c0168aae64fc"
+                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
+                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
             ],
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b",
-                "sha256:f353aab21fd474459d97b709e527b5571314ee5f067441dc9f88e33eecd96592"
+                "sha256:66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a",
+                "sha256:f6c5ef0d7480ad048c054c37632c67fca55299990fff127850181659eea33fc3"
             ],
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "pyrsistent": {
             "hashes": [
-                "sha256:05910b7ff43cec0a853c15da0bfaf2867faa95f29b08e71f5846a195f1f38c75"
+                "sha256:07f7ae71291af8b0dbad8c2ab630d8223e4a8c4e10fc37badda158c02e753acf"
             ],
-            "version": "==0.14.7"
+            "version": "==0.14.10"
         },
         "pytest": {
             "hashes": [
-                "sha256:3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec",
-                "sha256:e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"
+                "sha256:067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c",
+                "sha256:9687049d53695ad45cf5fdc7bbd51f0c49f1ea3ecfc4b7f3fde7501b541f17f4"
             ],
             "index": "pypi",
-            "version": "==3.10.1"
+            "version": "==4.3.0"
         },
         "pytest-benchmark": {
             "extras": [
                 "histogram"
             ],
             "hashes": [
-                "sha256:185526b10b7cf1804cb0f32ac0653561ef2f233c6e50a9b3d8066a9757e36480",
-                "sha256:3549545f1a051a789d956a4a9b176583cd6b847e621b788471e6c04b7d8d0e3c"
+                "sha256:4512c6805318d07926efcb3b39f7b98a10d035305a93edfd5329c86cbf9cfbf7",
+                "sha256:ab851115ce022639173b9497d4a4183a1d8fe9cdcf8fab9d8a57607008aedd3d"
             ],
             "index": "pypi",
-            "version": "==3.1.1"
+            "version": "==3.2.2"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:513c425e931a0344944f84ea47f3956be0e416d95acbd897a44970c8d926d5d7",
-                "sha256:e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762"
+                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33",
+                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"
             ],
             "index": "pypi",
-            "version": "==2.6.0"
+            "version": "==2.6.1"
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:53801e621223d34724926a5c98bd90e8e417ce35264365d39d6c896388dcc928",
-                "sha256:d89a8209d722b8307b5e351496830d5cc5e192336003a485443ae9adeb7dd4c0"
+                "sha256:4d0d06d173eecf172703219a71dbd4ade0e13904e6bbce1ce660e2e0dc78b5c4",
+                "sha256:bfdf02789e3d197bd682a758cae0a4a18706566395fbe2803badcd1335e0173e"
             ],
             "index": "pypi",
-            "version": "==1.10.0"
+            "version": "==1.10.1"
         },
         "pytest-mypy": {
             "hashes": [
@@ -659,17 +640,17 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
-            "version": "==2.7.5"
+            "version": "==2.8.0"
         },
         "pytz": {
             "hashes": [
-                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
-                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
             ],
-            "version": "==2018.7"
+            "version": "==2018.9"
         },
         "pyyaml": {
             "hashes": [
@@ -683,33 +664,33 @@
         },
         "pyzmq": {
             "hashes": [
-                "sha256:25a0715c8f69cf72f67cfe5a68a3f3ed391c67c063d2257bec0fe7fc2c7f08f8",
-                "sha256:2bab63759632c6b9e0d5bf19cc63c3b01df267d660e0abcf230cf0afaa966349",
-                "sha256:30ab49d99b24bf0908ebe1cdfa421720bfab6f93174e4883075b7ff38cc555ba",
-                "sha256:32c7ca9fc547a91e3c26fc6080b6982e46e79819e706eb414dd78f635a65d946",
-                "sha256:41219ae72b3cc86d97557fe5b1ef5d1adc1057292ec597b50050874a970a39cf",
-                "sha256:4b8c48a9a13cea8f1f16622f9bd46127108af14cd26150461e3eab71e0de3e46",
-                "sha256:55724997b4a929c0d01b43c95051318e26ddbae23565018e138ae2dc60187e59",
-                "sha256:65f0a4afae59d4fc0aad54a917ab599162613a761b760ba167d66cc646ac3786",
-                "sha256:6f88591a8b246f5c285ee6ce5c1bf4f6bd8464b7f090b1333a446b6240a68d40",
-                "sha256:75022a4c60dcd8765bb9ca32f6de75a0ec83b0d96e0309dc479f4c7b21f26cb7",
-                "sha256:76ea493bfab18dcb090d825f3662b5612e2def73dffc196d51a5194b0294a81d",
-                "sha256:7b60c045b80709e4e3c085bab9b691e71761b44c2b42dbb047b8b498e7bc16b3",
-                "sha256:8e6af2f736734aef8ed6f278f9f552ec7f37b1a6b98e59b887484a840757f67d",
-                "sha256:9ac2298e486524331e26390eac14e4627effd3f8e001d4266ed9d8f1d2d31cce",
-                "sha256:9ba650f493a9bc1f24feca1d90fce0e5dd41088a252ac9840131dfbdbf3815ca",
-                "sha256:a02a4a385e394e46012dc83d2e8fd6523f039bb52997c1c34a2e0dd49ed839c1",
-                "sha256:a3ceee84114d9f5711fa0f4db9c652af0e4636c89eabc9b7f03a3882569dd1ed",
-                "sha256:a72b82ac1910f2cf61a49139f4974f994984475f771b0faa730839607eeedddf",
-                "sha256:ab136ac51027e7c484c53138a0fab4a8a51e80d05162eb7b1585583bcfdbad27",
-                "sha256:c095b224300bcac61e6c445e27f9046981b1ac20d891b2f1714da89d34c637c8",
-                "sha256:c5cc52d16c06dc2521340d69adda78a8e1031705924e103c0eb8fc8af861d810",
-                "sha256:d612e9833a89e8177f8c1dc68d7b4ff98d3186cd331acd616b01bbdab67d3a7b",
-                "sha256:e828376a23c66c6fe90dcea24b4b72cd774f555a6ee94081670872918df87a19",
-                "sha256:e9767c7ab2eb552796440168d5c6e23a99ecaade08dda16266d43ad461730192",
-                "sha256:ebf8b800d42d217e4710d1582b0c8bff20cdcb4faad7c7213e52644034300924"
+                "sha256:07a03450418694fb07e76a0191b6bc9f411afc8e364ca2062edcf28bb0e51c63",
+                "sha256:15f0bf7cd80020f165635595e197603aedb37fddf4164ad5ae226afc43242f7b",
+                "sha256:1756dc72e192c670490e38c788c3a35f901adc74ee436e5131d5a3e85fdd7dc6",
+                "sha256:1d1eb490da54679d724b08ef3ee04530849023670c4ba7e400ed2cdf906720c4",
+                "sha256:228402625796821f08706f58cc42a3c51c9897d723550babaefe4feec2b6dacc",
+                "sha256:264ac9dcee6a7af2bce4b61f2d19e5926118a5caa629b50f107ef6318670a364",
+                "sha256:2b5a43da65f5dec857184d5c2ce13b80071019e96358f146bdecff7238765bc9",
+                "sha256:3928534fa00a2aabfcfdb439c08ba37fbe99ab0cf57776c8db8d2b73a51693ba",
+                "sha256:3d2a295b1086d450981f73d3561ac204a0cc9c8ded386a4a34327d918f3b1d0a",
+                "sha256:411def5b4cbe6111856040a55c8048df113882e90c57ce88de4a48f0189441ac",
+                "sha256:4b77e96a7ffc1c5e08eaf274db554f227b31717d086adca1bb42b12ef35a7194",
+                "sha256:4c87fa3e449e1f4ab9170cdfe8213dc0ba34a11b160e6adecafa892e451a29b6",
+                "sha256:4fd8621a309db6ec23ef1369f43cdf7a9b0dc217d8ff9ca4095a6e932b379bda",
+                "sha256:54fe55a1694ffe608c8e4c5183e83cab7a91f3e5c84bd6f188868d6676c12aba",
+                "sha256:60acabd86808a16a895a247fd2bf7a127284a33562d79687bb5df163cff068b2",
+                "sha256:618887be4ad754228c0cbba7631f6574608b4430fe93974e6322324f1304fdac",
+                "sha256:69130efb6efa936de601cb135a8a4eec1caccd4ea2b784237145ff4075c2d3ae",
+                "sha256:6e7f78eeac82140bde7e60e975c6e6b1b678a4dd377782ab63319c1c78bf3aa1",
+                "sha256:6ee760cdb84e43574da6b3f2f1fc1251e8acf87253900d28a06451c5f5de39e9",
+                "sha256:75c87f1dc1e65cea4b709f2ebc78fa18d4b475e41463502aec9cd26208b88e0f",
+                "sha256:97cb1b7cd2c46e87b0a26651eccd2bbb8c758035efd1635ebb81ac36aa76a88c",
+                "sha256:abfa774dbadacc849121ed92eae05189d226daab583388b499472e1bbb17ef69",
+                "sha256:ae3d2627d74195ddc95675f2f814aca998381b73dc4341b9e10e3e191e1bdb0b",
+                "sha256:b30c339eb58355f51f4f54dd61d785f1ff58c86bca1c3a5916977631d121867b",
+                "sha256:cbabdced5b137cd56aa22633f13ac5690029a0ad43ab6c05f53206e489178362"
             ],
-            "version": "==17.1.2"
+            "version": "==18.0.0"
         },
         "requests": {
             "hashes": [
@@ -742,11 +723,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:120732cbddb1b2364471c3d9f8bfd4b0c5b550862f99a65736c77f970b142aea",
-                "sha256:b348790776490894e0424101af9c8413f2a86831524bd55c5f379d3e3e12ca64"
+                "sha256:230af939a2f678ab4f2a0a948c3b24a822a0d280821859caaefb750ef7413003",
+                "sha256:835c701420102a0a71ba2ed54a5bada2da6fd01263bf6dc8c5c80c798e27709c"
             ],
             "index": "pypi",
-            "version": "==1.8.2"
+            "version": "==2.0.0b1"
         },
         "sphinx-autobuild": {
             "hashes": [
@@ -756,24 +737,61 @@
             "index": "pypi",
             "version": "==0.7.1"
         },
-        "sphinxcontrib-websupport": {
+        "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
-                "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
+                "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4",
+                "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"
             ],
-            "version": "==1.1.0"
+            "index": "pypi",
+            "version": "==0.4.3"
+        },
+        "sphinxcontrib-applehelp": {
+            "hashes": [
+                "sha256:edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897",
+                "sha256:fb8dee85af95e5c30c91f10e7eb3c8967308518e0f7488a2828ef7bc191d0d5d"
+            ],
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-devhelp": {
+            "hashes": [
+                "sha256:6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34",
+                "sha256:9512ecb00a2b0821a146736b39f7aeb90759834b07e81e8cc23a9c70bacb9981"
+            ],
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-htmlhelp": {
+            "hashes": [
+                "sha256:0d691ca8edf5995fbacfe69b191914256071a94cbad03c3688dca47385c9206c",
+                "sha256:e31c8271f5a8f04b620a500c0442a7d5cfc1a732fa5c10ec363f90fe72af0cb8"
+            ],
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-jsmath": {
+            "hashes": [
+                "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
+                "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
+            ],
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-qthelp": {
+            "hashes": [
+                "sha256:18ec9f74ea2c92fd512d5f3b532d6ab4ac2be76b12cc2490f7729842ba2a60c9",
+                "sha256:f39159b45de6d3d86c30874a3220be4f8e75ed12c71aff50cb8b2cac46e240f0"
+            ],
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-serializinghtml": {
+            "hashes": [
+                "sha256:01d9b2617d7e8ddf7a00cae091f08f9fa4db587cc160b493141ee56710810932",
+                "sha256:392187ac558863b8aff0d76dc78e0731fed58f3b06e2b00e22995dcdb630f213"
+            ],
+            "version": "==1.1.1"
         },
         "tornado": {
             "hashes": [
-                "sha256:0662d28b1ca9f67108c7e3b77afabfb9c7e87bde174fbda78186ecedc2499a9d",
-                "sha256:4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409",
-                "sha256:732e836008c708de2e89a31cb2fa6c0e5a70cb60492bee6f1ea1047500feaf7f",
-                "sha256:8154ec22c450df4e06b35f131adc4f2f3a12ec85981a203301d310abf580500f",
-                "sha256:8e9d728c4579682e837c92fdd98036bd5cdefa1da2aaf6acf26947e6dd0c01c5",
-                "sha256:d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb",
-                "sha256:e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444"
+                "sha256:d3b719a0cb7094e2b1ca94b31f4b601639fa7ad01a548a1a2ccdd6cbdfd56671"
             ],
-            "version": "==5.1.1"
+            "version": "==6.0b1"
         },
         "traitlets": {
             "hashes": [
@@ -784,31 +802,27 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58",
-                "sha256:10703d3cec8dcd9eef5a630a04056bbc898abc19bac5691612acba7d1325b66d",
-                "sha256:1f6c4bd0bdc0f14246fd41262df7dfc018d65bb05f6e16390b7ea26ca454a291",
-                "sha256:25d8feefe27eb0303b73545416b13d108c6067b846b543738a25ff304824ed9a",
-                "sha256:29464a177d56e4e055b5f7b629935af7f49c196be47528cc94e0a7bf83fbc2b9",
-                "sha256:2e214b72168ea0275efd6c884b114ab42e316de3ffa125b267e732ed2abda892",
-                "sha256:3e0d5e48e3a23e9a4d1a9f698e32a542a4a288c871d33ed8df1b092a40f3a0f9",
-                "sha256:519425deca5c2b2bdac49f77b2c5625781abbaf9a809d727d3a5596b30bb4ded",
-                "sha256:57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa",
-                "sha256:668d0cec391d9aed1c6a388b0d5b97cd22e6073eaa5fbaa6d2946603b4871efe",
-                "sha256:68ba70684990f59497680ff90d18e756a47bf4863c604098f10de9716b2c0bdd",
-                "sha256:6de012d2b166fe7a4cdf505eee3aaa12192f7ba365beeefaca4ec10e31241a85",
-                "sha256:79b91ebe5a28d349b6d0d323023350133e927b4de5b651a8aa2db69c761420c6",
-                "sha256:8550177fa5d4c1f09b5e5f524411c44633c80ec69b24e0e98906dd761941ca46",
-                "sha256:898f818399cafcdb93cbbe15fc83a33d05f18e29fb498ddc09b0214cdfc7cd51",
-                "sha256:94b091dc0f19291adcb279a108f5d38de2430411068b219f41b343c03b28fb1f",
-                "sha256:a26863198902cda15ab4503991e8cf1ca874219e0118cbf07c126bce7c4db129",
-                "sha256:a8034021801bc0440f2e027c354b4eafd95891b573e12ff0418dec385c76785c",
-                "sha256:bc978ac17468fe868ee589c795d06777f75496b1ed576d308002c8a5756fb9ea",
-                "sha256:c05b41bc1deade9f90ddc5d988fe506208019ebba9f2578c622516fd201f5863",
-                "sha256:c9b060bd1e5a26ab6e8267fd46fc9e02b54eb15fffb16d112d4c7b1c12987559",
-                "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
-                "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
+                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
+                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
+                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
+                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
+                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
+                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
+                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
+                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
+                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
+                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
+                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
+                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
+                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
+                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
+                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
+                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
+                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
+                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
+                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
             ],
-            "version": "==1.1.0"
+            "version": "==1.3.1"
         },
         "urllib3": {
             "hashes": [

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,6 @@
 =========
 pyUmbral
 =========
-v0.1.3-alpha.0
 
 .. start-badges
 
@@ -40,10 +39,11 @@ v0.1.3-alpha.0
 
 .. end-badges
 
-pyUmbral is a python implementation of David Nuñez's threshold proxy re-encryption scheme: Umbral_.
+pyUmbral is a Python implementation of David Nuñez's threshold proxy re-encryption scheme: Umbral_.
 Implemented with OpenSSL_ and Cryptography.io_, pyUmbral is a referential and open-source cryptography library
 extending the traditional cryptological narrative of "Alice and Bob" by introducing a new actor,
-*Ursula*, who has the ability to take secrets encrypted for Alice and *re-encrypt* them for Bob.
+*Ursula*, who has the ability to take secrets encrypted for Alice and *re-encrypt* them for Bob,
+without being able to learn any information about the original secret.
 
 pyUmbral is the cryptographic engine behind nucypher_,
 a proxy re-encryption network to empower privacy in decentralized systems.
@@ -57,6 +57,9 @@ Usage
 =====
 
 **Key Generation**
+
+As in any public-key cryptosystem, users need a pair of public and private keys.
+Additionally, users that delegate access to their data (like Alice, in this example) need a signing keypair.
 
 .. code-block:: python
 
@@ -77,10 +80,18 @@ Usage
 
 **Encryption**
 
+Now let's encrypt data with Alice's public key.
+Invocation of ``pre.encrypt`` returns both the ``ciphertext`` and a ``capsule``.
+Note that anyone with Alice's public key can perform this operation.
+
+Since data was encrypted with Alice's public key,
+Alice can open the capsule and decrypt the ciphertext with her private key.
+
+
 .. code-block:: python
 
     # Encrypt data with Alice's public key.
-    plaintext = b'Proxy Re-encryption is cool!'
+    plaintext = b'Proxy Re-Encryption is cool!'
     ciphertext, capsule = pre.encrypt(alices_public_key, plaintext)
 
     # Decrypt data with Alice's private key.
@@ -90,6 +101,10 @@ Usage
 
 
 **Re-Encryption Key Fragments**
+
+When Alice wants to grant Bob access to open her encrypted messages,
+she creates *re-encryption key fragments*, or *"kfrags"*,
+which are next sent to N proxies or *Ursulas*.
 
 .. code-block:: python
 
@@ -103,6 +118,13 @@ Usage
 
 
 **Re-Encryption**
+
+Bob asks several Ursulas to re-encrypt the capsule so he can open it.
+Each Ursula performs re-encryption on the capsule using the ``kfrag``
+provided by Alice, obtaining this way a "capsule fragment", or ``cfrag``.
+
+Bob collects the resulting cfrags from several Ursulas.
+Bob must gather at least ``threshold`` cfrags in order to activate the capsule.
 
 .. code-block:: python
 
@@ -120,6 +142,9 @@ Usage
 
 
 **Decryption by Bob**
+
+Finally, Bob activates the capsule by attaching at least ``threshold`` cfrags,
+and then decrypts the re-encrypted ciphertext.
 
 .. code-block:: python
 
@@ -140,7 +165,7 @@ See more detailed usage examples in the docs_ directory.
 Quick Installation
 ==================
 
-To install pyUmbral, simply use `pip`:
+To install pyUmbral, simply use ``pip``:
 
 .. code-block:: bash
 
@@ -148,7 +173,7 @@ To install pyUmbral, simply use `pip`:
 
 
 Alternatively, you can checkout the repo and install it from there. 
-The NuCypher team uses pipenv for managing pyUmbral's dependencies.
+The NuCypher team uses ``pipenv`` for managing pyUmbral's dependencies.
 The recommended installation procedure is as follows:
 
 .. code-block:: bash
@@ -157,9 +182,9 @@ The recommended installation procedure is as follows:
     $ pipenv install
 
 Post-installation, you can activate the project virtual environment
-in your current terminal session by running :bash:`pipenv shell`.
+in your current terminal session by running ``pipenv shell``.
 
-For more information on pipenv, find the official documentation here: https://docs.pipenv.org/.
+For more information on ``pipenv``, find the official documentation here: https://docs.pipenv.org/.
 
 
 Academic Whitepaper

--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,13 @@ Implemented with OpenSSL_ and Cryptography.io_, pyUmbral is a referential and op
 extending the traditional cryptological narrative of "Alice and Bob" by introducing a new actor,
 *Ursula*, who has the ability to take secrets encrypted for Alice and *re-encrypt* them for Bob.
 
+pyUmbral is the cryptographic engine behind nucypher_,
+a proxy re-encryption network to empower privacy in decentralized systems.
+
 .. _Umbral: https://github.com/nucypher/umbral-doc/blob/master/umbral-doc.pdf
 .. _Cryptography.io: https://cryptography.io/en/latest/
 .. _OpenSSL: https://www.openssl.org/
+.. _nucypher: https://github.com/nucypher/nucypher
 
 Usage
 =====

--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,18 @@ pyUmbral
 
 .. end-badges
 
-pyUmbral is a Python implementation of David Nuñez's threshold proxy re-encryption scheme: Umbral_.
-Implemented with OpenSSL_ and Cryptography.io_, pyUmbral is a referential and open-source cryptography library
-extending the traditional cryptological narrative of "Alice and Bob" by introducing a new actor,
-*Ursula*, who has the ability to take secrets encrypted for Alice and *re-encrypt* them for Bob,
-without being able to learn any information about the original secret.
+pyUmbral is the reference implementation of the Umbral_ threshold proxy re-encryption scheme.
+It is open-source, built with Python, and uses OpenSSL_ and Cryptography.io_.
+
+Using Umbral, Alice (the data owner) can *delegate decryption rights* to Bob for
+any ciphertext intended to her, through a re-encryption process performed by a
+set of semi-trusted proxies or *Ursulas*. When a threshold of these proxies
+participate by performing re-encryption, Bob is able to combine these independent
+re-encryptions and decrypt the original message using his private key.
+
+.. image:: https://www.nucypher.com/_next/static/images/umbral-d60f22230f2ac92b56c6e7d84794e5c4.svg
+  :width: 400 px
+  :align: center
 
 pyUmbral is the cryptographic engine behind nucypher_,
 a proxy re-encryption network to empower privacy in decentralized systems.
@@ -186,7 +193,7 @@ The Umbral scheme academic whitepaper and cryptographic specifications
 are available on GitHub_.
 
   "Umbral: A Threshold Proxy Re-Encryption Scheme"
-  *by David Nuñez*
+  *by David Nuñez*.
   https://github.com/nucypher/umbral-doc/blob/master/umbral-doc.pdf
 
 .. _GitHub: https://github.com/nucypher/umbral-doc/

--- a/README.rst
+++ b/README.rst
@@ -7,15 +7,7 @@ pyUmbral
 
 .. start-badges
 
-.. list-table::
-    :stub-columns: 1
-
-    * - info
-      - |docs| |discord|
-    * - tests
-      - | |circleci|
-    * - package
-      - | |version| |commits-since|
+|version|  |circleci| |commits-since| |docs| |discord|
 
 .. |docs| image:: https://readthedocs.org/projects/pyumbral/badge/?style=flat
     :target: https://readthedocs.org/projects/pyumbral

--- a/docs/examples/umbral_simple_api.py
+++ b/docs/examples/umbral_simple_api.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/docs/source/choosing_and_using_curves.rst
+++ b/docs/source/choosing_and_using_curves.rst
@@ -6,8 +6,10 @@ Choosing and Using Curves
 The matter of which curve to use is the subject of some debate.  If you aren't sure, you might start here:
 https://safecurves.cr.yp.to/
 
-A number of curves are available in the python cryptography library, on which pyumbral depends.
-You can find them in cryptography.hazmat.primitives.asymmetric.ec.
+A number of curves are available in the Cryptography.io_ library, on which pyUmbral depends.
+You can find them in the ``cryptography.hazmat.primitives.asymmetric.ec`` module.
+
+.. _Cryptography.io: https://cryptography.io/en/latest/
 
 Be careful when choosing a curve - the security of your application depends on it.
 
@@ -39,7 +41,7 @@ operation.  This causes a small one-time performance penalty.
     Set a default curve with umbral.config.set_default_curve().
 
 
-To use SECP256K1 and avoid this penalty, you can simply call `set_default_curve()` with no argument:
+To use SECP256K1 and avoid this penalty, you can simply call ``set_default_curve()`` with no argument:
 
 
 .. code-block:: python
@@ -47,7 +49,7 @@ To use SECP256K1 and avoid this penalty, you can simply call `set_default_curve(
     >>> config.set_default_curve()
 
 Attempting to set the default curve twice in the same runtime will raise
-a `UmbralConfigurationError`.
+a ``UmbralConfigurationError``.
 
 
 .. code-block:: python

--- a/docs/source/choosing_and_using_curves.rst
+++ b/docs/source/choosing_and_using_curves.rst
@@ -13,8 +13,9 @@ You can find them in the ``cryptography.hazmat.primitives.asymmetric.ec`` module
 
 Be careful when choosing a curve - the security of your application depends on it.
 
-We provide SECP256K1 as a default because it is the basis for a number of crypto-blockchain projects;
+We provide curve ``SECP256K1`` as a default because it is the basis for a number of crypto-blockchain projects;
 we don't otherwise endorse its security.
+We additionally support curves ``SECP256R1`` (also known as "NIST P-256") and ``SECP384R1`` ("NIST P-384").
 
 
 Setting a default curve

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,7 +78,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,8 @@
 # -- Project information -----------------------------------------------------
 
 project = 'pyUmbral'
-copyright = '2018, Michael Egorov, Justin Myles Holmes, David Nuñez, John Pacific, Kieran Prasch'
-author = 'Michael Egorov, Justin Myles Holmes, David Nuñez, John Pacific, Kieran Prasch'
+copyright = u'2018, Michael Egorov, Justin Myles Holmes, David Nuñez, John Pacific, Kieran Prasch'
+author = u'Michael Egorov, Justin Myles Holmes, David Nuñez, John Pacific, Kieran Prasch'
 
 # The short X.Y version
 version = '0.1'
@@ -133,7 +133,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'pyUmbral.tex', 'pyUmbral Documentation',
-     'Michael Egorov, Justin Myles Holmes, David Nuñez, John Pacific, Kieran Prasch', 'manual'),
+     u'Michael Egorov, Justin Myles Holmes, David Nuñez, John Pacific, Kieran Prasch', 'manual'),
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'pyUmbral'
-copyright = u'2018, Michael Egorov, Justin Myles Holmes, David Nuñez, John Pacific, Kieran Prasch'
+copyright = u'2019, Michael Egorov, Justin Myles Holmes, David Nuñez, John Pacific, Kieran Prasch'
 author = u'Michael Egorov, Justin Myles Holmes, David Nuñez, John Pacific, Kieran Prasch'
 
 # The short X.Y version

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,19 +4,53 @@
 ========
 pyUmbral
 ========
-v0.1.3-alpha.0
+.. start-badges
 
-.. image:: https://circleci.com/gh/nucypher/pyUmbral/tree/master.svg?style=svg
+.. list-table::
+    :stub-columns: 1
+
+    * - info
+      - |docs| |discord|
+    * - tests
+      - | |circleci|
+    * - package
+      - | |version| |commits-since|
+
+.. |docs| image:: https://readthedocs.org/projects/pyumbral/badge/?style=flat
+    :target: https://readthedocs.org/projects/pyumbral
+    :alt: Documentation Status
+
+.. |discord| image:: https://img.shields.io/discord/411401661714792449.svg?logo=discord
+    :target: https://discord.gg/xYqyEby
+    :alt: Discord
+
+.. |circleci| image:: https://img.shields.io/circleci/project/github/nucypher/pyUmbral.svg?logo=circleci
     :target: https://circleci.com/gh/nucypher/pyUmbral/tree/master
+    :alt: CircleCI build status
 
-pyUmbral is a python implementation of David Nuñez's threshold proxy rencryption scheme: Umbral_.
+.. |version| image:: https://img.shields.io/pypi/v/umbral.svg
+    :alt: PyPI Package latest release
+    :target: https://pypi.org/project/umbral
+
+.. |commits-since| image:: https://img.shields.io/github/commits-since/nucypher/pyumbral/v0.1.3-alpha.0.svg
+    :alt: Commits since latest release
+    :target: https://github.com/nucypher/pyUmbral/compare/v0.1.3-alpha.0...master
+
+.. end-badges
+
+pyUmbral is a Python implementation of David Nuñez's threshold proxy re-encryption scheme: Umbral_.
 Implemented with OpenSSL_ and Cryptography.io_, pyUmbral is a referential and open-source cryptography library
 extending the traditional cryptological narrative of "Alice and Bob" by introducing a new actor,
-*Ursula*, who has the ability to take secrets encrypted for Alice and *re-encrypt* them for Bob.
+*Ursula*, who has the ability to take secrets encrypted for Alice and *re-encrypt* them for Bob,
+without being able to learn any information about the original secret.
+
+pyUmbral is the cryptographic engine behind nucypher_,
+a proxy re-encryption network to empower privacy in decentralized systems.
 
 .. _Umbral: https://github.com/nucypher/umbral-doc/blob/master/umbral-doc.pdf
 .. _Cryptography.io: https://cryptography.io/en/latest/
 .. _OpenSSL: https://www.openssl.org/
+.. _nucypher: https://github.com/nucypher/nucypher
 
 .. toctree::
    :maxdepth: 3
@@ -24,14 +58,6 @@ extending the traditional cryptological narrative of "Alice and Bob" by introduc
 
    installation
    using_pyumbral
-
-
-Features
-==========
-- Re-encryption Toolkit
-- Re-encryption Key Fragmentation
-- Key Encapsulation
-- Elliptic Curve Arithmetic
 
 
 Academic Whitepaper

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,15 +6,7 @@ pyUmbral
 ========
 .. start-badges
 
-.. list-table::
-    :stub-columns: 1
-
-    * - info
-      - |docs| |discord|
-    * - tests
-      - | |circleci|
-    * - package
-      - | |version| |commits-since|
+|version|  |circleci| |commits-since| |docs| |discord|
 
 .. |docs| image:: https://readthedocs.org/projects/pyumbral/badge/?style=flat
     :target: https://readthedocs.org/projects/pyumbral

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,11 +30,18 @@ pyUmbral
 
 .. end-badges
 
-pyUmbral is a Python implementation of David Nuñez's threshold proxy re-encryption scheme: Umbral_.
-Implemented with OpenSSL_ and Cryptography.io_, pyUmbral is a referential and open-source cryptography library
-extending the traditional cryptological narrative of "Alice and Bob" by introducing a new actor,
-*Ursula*, who has the ability to take secrets encrypted for Alice and *re-encrypt* them for Bob,
-without being able to learn any information about the original secret.
+pyUmbral is the reference implementation of the Umbral_ threshold proxy re-encryption scheme.
+It is open-source, built with Python, and uses OpenSSL_ and Cryptography.io_.
+
+Using Umbral, Alice (the data owner) can *delegate decryption rights* to Bob for
+any ciphertext intended to her, through a re-encryption process performed by a
+set of semi-trusted proxies or *Ursulas*. When a threshold of these proxies
+participate by performing re-encryption, Bob is able to combine these independent
+re-encryptions and decrypt the original message using his private key.
+
+.. image:: https://www.nucypher.com/_next/static/images/umbral-d60f22230f2ac92b56c6e7d84794e5c4.svg
+  :width: 400 px
+  :align: center
 
 pyUmbral is the cryptographic engine behind nucypher_,
 a proxy re-encryption network to empower privacy in decentralized systems.
@@ -56,10 +63,10 @@ Academic Whitepaper
 ====================
 
 The Umbral scheme academic whitepaper and cryptographic specifications
-are availible on GitHub_.
+are available on GitHub_.
 
-  "Umbral A Threshold Proxy Re-Encryption Scheme"
-  *by David Nuñez*
+  "Umbral: A Threshold Proxy Re-Encryption Scheme"
+  *by David Nuñez*.
   https://github.com/nucypher/umbral-doc/blob/master/umbral-doc.pdf
 
 .. _GitHub: https://github.com/nucypher/umbral-doc/

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,7 +6,7 @@ v0.1.3-alpha.0
 Using pip
 -------------------------
 
-The easiest way to install pyUmbral is using pip:
+The easiest way to install pyUmbral is using ``pip``:
 
 .. code-block:: bash
 
@@ -48,15 +48,15 @@ Once you have acquired the source code, you can...
 Install dependencies
 ---------------------
 
-| The NuCypher team uses pipenv for managing pyUmbral's dependencies.
-| The recommended installation procedure is as follows:
+The NuCypher team uses pipenv for managing pyUmbral's dependencies.
+The recommended installation procedure is as follows:
 
 .. code-block:: bash
 
    $ sudo pip3 install pipenv
    $ pipenv install
 
-Post-installation, you can activate the pyUmbral's virtual enviorment
+Post-installation, you can activate the pyUmbral's virtual environment
 in your current terminal session by running :code:`pipenv shell`.
 
 If your installation is successful, the following command will succeed without error.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -16,7 +16,7 @@ The easiest way to install pyUmbral is using ``pip``:
 Build from source code
 -------------------------
 
-pyUmbral is maintained on GitHub https://github.com/nucypher/pyUmbral.
+pyUmbral is maintained on GitHub: https://github.com/nucypher/pyUmbral.
 
 Clone the repository to download the source code.
 
@@ -63,7 +63,7 @@ If your installation is successful, the following command will succeed without e
 
 .. code-block:: bash
 
-   $ pipenv shell
+   $ pipenv run python
    >>> import umbral
 
 For more information on pipenv, The official documentation is located here: https://docs.pipenv.org/.

--- a/docs/source/using_pyumbral.rst
+++ b/docs/source/using_pyumbral.rst
@@ -5,8 +5,6 @@ Using pyUmbral
 .. image:: .static/PRE_image.png
 
 
-Import umbral modules
-
 .. testsetup:: capsule_story
 
     import sys
@@ -28,7 +26,7 @@ Configuration
 Setting the default curve
 --------------------------
 
-The best way to start using pyUmbral is to decide on a elliptic curve to use and set it as your default.
+The best way to start using pyUmbral is to decide on an elliptic curve to use and set it as your default.
 
 
 .. doctest:: capsule_story

--- a/docs/source/using_pyumbral.rst
+++ b/docs/source/using_pyumbral.rst
@@ -46,8 +46,8 @@ Encryption
 
 Generate an Umbral key pair
 -----------------------------
-First, Let's generate two asymmetric key pairs for Alice:
-A delegating key pair and a Signing key pair.
+First, let's generate two asymmetric key pairs for Alice:
+A delegating key pair and a signing key pair.
 
 .. doctest:: capsule_story
 
@@ -64,9 +64,8 @@ A delegating key pair and a Signing key pair.
 Encrypt with a public key
 --------------------------
 Now let's encrypt data with Alice's public key.
-Invocation of `pre.encrypt` returns both the `ciphertext`,
-and a `capsule`, Anyone with Alice's public key can perform
-this operation.
+Invocation of ``pre.encrypt`` returns both the ``ciphertext`` and a ``capsule``.
+Note that anyone with Alice's public key can perform this operation.
 
 
 .. doctest:: capsule_story
@@ -86,7 +85,7 @@ Alice can open the capsule and decrypt the ciphertext with her private key.
     >>> cleartext = pre.decrypt(ciphertext=ciphertext, capsule=capsule, decrypting_key=alices_private_key)
 
 
-Threshold split-key re-encryption
+Threshold Re-encryption
 ==================================
 
 Bob Exists
@@ -102,12 +101,13 @@ Bob Exists
 Alice grants access to Bob by generating kfrags 
 -----------------------------------------------
 When Alice wants to grant Bob access to open her encrypted messages, 
-she creates *threshold split re-encryption keys*, or *"kfrags"*, 
-which are next sent to N proxies or *Ursulas*. 
+she creates *re-encryption key fragments*, or *"kfrags"*,
+which are next sent to N proxies or *Ursulas*.
 
-| Generate re-encryption key fragments with "`M`(threshold) of `N`":
-| `threshold` - Minimum threshold of key fragments needed to activate a capsule.
-| `N` - Total number of key fragments to generate.
+Alice must specify ``N`` (the total number of kfrags),
+and a ``threshold`` (the minimum number of kfrags needed to activate a capsule).
+In the following example, Alice creates 20 kfrags,
+but Bob needs to get only 10 re-encryptions to activate the capsule.
 
 .. doctest:: capsule_story
 
@@ -148,14 +148,14 @@ or re-encrypted for him by Ursula, he will not be able to open it.
 Ursulas perform re-encryption
 ------------------------------
 Bob asks several Ursulas to re-encrypt the capsule so he can open it. 
-Each Ursula performs re-encryption on the capsule using the `kfrag` 
-provided by Alice, obtaining this way a "capsule fragment", or `cfrag`,
-Let's mock a network or transport layer by sampling `threshold` random `kfrags`,
+Each Ursula performs re-encryption on the capsule using the ``kfrag``
+provided by Alice, obtaining this way a "capsule fragment", or ``cfrag``.
+Let's mock a network or transport layer by sampling ``threshold`` random kfrags,
 one for each required Ursula. Note that each Ursula must prepare the received 
 capsule before re-encryption by setting the proper correctness keys.
 
-Bob collects the resulting `cfrags` from several Ursulas. 
-Bob must gather at least `threshold` `cfrags` in order to activate the capsule.
+Bob collects the resulting cfrags from several Ursulas.
+Bob must gather at least ``threshold`` cfrags in order to activate the capsule.
 
 
 .. doctest:: capsule_story
@@ -182,7 +182,7 @@ Bob must gather at least `threshold` `cfrags` in order to activate the capsule.
 
 Bob attaches cfrags to the capsule
 ----------------------------------
-Bob attaches at least `threshold` `cfrags` to the capsule, 
+Bob attaches at least ``threshold`` cfrags to the capsule,
 which has to be prepared in advance with the necessary correctness keys. 
 Only then it can become *activated*.
 
@@ -199,8 +199,7 @@ Only then it can become *activated*.
 
 Bob activates and opens the capsule
 ------------------------------------
-Finally, Bob activates and opens the capsule,
-then decrypts the re-encrypted ciphertext.
+Finally, Bob decrypts the re-encrypted ciphertext using the activated capsule.
 
 .. doctest:: capsule_story
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/functional/test_correctness.py
+++ b/tests/functional/test_correctness.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/functional/test_correctness_keys.py
+++ b/tests/functional/test_correctness_keys.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/functional/test_pre_api.py
+++ b/tests/functional/test_pre_api.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/functional/test_vectors.py
+++ b/tests/functional/test_vectors.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/metrics/reencryption_benchmark.py
+++ b/tests/metrics/reencryption_benchmark.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/metrics/reencryption_firehose.py
+++ b/tests/metrics/reencryption_firehose.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/scenario/__init__.py
+++ b/tests/scenario/__init__.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/scenario/test_lifecycle_multidomain.py
+++ b/tests/scenario/test_lifecycle_multidomain.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/scenario/test_simple_api.py
+++ b/tests/scenario/test_simple_api.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_capsule_correctness_checks.py
+++ b/tests/unit/test_capsule_correctness_checks.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_capsule_operations.py
+++ b/tests/unit/test_capsule_operations.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_capsule_serializers.py
+++ b/tests/unit/test_capsule_serializers.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_cfrags.py
+++ b/tests/unit/test_cfrags.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_curve.py
+++ b/tests/unit/test_curve.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_dem.py
+++ b/tests/unit/test_dem.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_kfrags.py
+++ b/tests/unit/test_kfrags.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_primitives/conftest.py
+++ b/tests/unit/test_primitives/conftest.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_primitives/test_curvebn_arithmetic.py
+++ b/tests/unit/test_primitives/test_curvebn_arithmetic.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_primitives/test_curvebn_methods.py
+++ b/tests/unit/test_primitives/test_curvebn_methods.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_primitives/test_curvebn_serializers.py
+++ b/tests/unit/test_primitives/test_curvebn_serializers.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_primitives/test_point_arithmetic.py
+++ b/tests/unit/test_primitives/test_point_arithmetic.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_primitives/test_point_serializers.py
+++ b/tests/unit/test_primitives/test_point_serializers.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_serialization_property_based.py
+++ b/tests/unit/test_serialization_property_based.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_signing.py
+++ b/tests/unit/test_signing.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/tests/unit/test_umbral_keys.py
+++ b/tests/unit/test_umbral_keys.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/__about__.py
+++ b/umbral/__about__.py
@@ -18,4 +18,4 @@ __email__ = "dev@nucypher.com"
 
 __license__ = "GNU General Public License, Version 3"
 
-__copyright__ = 'Copyright (C) 2018 NuCypher'
+__copyright__ = 'Copyright (C) 2019 NuCypher'

--- a/umbral/__about__.py
+++ b/umbral/__about__.py
@@ -1,3 +1,20 @@
+"""
+This file is part of pyUmbral.
+
+pyUmbral is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published b
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+pyUmbral is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
+"""
+
 from __future__ import absolute_import, division, print_function
 
 __all__ = [

--- a/umbral/__init__.py
+++ b/umbral/__init__.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/cfrags.py
+++ b/umbral/cfrags.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/config.py
+++ b/umbral/config.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/curve.py
+++ b/umbral/curve.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/curvebn.py
+++ b/umbral/curvebn.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/dem.py
+++ b/umbral/dem.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/kfrags.py
+++ b/umbral/kfrags.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/openssl.py
+++ b/umbral/openssl.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/params.py
+++ b/umbral/params.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/point.py
+++ b/umbral/point.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/random_oracles.py
+++ b/umbral/random_oracles.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/signing.py
+++ b/umbral/signing.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify

--- a/umbral/utils.py
+++ b/umbral/utils.py
@@ -1,6 +1,4 @@
 """
-Copyright (C) 2018 NuCypher
-
 This file is part of pyUmbral.
 
 pyUmbral is free software: you can redistribute it and/or modify


### PR DESCRIPTION
The main change is updating the first paragraph of the README to this:

> pyUmbral is the reference implementation of the Umbral threshold proxy re-encryption scheme. It is open-source, built with Python, and uses OpenSSL and Cryptography.io.
> 
> Using Umbral, Alice (the data owner) can delegate decryption rights to Bob for any ciphertext intended to her, through a re-encryption process performed by a set of semi-trusted proxies or Ursulas. When a threshold of these proxies participate by performing re-encryption, Bob is able to combine these independent re-encryptions and decrypt the original message using his private key.
> 
> pyUmbral is the cryptographic engine behind nucypher, a proxy re-encryption network to empower privacy in decentralized systems.

Other changes:
- Updates docs to match the README, as well as some touchups there.
- Set the `sphinx_rtd_theme` in the docs (the same that NuCypher uses).
- Updates copyright notice to 2019 and removes it from individual file headers.