### PR TITLE
Naming fixes

### DIFF
--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -44,8 +44,8 @@ def test_keys(implementations):
 
 def _create_sk_factory_and_sk(umbral, skf_label, key_label):
     skf = umbral.SecretKeyFactory.random()
-    derived_skf = skf.secret_key_factory_by_label(skf_label)
-    sk = derived_skf.secret_key_by_label(key_label)
+    derived_skf = skf.make_factory(skf_label)
+    sk = derived_skf.make_key(key_label)
     return skf.to_secret_bytes(), derived_skf.to_secret_bytes(), sk.to_secret_bytes()
 
 
@@ -53,11 +53,11 @@ def _check_sk_is_same(umbral, skf_label, key_label, skf_bytes, derived_skf_bytes
     skf = umbral.SecretKeyFactory.from_bytes(skf_bytes)
 
     derived_skf_restored = umbral.SecretKeyFactory.from_bytes(derived_skf_bytes)
-    derived_skf_generated = skf.secret_key_factory_by_label(skf_label)
+    derived_skf_generated = skf.make_factory(skf_label)
     assert derived_skf_generated.to_secret_bytes() == derived_skf_restored.to_secret_bytes()
 
     sk_restored = umbral.SecretKey.from_bytes(sk_bytes)
-    sk_generated = derived_skf_generated.secret_key_by_label(key_label)
+    sk_generated = derived_skf_generated.make_key(key_label)
     assert sk_restored.to_secret_bytes() == sk_generated.to_secret_bytes()
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -27,21 +27,21 @@ def test_derive_key_from_label():
 
     label = b"my_healthcare_information"
 
-    sk1 = factory.secret_key_by_label(label)
+    sk1 = factory.make_key(label)
     assert type(sk1) == SecretKey
 
     pk1 = sk1.public_key()
     assert type(pk1) == PublicKey
 
     # Check that key derivation is reproducible
-    sk2 = factory.secret_key_by_label(label)
+    sk2 = factory.make_key(label)
     pk2 = sk2.public_key()
     assert sk1.to_secret_bytes() == sk2.to_secret_bytes()
     assert pk1 == pk2
 
     # Different labels on the same master secret create different keys
     label = b"my_tax_information"
-    sk3 = factory.secret_key_by_label(label)
+    sk3 = factory.make_key(label)
     pk3 = sk3.public_key()
     assert sk1 != sk3
 
@@ -51,20 +51,20 @@ def test_derive_skf_from_label():
 
     skf_label = b"Alice"
 
-    skf = root.secret_key_factory_by_label(skf_label)
+    skf = root.make_factory(skf_label)
     assert type(skf) == SecretKeyFactory
 
-    skf_same = root.secret_key_factory_by_label(skf_label)
+    skf_same = root.make_factory(skf_label)
     assert skf.to_secret_bytes() == skf_same.to_secret_bytes()
 
     # Just in case, check that they produce the same secret keys too.
     key_label = b"my_healthcare_information"
-    key = skf.secret_key_by_label(key_label)
-    key_same = skf_same.secret_key_by_label(key_label)
+    key = skf.make_key(key_label)
+    key_same = skf_same.make_key(key_label)
     assert key.to_secret_bytes() == key_same.to_secret_bytes()
 
     # Different label produces a different factory
-    skf_different = root.secret_key_factory_by_label(b"Bob")
+    skf_different = root.make_factory(b"Bob")
     assert skf.to_secret_bytes() != skf_different.to_secret_bytes()
 
 
@@ -75,7 +75,7 @@ def test_from_secure_randomness():
     assert type(skf) == SecretKeyFactory
 
     # Check that it can produce keys
-    sk = skf.secret_key_by_label(b"key label")
+    sk = skf.make_key(b"key label")
 
     # Wrong seed size
 
@@ -146,8 +146,8 @@ def test_secret_key_factory_serialization():
     decoded_factory = SecretKeyFactory.from_bytes(encoded_factory)
 
     label = os.urandom(32)
-    sk1 = factory.secret_key_by_label(label)
-    sk2 = decoded_factory.secret_key_by_label(label)
+    sk1 = factory.make_key(label)
+    sk2 = decoded_factory.make_key(label)
     assert sk1.to_secret_bytes() == sk2.to_secret_bytes()
 
 

--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -132,7 +132,7 @@ class SecretKeyFactory(SerializableSecret, Deserializable):
             raise ValueError(f"Expected {cls.seed_size()} bytes, got {len(seed)}")
         return cls(seed)
 
-    def secret_key_by_label(self, label: bytes) -> SecretKey:
+    def make_key(self, label: bytes) -> SecretKey:
         """
         Creates a :py:class:`SecretKey` deterministically from the given label.
         """
@@ -145,7 +145,7 @@ class SecretKeyFactory(SerializableSecret, Deserializable):
 
         return SecretKey(scalar_key)
 
-    def secret_key_factory_by_label(self, label: bytes) -> 'SecretKeyFactory':
+    def make_factory(self, label: bytes) -> 'SecretKeyFactory':
         """
         Creates a :py:class:`SecretKeyFactory` deterministically from the given label.
         """

--- a/umbral/signing.py
+++ b/umbral/signing.py
@@ -75,21 +75,21 @@ class Signature(Serializable, Deserializable):
         self.r = r
         self.s = s
 
-    def verify_digest(self, verifying_key: PublicKey, digest: Hash) -> bool:
+    def verify_digest(self, verifying_pk: PublicKey, digest: Hash) -> bool:
         return openssl.ecdsa_verify(curve=CURVE,
                                     sig_r=int(self.r),
                                     sig_s=int(self.s),
-                                    public_point=verifying_key.point()._backend_point,
+                                    public_point=verifying_pk.point()._backend_point,
                                     prehashed_message=digest.finalize(),
                                     hash_algorithm=digest._backend_hash_algorithm)
 
-    def verify(self, verifying_key: PublicKey, message: bytes) -> bool:
+    def verify(self, verifying_pk: PublicKey, message: bytes) -> bool:
         """
         Returns ``True`` if the ``message`` was signed by someone possessing the secret counterpart
-        to ``verifying_key``.
+        to ``verifying_pk``.
         """
         digest = digest_for_signing(message)
-        return self.verify_digest(verifying_key, digest)
+        return self.verify_digest(verifying_pk, digest)
 
     @classmethod
     def serialized_size(cls):


### PR DESCRIPTION
Synchronized with https://github.com/nucypher/rust-umbral/pull/71

- renames `SecretKeyFactory::secret_key_by_label()`/`secret_factory_by_label()` -> `make_key()`/`make_factory()`. The former names were way too wordy.
- replaces `verifying_key` parameter in `Signature::verify()` with `verifying_pk` - it is called like that everywhere else.