### PR TITLE
1st Chimney anniversary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ workflows:
           requires:
             - mypy_type_check_36
             - doctests_36
+            - notebook_tests_36
           filters:
             tags:
               only: /v[0-9]+.*/

--- a/docs/examples/umbral_simple_api.py
+++ b/docs/examples/umbral_simple_api.py
@@ -75,7 +75,7 @@ try:
     fail_decrypted_data = pre.decrypt(ciphertext=ciphertext,
                                       capsule=bob_capsule,
                                       decrypting_key=bobs_private_key)
-except:
+except pre.UmbralDecryptionError:
     print("Decryption failed! Bob doesn't has access granted yet.")
 
 #8

--- a/docs/notebooks/pyUmbral Simple API.ipynb
+++ b/docs/notebooks/pyUmbral Simple API.ipynb
@@ -166,7 +166,7 @@
     "    fail_decrypted_data = pre.decrypt(ciphertext=ciphertext, \n",
     "                                      capsule=capsule, \n",
     "                                      decrypting_key=bobs_private_key)\n",
-    "except:\n",
+    "except pre.UmbralDecryptionError:\n",
     "    print(\"Decryption failed! Bob doesn't has access granted yet.\")\n"
    ]
   },

--- a/docs/source/using_pyumbral.rst
+++ b/docs/source/using_pyumbral.rst
@@ -142,7 +142,7 @@ or re-encrypted for him by Ursula, he will not be able to open it.
     ...                    decrypting_key=bobs_private_key)
     Traceback (most recent call last):
         ...
-    cryptography.exceptions.InvalidTag
+    umbral.pre.UmbralDecryptionError
 
 
 Ursulas perform re-encryption

--- a/docs/source/using_pyumbral.rst
+++ b/docs/source/using_pyumbral.rst
@@ -80,10 +80,12 @@ Alice can open the capsule and decrypt the ciphertext with her private key.
 
 .. doctest:: capsule_story
 
-    >>> cleartext = pre.decrypt(ciphertext=ciphertext, capsule=capsule, decrypting_key=alices_private_key)
+    >>> cleartext = pre.decrypt(ciphertext=ciphertext,
+    ...                         capsule=capsule,
+    ...                         decrypting_key=alices_private_key)
 
 
-Threshold Re-encryption
+Threshold Re-Encryption
 ==================================
 
 Bob Exists
@@ -178,6 +180,9 @@ Bob must gather at least ``threshold`` cfrags in order to activate the capsule.
     >>> assert len(cfrags) == 10
 
 
+Decryption
+==================================
+
 Bob attaches cfrags to the capsule
 ----------------------------------
 Bob attaches at least ``threshold`` cfrags to the capsule,
@@ -201,7 +206,9 @@ Finally, Bob decrypts the re-encrypted ciphertext using the activated capsule.
 
 .. doctest:: capsule_story
 
-    >>> cleartext = pre.decrypt(ciphertext=ciphertext, capsule=capsule, decrypting_key=bobs_private_key)
+    >>> cleartext = pre.decrypt(ciphertext=ciphertext,
+    ...                         capsule=capsule,
+    ...                         decrypting_key=bobs_private_key)
 
 .. doctest:: capsule_story
    :hide:

--- a/tests/functional/test_pre_api.py
+++ b/tests/functional/test_pre_api.py
@@ -21,12 +21,14 @@ from umbral import pre
 from umbral.signing import Signer
 from ..conftest import wrong_parameters
 
+
 def test_public_key_encryption(alices_keys):
     delegating_privkey, _ = alices_keys
     plain_data = b'peace at dawn'
     ciphertext, capsule = pre.encrypt(delegating_privkey.get_pubkey(), plain_data)
     cleartext = pre.decrypt(ciphertext, capsule, delegating_privkey)
     assert cleartext == plain_data
+
 
 @pytest.mark.parametrize("N, M", wrong_parameters)
 def test_wrong_N_M_in_split_rekey(N, M, alices_keys, bobs_keys):
@@ -41,3 +43,14 @@ def test_wrong_N_M_in_split_rekey(N, M, alices_keys, bobs_keys):
                                       threshold=M,
                                       N=N)
 
+
+def test_decryption_error(alices_keys, bobs_keys, ciphertext_and_capsule, message):
+    delegating_privkey, _signing_privkey = alices_keys
+    receiving_privkey, _receiving_pubkey = bobs_keys
+    ciphertext, capsule = ciphertext_and_capsule
+
+    cleartext = pre.decrypt(ciphertext, capsule, delegating_privkey)
+    assert message == cleartext
+
+    with pytest.raises(pre.UmbralDecryptionError) as e:
+        _cleartext = pre.decrypt(ciphertext, capsule, receiving_privkey)

--- a/tests/unit/test_primitives/test_point_serializers.py
+++ b/tests/unit/test_primitives/test_point_serializers.py
@@ -51,6 +51,7 @@ def test_generate_random_points():
         assert isinstance(another_point, Point)
         assert point != another_point
 
+
 @pytest.mark.parametrize("curve, nid, point_bytes", generate_test_points_bytes())
 def test_bytes_serializers(point_bytes, nid, curve):
     point_with_curve = Point.from_bytes(point_bytes, curve=curve) # from curve
@@ -75,6 +76,7 @@ def test_bytes_serializers(point_bytes, nid, curve):
         malformed_point_bytes = point_representation[:-1]
         with pytest.raises(InternalError):
             _ = Point.from_bytes(malformed_point_bytes)
+
 
 @pytest.mark.parametrize("curve, nid, point_affine", generate_test_points_affine())
 def test_affine(point_affine, nid, curve):

--- a/tests/unit/test_umbral_keys.py
+++ b/tests/unit/test_umbral_keys.py
@@ -87,37 +87,23 @@ def test_private_key_serialization_with_encryption(random_ec_curvebn1):
 
 
 def test_public_key_serialization(random_ec_curvebn1):
-    priv_key = random_ec_curvebn1
-
-    params = default_params()
-    pub_key = priv_key * params.g
-
-    umbral_key = UmbralPublicKey(pub_key, params)
+    umbral_key = UmbralPrivateKey(random_ec_curvebn1, default_params()).get_pubkey()
+    pub_point = umbral_key.point_key
 
     encoded_key = umbral_key.to_bytes()
 
     decoded_key = UmbralPublicKey.from_bytes(encoded_key)
-    assert pub_key == decoded_key.point_key
+    assert pub_point == decoded_key.point_key
 
 
 def test_public_key_to_compressed_bytes(random_ec_curvebn1):
-    priv_key = random_ec_curvebn1
-
-    params = default_params()
-    pub_key = priv_key * params.g
-
-    umbral_key = UmbralPublicKey(pub_key, params)
+    umbral_key = UmbralPrivateKey(random_ec_curvebn1, default_params()).get_pubkey()
     key_bytes = bytes(umbral_key)
     assert len(key_bytes) == Point.expected_bytes_length(is_compressed=True)
 
 
 def test_public_key_to_uncompressed_bytes(random_ec_curvebn1):
-    priv_key = random_ec_curvebn1
-
-    params = default_params()
-    pub_key = priv_key * params.g
-
-    umbral_key = UmbralPublicKey(pub_key, params)
+    umbral_key = UmbralPrivateKey(random_ec_curvebn1, default_params()).get_pubkey()
     key_bytes = umbral_key.to_bytes(is_compressed=False)
     assert len(key_bytes) == Point.expected_bytes_length(is_compressed=False)
 
@@ -138,6 +124,10 @@ def test_public_key_as_hex(random_ec_curvebn1):
     hex_string = pubkey.hex()
     decoded_pubkey = UmbralPublicKey.from_hex(hex_string)
 
+    assert pubkey == decoded_pubkey
+
+    hex_string = pubkey.hex(is_compressed=False)
+    decoded_pubkey = UmbralPublicKey.from_hex(hex_string)
     assert pubkey == decoded_pubkey
 
 

--- a/tests/unit/test_umbral_keys.py
+++ b/tests/unit/test_umbral_keys.py
@@ -133,6 +133,14 @@ def test_key_encoder_decoder(random_ec_curvebn1):
     assert decoded_key.to_bytes() == umbral_key.to_bytes()
 
 
+def test_public_key_as_hex(random_ec_curvebn1):
+    pubkey = UmbralPrivateKey(random_ec_curvebn1, default_params()).get_pubkey()
+    hex_string = pubkey.hex()
+    decoded_pubkey = UmbralPublicKey.from_hex(hex_string)
+
+    assert pubkey == decoded_pubkey
+
+
 def test_umbral_key_to_cryptography_keys():
     umbral_priv_key = UmbralPrivateKey.gen_key()
     umbral_pub_key = umbral_priv_key.get_pubkey()

--- a/tests/unit/test_umbral_keys.py
+++ b/tests/unit/test_umbral_keys.py
@@ -18,6 +18,7 @@ along with pyUmbral. If not, see <https://www.gnu.org/licenses/>.
 import base64
 import os
 import pytest
+import string
 
 from umbral.config import default_params
 from umbral.keys import UmbralPublicKey, UmbralPrivateKey, UmbralKeyingMaterial
@@ -122,11 +123,19 @@ def test_key_encoder_decoder(random_ec_curvebn1):
 def test_public_key_as_hex(random_ec_curvebn1):
     pubkey = UmbralPrivateKey(random_ec_curvebn1, default_params()).get_pubkey()
     hex_string = pubkey.hex()
+
+    assert set(hex_string).issubset(set(string.hexdigits))
+    assert len(hex_string) == 2 * UmbralPublicKey.expected_bytes_length()
+
     decoded_pubkey = UmbralPublicKey.from_hex(hex_string)
 
     assert pubkey == decoded_pubkey
 
     hex_string = pubkey.hex(is_compressed=False)
+
+    assert set(hex_string).issubset(set(string.hexdigits))
+    assert len(hex_string) == 2 * UmbralPublicKey.expected_bytes_length(is_compressed=False)
+
     decoded_pubkey = UmbralPublicKey.from_hex(hex_string)
     assert pubkey == decoded_pubkey
 
@@ -161,11 +170,11 @@ def test_keying_material_serialization_with_encryption():
 
     insecure_cost = 15  # This is deliberately insecure, just to make the tests faster
     encoded_keying_material = umbral_keying_material.to_bytes(password=b'test',
-                                                  _scrypt_cost=insecure_cost)
+                                                              _scrypt_cost=insecure_cost)
 
     decoded_keying_material = UmbralKeyingMaterial.from_bytes(encoded_keying_material,
-                                                  password=b'test',
-                                                  _scrypt_cost=insecure_cost)
+                                                              password=b'test',
+                                                              _scrypt_cost=insecure_cost)
 
     label = os.urandom(32)
     privkey_bytes = umbral_keying_material.derive_privkey_by_label(label).to_bytes()

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -328,7 +328,7 @@ class UmbralPublicKey:
         return self.to_bytes(is_compressed=is_compressed).hex()
 
     @classmethod
-    def from_hex(cls, hex_string: str) -> 'UmbralPublicKey':
+    def from_hex(cls, hex_string) -> 'UmbralPublicKey':
         return cls.from_bytes(key_bytes=hex_string, decoder=bytes.fromhex)
 
     def to_cryptography_pubkey(self) -> _EllipticCurvePublicKey:

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -321,6 +321,16 @@ class UmbralPublicKey:
 
         return umbral_pubkey
 
+    def hex(self, is_compressed: bool = True) -> str:
+        """
+        Returns an Umbral public key as hex string.
+        """
+        return self.to_bytes(is_compressed=is_compressed).hex()
+
+    @classmethod
+    def from_hex(cls, hex_string: str) -> 'UmbralPublicKey':
+        return cls.from_bytes(key_bytes=hex_string, decoder=bytes.fromhex)
+
     def to_cryptography_pubkey(self) -> _EllipticCurvePublicKey:
         """
         Returns a cryptography.io EllipticCurvePublicKey from the Umbral key.


### PR DESCRIPTION
This PR does:
* Raises `UmbralDecryptionError` instead of `cryptography.exceptions.InvalidTag`, with a more informative error message.
* Updates the docs with a specific section for decryption
* Allows serialization of `UmbralPublicKeys` as hex strings