### PR TITLE
Facilities to reduce abuse of _attached_cfrags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,11 +137,15 @@ python_37_base: &python_37_base
 commands:
   pipenv_install:
     description: "Install Python dependencies with Pipenv"
+    parameters:
+      python_version:
+        type: string
+        default: "3.7"
     steps:
       - checkout
       - run:
           name: Install Python dependencies with Pipenv
-          command: pipenv install --three --dev --skip-lock --pre
+          command: pipenv install --python << parameters.python_version >> --dev --skip-lock --pre
       - run:
           name: Check PEP 508 Requirements
           command: pipenv check
@@ -189,17 +193,20 @@ jobs:
   pipenv_install_35:
     <<: *python_35_base
     steps:
-      - pipenv_install
+      - pipenv_install:
+          python_version: "3.5"
 
   pipenv_install_36:
     <<: *python_36_base
     steps:
-      - pipenv_install
+      - pipenv_install:
+          python_version: "3.6"
 
   pipenv_install_37:
     <<: *python_37_base
     steps:
-      - pipenv_install
+      - pipenv_install:
+          python_version: "3.7"
 
   pip_install_35:
     <<: *python_35_base

--- a/tests/unit/test_capsule_operations.py
+++ b/tests/unit/test_capsule_operations.py
@@ -121,3 +121,15 @@ def test_capsule_length(prepared_capsule, kfrags):
         assert len(capsule) == counter
         cfrag = pre.reencrypt(kfrag, capsule)
         capsule.attach_cfrag(cfrag)
+
+
+def test_capsule_clear(prepared_capsule, kfrags):
+    capsule = prepared_capsule
+
+    for counter, kfrag in enumerate(kfrags):
+        assert len(capsule) == counter
+        cfrag = pre.reencrypt(kfrag, capsule)
+        capsule.attach_cfrag(cfrag)
+
+    capsule.clear_cfrags()
+    assert len(capsule) == 0

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -176,6 +176,9 @@ class Capsule:
             error_msg = "CFrag is not correct and cannot be attached to the Capsule"
             raise UmbralCorrectnessError(error_msg, [cfrag])
 
+    def clear_cfrags(self):
+        self._attached_cfrags = set()
+
     def first_cfrag(self):
         try:
             return list(self._attached_cfrags)[0]

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -176,6 +176,12 @@ class Capsule:
             error_msg = "CFrag is not correct and cannot be attached to the Capsule"
             raise UmbralCorrectnessError(error_msg, [cfrag])
 
+    def first_cfrag(self):
+        try:
+            return list(self._attached_cfrags)[0]
+        except IndexError:
+            raise TypeError("This Capsule doesn't have any CFrags attached.  Ergo, you can't get the first one.")
+
     def components(self) -> Tuple[Point, Point, CurveBN]:
         return self.point_e, self.point_v, self.bn_sig
 
@@ -390,7 +396,7 @@ def _decapsulate_reencrypted(receiving_privkey: UmbralPrivateKey, capsule: Capsu
     pub_key = receiving_privkey.get_pubkey().point_key
     priv_key = receiving_privkey.bn_key
 
-    precursor = capsule._attached_cfrags[0].point_precursor
+    precursor = capsule.first_cfrag().point_precursor
     dh_point = priv_key * precursor
 
     # Combination of CFrags via Shamir's Secret Sharing reconstruction

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -55,6 +55,7 @@ class UmbralDecryptionError(GenericUmbralError):
 
 
 class Capsule:
+
     def __init__(self,
                  params: UmbralParameters,
                  point_e: Point,
@@ -73,7 +74,7 @@ class Capsule:
         self.point_v = point_v
         self.bn_sig = bn_sig
 
-        self._attached_cfrags = list()    # type: list
+        self._attached_cfrags = set()    # type: set
         self._cfrag_correctness_keys = {
             'delegating': None, 'receiving': None, 'verifying': None
         }   # type: dict
@@ -170,7 +171,7 @@ class Capsule:
 
     def attach_cfrag(self, cfrag: CapsuleFrag) -> None:
         if cfrag.verify_correctness(self):
-            self._attached_cfrags.append(cfrag)
+            self._attached_cfrags.add(cfrag)
         else:
             error_msg = "CFrag is not correct and cannot be attached to the Capsule"
             raise UmbralCorrectnessError(error_msg, [cfrag])

--- a/umbral/pre.py
+++ b/umbral/pre.py
@@ -181,6 +181,9 @@ class Capsule:
     def __bytes__(self) -> bytes:
         return self.to_bytes()
 
+    def __contains__(self, cfrag):
+        return cfrag in self._attached_cfrags
+
     def __eq__(self, other) -> bool:
         """
         Each component is compared to its counterpart in constant time per the __eq__ of Point and CurveBN.


### PR DESCRIPTION
Presently, there are several places in the NuCypher codebase (and on in this codebase) where we abuse the private `_attached_cfrags` attribute of `Capsule`.

This PR allows for the Capsule's CFrags to be cleared without needing to access this attribute. 